### PR TITLE
feat: SP1 plugin skeleton — manifests, init, doctor, status line (#1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "forge",
+  "owner": {
+    "name": "dngioidev"
+  },
+  "plugins": [
+    {
+      "name": "forge",
+      "source": "./plugin",
+      "description": "AI dev platform: pipeline skills, agent roster with pluggable backends, GitHub Projects board automation, learning loop, graph RAG"
+    }
+  ]
+}

--- a/.claude/forge.json
+++ b/.claude/forge.json
@@ -5,21 +5,41 @@
     "fields": {
       "status": {
         "id": "PVTSSF_lAHOCkJQ784BdZrhzhX7emI",
-        "options": { "backlog": "04db063a", "inProgress": "29224f44", "done": "7d8a60b9" }
+        "options": {
+          "backlog": "04db063a",
+          "inProgress": "29224f44",
+          "done": "7d8a60b9"
+        }
       },
       "priority": {
         "id": "PVTSSF_lAHOCkJQ784BdZrhzhX7esI",
-        "options": { "p0": "66c7f4b7", "p1": "23a624d0", "p2": "d9b45a49" }
+        "options": {
+          "p0": "66c7f4b7",
+          "p1": "23a624d0",
+          "p2": "d9b45a49"
+        }
       },
       "size": {
         "id": "PVTSSF_lAHOCkJQ784BdZrhzhX7esU",
-        "options": { "xs": "d2a09967", "s": "0a97017a", "m": "88715f78", "l": "e0e2c48d", "xl": "ec65bb19" }
+        "options": {
+          "xs": "d2a09967",
+          "s": "0a97017a",
+          "m": "88715f78",
+          "l": "e0e2c48d",
+          "xl": "ec65bb19"
+        }
       },
       "type": {
         "id": "PVTSSF_lAHOCkJQ784BdZrhzhX7euY",
-        "options": { "epic": "cc17fc25", "item": "54a8e89d", "bug": "8b7b608b", "test": "d572a031" }
+        "options": {
+          "epic": "cc17fc25",
+          "item": "54a8e89d",
+          "bug": "8b7b608b",
+          "test": "d572a031"
+        }
       }
-    }
+    },
+    "deliveryLogIssue": 15
   },
   "conventions": {
     "verify": "pnpm verify",

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,4 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc # v2.0.1
+      - uses: docker://rhysd/actionlint@sha256:1d74bfc9fd1963af8f89a7c22afaaafd42f49aad711a09951d02cb996398f61d # 1.7.7
+        with:
+          args: -color

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,35 @@
+name: verify
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm verify
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc # v2.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .forge/
 node_modules/
+.claude/settings.local.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 
 ## Decisions (ADRs)
 
-_(none yet — promoted from spec decision logs as they stabilize)_
+- [ADR-0001 — Status field options](decisions/0001-status-field-options.md) — built-in Status options are GraphQL-mutable but replacement mints new IDs; init replaces on fresh (empty) projects only, maps-as-is on live boards.
 
 ## Guides
 

--- a/docs/decisions/0001-status-field-options.md
+++ b/docs/decisions/0001-status-field-options.md
@@ -1,0 +1,31 @@
+# ADR-0001 — Built-in Status field options are mutable; init creates the standard set on fresh projects only
+
+**Date:** 2026-07-16 · **Status:** accepted · **Ticket:** #1 (SP1 spike, plan T4)
+
+## Context
+
+ProjectsV2 ships every new project with a built-in Status single-select (Todo / In Progress / Done). Forge's standard is six statuses (spec §6). It was unverified whether GraphQL can modify a *built-in* field's options ([spec §6 spike note](../specs/2026-07-15-forge-platform-design.md)).
+
+## Finding (verified live, 2026-07-16, scratch project dngioidev/#9)
+
+`updateProjectV2Field` **works** on the built-in Status field:
+
+```graphql
+mutation {
+  updateProjectV2Field(input: {
+    fieldId: "<status-field-id>",
+    singleSelectOptions: [ {name: "Backlog", color: GRAY, description: ""}, … ]
+  }) { projectV2Field { ... on ProjectV2SingleSelectField { options { id name } } } }
+}
+```
+
+Caveat that decides everything: the mutation **replaces the entire option list and mints new option IDs** — existing options are destroyed, and items assigned to them lose their status.
+
+## Decision
+
+- **Fresh projects** (created by `forge init`, zero items): init replaces Status options with the forge 6-status set — full bootstrap, no manual step.
+- **Adopted projects** (any existing items): init never touches Status options — it maps what exists (spec §6 degrade-gracefully) and prints the manual instruction for the owner to add missing statuses via the UI if wanted. Destroying live status assignments is not an acceptable default; an explicit `--force-status` opt-in may be added later if real need appears.
+
+## Consequences
+
+`forge init` needs an "is this project empty" check (items count == 0) to pick the path. The forge standard option set (names + colors) lives in one constant shared by init and doctor.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "forge",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Portable AI-dev-platform Claude Code plugin: pipeline skills, agent roster, board automation, learning loop, graph RAG",
+  "type": "module",
+  "engines": {
+    "node": ">=22.13"
+  },
+  "packageManager": "pnpm@10.14.0",
+  "scripts": {
+    "test": "vitest run",
+    "verify": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
+  }
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "forge",
+  "version": "0.1.0",
+  "description": "AI dev platform: pipeline skills, agent roster with pluggable backends, GitHub Projects board automation, learning loop, graph RAG",
+  "author": {
+    "name": "dngioi.dev"
+  }
+}

--- a/plugin/commands/doctor.md
+++ b/plugin/commands/doctor.md
@@ -1,0 +1,17 @@
+---
+description: Read-only forge health check — gh auth, Node version, forge.json validity, board IDs, gitignore, branch protection, secret scanning
+---
+
+Run the forge health check from the repo root:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.mjs"
+```
+
+It prints one ✓/⚠/✗ line per check with a fix hint, and exits nonzero when any ✗ is present.
+
+Relay the results to the user:
+- All ✓/⚠: say the setup is healthy and list the warnings (⚠) with their hints — warnings are advisory (branch protection, secret scanning, status line), not blockers.
+- Any ✗: list each failure with its hint. Offer to run `/forge:init` when the hint says so; do not hand-patch `forge.json` IDs or the board via ad-hoc GraphQL.
+
+This command is read-only — it never mutates the repo, the board, or settings.

--- a/plugin/commands/init.md
+++ b/plugin/commands/init.md
@@ -1,0 +1,24 @@
+---
+description: Bootstrap or adopt this repo's forge setup — GitHub Project, fields, delivery log, forge.json, gitignore, status line
+---
+
+Bootstrap forge for this repository (adopt-or-create, idempotent — safe to re-run).
+
+1. Ask the user which mode applies, unless the arguments already say:
+   - Adopt an existing GitHub Project: needs the project number.
+   - Create a fresh project: needs a title (default: the repo name).
+2. Ask whether to wire the forge status line into `.claude/settings.local.json` (recommended; it only merges the `statusLine` key, never touches other settings — local because the command embeds a machine-specific path).
+3. Run the script from the repo root:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/init.mjs" --project <number>
+node "${CLAUDE_PLUGIN_ROOT}/scripts/init.mjs" --create-project "<title>"
+```
+
+Append `--statusline` when the user said yes in step 2.
+
+4. The script prints each action taken and finishes with a doctor report. Relay the summary: what was created vs adopted, the forge.json path, and any doctor warnings with their fix hints. If the script exits nonzero, report the error verbatim — do not improvise fixes to the board by hand; hand-built GraphQL is exactly what forge exists to remove.
+
+Notes:
+- Status options: on an empty project the standard 6-status set is created automatically; on a board with existing items, options are mapped as-is and missing ones must be added via the UI (ADR-0001).
+- The command needs gh authenticated with the `project` scope (`gh auth refresh -s project` if doctor flags it).

--- a/plugin/scripts/doctor.mjs
+++ b/plugin/scripts/doctor.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * /forge:doctor — read-only health check (spec §6, plan T6).
+ * One distinct check per failure class; ✗ = exit 1, ⚠ = advisory.
+ */
+import { join, resolve } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from './lib/exec.mjs';
+import { loadConfig, CONFIG_RELPATH } from './lib/config.mjs';
+import { readJson } from './lib/jsonfile.mjs';
+import { getRepoInfo, getProjectFields } from './lib/board.mjs';
+
+const ok = (name, msg) => ({ name, level: 'ok', msg });
+const warn = (name, msg, hint) => ({ name, level: 'warn', msg, hint });
+const fail = (name, msg, hint) => ({ name, level: 'fail', msg, hint });
+
+export async function runDoctor(ctx) {
+  const { gh, cwd, log } = ctx;
+  const results = [];
+
+  // gh auth + project scope
+  const auth = await gh(['auth', 'status']);
+  if (!auth.ok) {
+    results.push(fail('gh-auth', 'gh is not authenticated', 'gh auth login -s project'));
+  } else {
+    const scopeLine = (auth.stdout + auth.stderr).split(/\r?\n/).find((l) => l.includes('Token scopes:')) ?? '';
+    if (!/'project'|\bproject\b/.test(scopeLine.replace('Token scopes:', ''))) {
+      results.push(fail('gh-scope', "token lacks the 'project' scope", 'gh auth refresh -s project'));
+    } else {
+      results.push(ok('gh-auth', 'authenticated with project scope'));
+    }
+  }
+
+  // node version
+  const [maj, min] = process.versions.node.split('.').map(Number);
+  if (maj > 22 || (maj === 22 && min >= 13)) results.push(ok('node', `node ${process.versions.node}`));
+  else results.push(fail('node', `node ${process.versions.node} < 22.13`, 'upgrade Node (>=22.13, spec §6)'));
+
+  // git repo
+  const git = await run('git', ['-C', cwd, 'rev-parse', '--is-inside-work-tree']);
+  if (git.ok) results.push(ok('git', 'inside a git work tree'));
+  else results.push(fail('git', 'not a git repository', 'run inside the consumer repo'));
+
+  // config
+  const cfg = await loadConfig(cwd);
+  if (!cfg.ok) {
+    for (const e of cfg.errors) results.push(fail('config', e, cfg.missing ? 'run /forge:init' : `fix ${CONFIG_RELPATH}`));
+  } else {
+    results.push(ok('config', `${CONFIG_RELPATH} valid`));
+  }
+
+  // board ids resolve
+  if (cfg.ok) {
+    const pf = await getProjectFields(gh, cfg.config.board.projectId);
+    if (!pf.ok) {
+      results.push(fail('board', `projectId does not resolve: ${pf.error}`, 're-run /forge:init'));
+    } else {
+      const dangling = [];
+      for (const [key, f] of Object.entries(cfg.config.board.fields)) {
+        const live = Object.values(pf.fields).find((x) => x.id === f.id);
+        if (!live) { dangling.push(`${key}.id`); continue; }
+        const liveOptionIds = new Set((live.options ?? []).map((o) => o.id));
+        for (const [optName, optId] of Object.entries(f.options)) {
+          if (!liveOptionIds.has(optId)) dangling.push(`${key}.options.${optName}`);
+        }
+      }
+      if (dangling.length) results.push(fail('board', `dangling ids: ${dangling.join(', ')}`, 're-run /forge:init to re-discover'));
+      else results.push(ok('board', 'project + all field/option ids resolve'));
+    }
+
+    // delivery log
+    if (cfg.config.board.deliveryLogIssue != null) {
+      const dl = await gh(['issue', 'view', String(cfg.config.board.deliveryLogIssue), '--json', 'state'], { parseJson: true });
+      if (!dl.ok) results.push(warn('delivery-log', `issue #${cfg.config.board.deliveryLogIssue} not found`, 're-run /forge:init'));
+      else if (dl.json.state !== 'OPEN') results.push(warn('delivery-log', `issue #${cfg.config.board.deliveryLogIssue} is closed`, 'reopen it'));
+      else results.push(ok('delivery-log', `issue #${cfg.config.board.deliveryLogIssue} open`));
+    }
+  }
+
+  // .forge/ gitignored
+  let gi = '';
+  try { gi = await readFile(join(cwd, '.gitignore'), 'utf8'); } catch { /* missing */ }
+  if (gi.split(/\r?\n/).some((l) => l.trim() === '.forge/')) results.push(ok('gitignore', '.forge/ ignored'));
+  else results.push(fail('gitignore', '.forge/ not in .gitignore', 'run /forge:init (it appends the entry)'));
+
+  // statusline wired (info-level) — local settings first (that's where init writes it)
+  const settingsLocal = await readJson(join(cwd, '.claude', 'settings.local.json')).catch(() => null);
+  const settings = await readJson(join(cwd, '.claude', 'settings.json')).catch(() => null);
+  if (settingsLocal?.statusLine || settings?.statusLine) results.push(ok('statusline', 'wired'));
+  else results.push(warn('statusline', 'status line not wired', 'run /forge:init with --statusline'));
+
+  // branch protection + secret scanning (warn-level)
+  const repo = await getRepoInfo(gh);
+  if (repo.ok) {
+    const prot = await gh(['api', `repos/${repo.owner}/${repo.name}/branches/${repo.defaultBranch}/protection`]);
+    if (prot.ok) results.push(ok('branch-protection', `${repo.defaultBranch} protected`));
+    else results.push(warn('branch-protection', `${repo.defaultBranch} has no branch protection`, 'require the verify check before merge (spec §6)'));
+
+    const sec = await gh(['api', `repos/${repo.owner}/${repo.name}`], { parseJson: true });
+    const sa = sec.ok ? sec.json.security_and_analysis : null;
+    if (sa?.secret_scanning?.status === 'enabled') results.push(ok('secret-scanning', 'enabled'));
+    else results.push(warn('secret-scanning', 'secret scanning not enabled', 'enable secret scanning + push protection in repo settings (spec §13)'));
+  }
+
+  const failed = results.filter((r) => r.level === 'fail');
+  const icon = { ok: '✓', warn: '⚠', fail: '✗' };
+  for (const r of results) {
+    log(`${icon[r.level]} ${r.name.padEnd(18)} ${r.msg}${r.hint ? `  → ${r.hint}` : ''}`);
+  }
+  log(failed.length === 0 ? 'doctor: healthy' : `doctor: ${failed.length} problem(s)`);
+  return { ok: failed.length === 0, results };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  runDoctor({ gh: makeGh(run), cwd: process.cwd(), log: console.log }).then((res) => process.exit(res.ok ? 0 : 1));
+}

--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * /forge:init — adopt-or-create bootstrap (spec §6, plan T5).
+ * Every step is detect-before-create: re-runs resume/refresh, never duplicate.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { run, makeGh } from './lib/exec.mjs';
+import { loadConfig, CONFIG_RELPATH } from './lib/config.mjs';
+import { mergeJson } from './lib/jsonfile.mjs';
+import {
+  STANDARD_STATUS, STANDARD_FIELDS, getRepoInfo, getProject, createProject,
+  getProjectFields, createSingleSelectField, replaceStatusOptions,
+  findIssueByTitle, createIssue, toConfigField,
+} from './lib/board.mjs';
+import { runDoctor } from './doctor.mjs';
+
+const DELIVERY_LOG_TITLE = 'Delivery log';
+
+export function parseArgs(argv) {
+  const args = { project: null, createProject: null, statusline: false, skipDoctor: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--project') args.project = Number(argv[++i]);
+    else if (a === '--create-project') args.createProject = argv[++i];
+    else if (a === '--statusline') args.statusline = true;
+    else if (a === '--skip-doctor') args.skipDoctor = true;
+  }
+  return args;
+}
+
+export async function runInit(ctx) {
+  const { gh, cwd, log, args } = ctx;
+  const actions = [];
+  const say = (m) => { actions.push(m); log(m); };
+
+  // 1. Preflight
+  const auth = await gh(['auth', 'status']);
+  if (!auth.ok) return { ok: false, error: 'gh is not authenticated — run: gh auth login -s project', actions };
+  const [maj, min] = process.versions.node.split('.').map(Number);
+  if (maj < 22 || (maj === 22 && min < 13)) {
+    return { ok: false, error: `Node ${process.versions.node} < 22.13 (needed for node:sqlite later; upgrade now to avoid surprises)`, actions };
+  }
+  const repo = await getRepoInfo(gh);
+  if (!repo.ok) return { ok: false, error: `not a GitHub repo context: ${repo.error}`, actions };
+
+  // 2. Mode
+  const existing = await loadConfig(cwd);
+  const adopt = !existing.missing;
+  say(adopt ? `adopt mode: refreshing existing ${CONFIG_RELPATH}` : 'fresh mode: no forge.json yet');
+
+  // 3. Project
+  let project;
+  const wantedNumber = args.project ?? existing.config?.board?.projectNumber ?? null;
+  if (wantedNumber != null) {
+    const p = await getProject(gh, repo.owner, wantedNumber);
+    if (!p.ok) return { ok: false, error: p.error, actions };
+    project = p;
+    say(`project: using #${p.number} "${p.title}"`);
+  } else if (args.createProject != null) {
+    const title = args.createProject || repo.name;
+    const p = await createProject(gh, repo.owner, title);
+    if (!p.ok) return { ok: false, error: p.error, actions };
+    project = p;
+    say(`project: created #${p.number} "${p.title}"`);
+  } else {
+    return { ok: false, error: 'no project specified — pass --project <number> or --create-project "<title>"', actions };
+  }
+
+  // 4. Fields
+  let pf = await getProjectFields(gh, project.id);
+  if (!pf.ok) return { ok: false, error: pf.error, actions };
+
+  const statusField = pf.fields['status'];
+  if (!statusField) return { ok: false, error: 'project has no Status field — unexpected for ProjectsV2', actions };
+  const statusNames = (statusField.options ?? []).map((o) => o.name);
+  const missingStatuses = STANDARD_STATUS.filter((s) => !statusNames.some((n) => n.toLowerCase() === s.name.toLowerCase()));
+  if (missingStatuses.length > 0) {
+    if (pf.itemsCount === 0) {
+      // ADR-0001: replacement is safe only on empty projects
+      const r = await replaceStatusOptions(gh, statusField.id, STANDARD_STATUS);
+      if (!r.ok) return { ok: false, error: r.error, actions };
+      say(`status: replaced options with forge standard set (project empty — ADR-0001)`);
+    } else {
+      say(`status: mapping existing options as-is; missing from standard set: ${missingStatuses.map((s) => s.name).join(', ')} (add via UI if wanted — ADR-0001 forbids replacing options on live boards)`);
+    }
+  } else {
+    say('status: standard set already present');
+  }
+
+  for (const [key, defs] of Object.entries(STANDARD_FIELDS)) {
+    if (!pf.fields[key]) {
+      const r = await createSingleSelectField(gh, project.id, key[0].toUpperCase() + key.slice(1), defs);
+      if (!r.ok) return { ok: false, error: r.error, actions };
+      say(`fields: created ${key}`);
+    }
+  }
+
+  // Re-discover so config reflects reality (also covers resume-after-partial-failure)
+  pf = await getProjectFields(gh, project.id);
+  if (!pf.ok) return { ok: false, error: pf.error, actions };
+
+  // 5. Delivery log issue
+  let deliveryLogIssue = existing.config?.board?.deliveryLogIssue ?? null;
+  if (deliveryLogIssue == null) {
+    const found = await findIssueByTitle(gh, DELIVERY_LOG_TITLE);
+    if (!found.ok) return { ok: false, error: found.error, actions };
+    if (found.issue) {
+      deliveryLogIssue = found.issue.number;
+      say(`delivery log: found existing #${deliveryLogIssue}`);
+    } else {
+      const created = await createIssue(gh, DELIVERY_LOG_TITLE, 'Pinned delivery log — one row per merged change. Managed by forge (spec §6).');
+      if (!created.ok) return { ok: false, error: created.error, actions };
+      deliveryLogIssue = created.number;
+      say(`delivery log: created #${deliveryLogIssue}`);
+    }
+  }
+
+  // 6. Write forge.json (merge — never clobber consumer customizations)
+  const board = {
+    projectNumber: project.number,
+    projectId: project.id,
+    fields: {
+      status: toConfigField(pf.fields['status']),
+      priority: toConfigField(pf.fields['priority']),
+      size: toConfigField(pf.fields['size']),
+      type: toConfigField(pf.fields['type']),
+    },
+    ...(deliveryLogIssue != null ? { deliveryLogIssue } : {}),
+  };
+  const defaults = adopt ? {} : {
+    conventions: { verify: 'pnpm verify', commitFormat: 'conventional+issue-ref', specsDir: 'docs/specs', plansDir: 'docs/plans' },
+    features: { graph: false, designReview: false, deploy: false, e2e: false },
+    design: { source: 'code' },
+    team: {
+      members: [{ github: repo.owner, roles: ['maintainer'] }],
+      policy: {
+        approvals: { spec: ['maintainer'], merge: ['maintainer'], distill: ['maintainer'], deploy: ['maintainer'], escalation: { default: ['maintainer'] } },
+        assignment: 'manual',
+      },
+    },
+  };
+  await mergeJson(join(cwd, CONFIG_RELPATH), { ...defaults, board });
+  say(`config: wrote ${CONFIG_RELPATH}`);
+
+  // 7. .gitignore
+  const giPath = join(cwd, '.gitignore');
+  let gi = '';
+  try { gi = await readFile(giPath, 'utf8'); } catch { /* no .gitignore yet */ }
+  if (!gi.split(/\r?\n/).some((l) => l.trim() === '.forge/')) {
+    await writeFile(giPath, gi + (gi.endsWith('\n') || gi === '' ? '' : '\n') + '.forge/\n', 'utf8');
+    say('.gitignore: added .forge/');
+  }
+
+  // 8. Status line (opt-in via --statusline; the command md asks the user first).
+  // Written to settings.local.json: the command embeds a machine-specific
+  // absolute path, which must never land in the shared committed settings.
+  if (args.statusline) {
+    const scriptPath = resolve(dirname(fileURLToPath(import.meta.url)), 'statusline.mjs');
+    await mergeJson(join(cwd, '.claude', 'settings.local.json'), {
+      statusLine: { type: 'command', command: `node "${scriptPath}"` },
+    });
+    say('statusline: wired into .claude/settings.local.json');
+  }
+
+  // 9. Doctor
+  let doctor = null;
+  if (!args.skipDoctor) {
+    doctor = await runDoctor({ gh, cwd, log });
+  }
+  return { ok: true, actions, board, doctor };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const ctx = { gh: makeGh(run), cwd: process.cwd(), log: console.log, args: parseArgs(process.argv.slice(2)) };
+  runInit(ctx).then((res) => {
+    if (!res.ok) { console.error(`init failed: ${res.error}`); process.exit(1); }
+    process.exit(res.doctor && !res.doctor.ok ? 1 : 0);
+  });
+}

--- a/plugin/scripts/lib/board.mjs
+++ b/plugin/scripts/lib/board.mjs
@@ -1,0 +1,156 @@
+/**
+ * ProjectsV2 operations shared by init and doctor. Every call goes through an
+ * injected gh wrapper (see exec.mjs makeGh) — argv arrays only, GraphQL
+ * variables via -f/-F flags, never string-interpolated queries (spec §13).
+ */
+
+/** Forge standard field sets (names/colors chosen in ADR-0001 + spec §6). */
+export const STANDARD_STATUS = [
+  { key: 'backlog', name: 'Backlog', color: 'GRAY' },
+  { key: 'ready', name: 'Ready', color: 'BLUE' },
+  { key: 'inProgress', name: 'In progress', color: 'YELLOW' },
+  { key: 'inReview', name: 'In review', color: 'ORANGE' },
+  { key: 'blocked', name: 'Blocked / Needs decision', color: 'RED' },
+  { key: 'done', name: 'Done', color: 'GREEN' },
+];
+
+export const STANDARD_FIELDS = {
+  priority: [
+    { key: 'p0', name: 'P0', color: 'RED' },
+    { key: 'p1', name: 'P1', color: 'YELLOW' },
+    { key: 'p2', name: 'P2', color: 'GREEN' },
+  ],
+  size: [
+    { key: 'xs', name: 'XS', color: 'GRAY' },
+    { key: 's', name: 'S', color: 'BLUE' },
+    { key: 'm', name: 'M', color: 'GREEN' },
+    { key: 'l', name: 'L', color: 'YELLOW' },
+    { key: 'xl', name: 'XL', color: 'RED' },
+  ],
+  type: [
+    { key: 'epic', name: 'Epic', color: 'PURPLE' },
+    { key: 'item', name: 'Item', color: 'BLUE' },
+    { key: 'bug', name: 'Bug', color: 'RED' },
+    { key: 'test', name: 'Test', color: 'GREEN' },
+  ],
+};
+
+/** "In progress" -> inProgress; "Blocked / Needs decision" -> blocked. */
+export function optionKey(name) {
+  const lower = name.toLowerCase().trim();
+  if (lower.startsWith('blocked')) return 'blocked';
+  return lower
+    .replace(/[^a-z0-9]+(.)/g, (_, c) => c.toUpperCase())
+    .replace(/[^a-zA-Z0-9]/g, '');
+}
+
+export async function getRepoInfo(gh) {
+  const res = await gh(['repo', 'view', '--json', 'owner,name,defaultBranchRef'], { parseJson: true });
+  if (!res.ok) return { ok: false, error: res.stderr || 'gh repo view failed' };
+  return {
+    ok: true,
+    owner: res.json.owner.login,
+    name: res.json.name,
+    defaultBranch: res.json.defaultBranchRef?.name ?? 'main',
+  };
+}
+
+export async function getProject(gh, owner, number) {
+  const res = await gh(['project', 'view', String(number), '--owner', owner, '--format', 'json'], { parseJson: true });
+  if (!res.ok) return { ok: false, error: res.stderr || `project ${number} not found for ${owner}` };
+  return { ok: true, id: res.json.id, title: res.json.title, number: res.json.number };
+}
+
+export async function createProject(gh, owner, title) {
+  const res = await gh(['project', 'create', '--owner', owner, '--title', title, '--format', 'json'], { parseJson: true });
+  if (!res.ok) return { ok: false, error: res.stderr || 'project create failed' };
+  return { ok: true, id: res.json.id, number: res.json.number, title: res.json.title };
+}
+
+const FIELDS_QUERY = `query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      items(first: 1) { totalCount }
+      fields(first: 50) {
+        nodes {
+          __typename
+          ... on ProjectV2FieldCommon { id name }
+          ... on ProjectV2SingleSelectField { id name options { id name } }
+        }
+      }
+    }
+  }
+}`;
+
+/** Returns { itemsCount, fields: { <lowercased name>: {id, name, options:[{id,name}]} } } */
+export async function getProjectFields(gh, projectId) {
+  const res = await gh(['api', 'graphql', '-f', `query=${FIELDS_QUERY}`, '-f', `id=${projectId}`], { parseJson: true });
+  if (!res.ok) return { ok: false, error: res.stderr || 'fields query failed' };
+  const node = res.json.data?.node;
+  if (!node) return { ok: false, error: `project node ${projectId} not resolvable` };
+  const fields = {};
+  for (const f of node.fields.nodes) {
+    if (f && f.name) fields[f.name.toLowerCase()] = f;
+  }
+  return { ok: true, itemsCount: node.items.totalCount, fields };
+}
+
+const CREATE_FIELD_MUTATION = `mutation($projectId: ID!, $name: String!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+  createProjectV2Field(input: { projectId: $projectId, dataType: SINGLE_SELECT, name: $name, singleSelectOptions: $options }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { id name options { id name } } }
+  }
+}`;
+
+export async function createSingleSelectField(gh, projectId, name, optionDefs) {
+  const options = JSON.stringify(optionDefs.map((o) => ({ name: o.name, color: o.color, description: '' })));
+  const res = await gh(
+    ['api', 'graphql', '-f', `query=${CREATE_FIELD_MUTATION}`, '-f', `projectId=${projectId}`, '-f', `name=${name}`, '-F', `options=${options}`],
+    { parseJson: true },
+  );
+  if (!res.ok) return { ok: false, error: res.stderr || `create field ${name} failed` };
+  return { ok: true, field: res.json.data.createProjectV2Field.projectV2Field };
+}
+
+const UPDATE_STATUS_MUTATION = `mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+  updateProjectV2Field(input: { fieldId: $fieldId, singleSelectOptions: $options }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { id name options { id name } } }
+  }
+}`;
+
+/**
+ * ADR-0001: replaces ALL options and mints new ids — call only on projects
+ * with zero items (fresh bootstrap). Callers must check itemsCount first.
+ */
+export async function replaceStatusOptions(gh, fieldId, optionDefs) {
+  const options = JSON.stringify(optionDefs.map((o) => ({ name: o.name, color: o.color, description: '' })));
+  const res = await gh(
+    ['api', 'graphql', '-f', `query=${UPDATE_STATUS_MUTATION}`, '-f', `fieldId=${fieldId}`, '-F', `options=${options}`],
+    { parseJson: true },
+  );
+  if (!res.ok) return { ok: false, error: res.stderr || 'status options update failed' };
+  return { ok: true, field: res.json.data.updateProjectV2Field.projectV2Field };
+}
+
+export async function findIssueByTitle(gh, title) {
+  const res = await gh(
+    ['issue', 'list', '--state', 'all', '--limit', '100', '--search', `"${title}" in:title`, '--json', 'number,title,state'],
+    { parseJson: true },
+  );
+  if (!res.ok) return { ok: false, error: res.stderr || 'issue list failed' };
+  const hit = res.json.find((i) => i.title === title);
+  return { ok: true, issue: hit ?? null };
+}
+
+export async function createIssue(gh, title, body) {
+  const res = await gh(['issue', 'create', '--title', title, '--body', body]);
+  if (!res.ok) return { ok: false, error: res.stderr || 'issue create failed' };
+  const m = /\/issues\/(\d+)/.exec(res.stdout);
+  return { ok: true, number: m ? Number(m[1]) : null };
+}
+
+/** Map a discovered single-select field into the forge.json shape. */
+export function toConfigField(field) {
+  const options = {};
+  for (const o of field.options ?? []) options[optionKey(o.name)] = o.id;
+  return { id: field.id, options };
+}

--- a/plugin/scripts/lib/config.mjs
+++ b/plugin/scripts/lib/config.mjs
@@ -1,0 +1,115 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const CONFIG_RELPATH = join('.claude', 'forge.json');
+
+const FIELD_KEYS = ['status', 'priority', 'size', 'type'];
+
+/**
+ * Structural validation of .claude/forge.json — plain checks, no schema
+ * library (zero-dependency principle, spec §2). Returns every problem it
+ * finds so doctor can print them all at once.
+ */
+export function validateConfig(cfg) {
+  const errors = [];
+  const push = (msg) => errors.push(msg);
+
+  if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
+    return { ok: false, errors: ['config root must be a JSON object'] };
+  }
+
+  const board = cfg.board;
+  if (!board || typeof board !== 'object') {
+    push('board: missing block');
+  } else {
+    if (!Number.isInteger(board.projectNumber) || board.projectNumber <= 0) {
+      push('board.projectNumber: must be a positive integer');
+    }
+    if (typeof board.projectId !== 'string' || !/^PVT_/.test(board.projectId)) {
+      push('board.projectId: must be a ProjectV2 id (PVT_…)');
+    }
+    if (!board.fields || typeof board.fields !== 'object') {
+      push('board.fields: missing block');
+    } else {
+      for (const key of FIELD_KEYS) {
+        const f = board.fields[key];
+        if (!f || typeof f !== 'object') {
+          push(`board.fields.${key}: missing`);
+          continue;
+        }
+        if (typeof f.id !== 'string' || !/^PVTSSF_/.test(f.id)) {
+          push(`board.fields.${key}.id: must be a single-select field id (PVTSSF_…)`);
+        }
+        if (!f.options || typeof f.options !== 'object' || Object.keys(f.options).length === 0) {
+          push(`board.fields.${key}.options: must be a non-empty map of option name -> option id`);
+        } else {
+          for (const [name, id] of Object.entries(f.options)) {
+            if (typeof id !== 'string' || id.length === 0) push(`board.fields.${key}.options.${name}: empty option id`);
+          }
+        }
+      }
+    }
+    if (board.deliveryLogIssue !== undefined && (!Number.isInteger(board.deliveryLogIssue) || board.deliveryLogIssue <= 0)) {
+      push('board.deliveryLogIssue: must be a positive integer when present');
+    }
+  }
+
+  if (cfg.conventions !== undefined) {
+    if (typeof cfg.conventions !== 'object' || Array.isArray(cfg.conventions)) {
+      push('conventions: must be an object');
+    } else {
+      for (const [k, v] of Object.entries(cfg.conventions)) {
+        if (typeof v !== 'string') push(`conventions.${k}: must be a string`);
+      }
+    }
+  }
+
+  if (cfg.features !== undefined) {
+    if (typeof cfg.features !== 'object' || Array.isArray(cfg.features)) {
+      push('features: must be an object');
+    } else {
+      for (const [k, v] of Object.entries(cfg.features)) {
+        if (typeof v !== 'boolean') push(`features.${k}: must be a boolean`);
+      }
+    }
+  }
+
+  if (cfg.team !== undefined) {
+    const team = cfg.team;
+    if (typeof team !== 'object' || Array.isArray(team)) {
+      push('team: must be an object');
+    } else if (team.members !== undefined) {
+      if (!Array.isArray(team.members) || team.members.length === 0) {
+        push('team.members: must be a non-empty array when present');
+      } else {
+        team.members.forEach((m, i) => {
+          if (!m || typeof m.github !== 'string' || m.github.length === 0) push(`team.members[${i}].github: required`);
+          if (!Array.isArray(m.roles) || m.roles.length === 0) push(`team.members[${i}].roles: required non-empty array`);
+        });
+        const hasMaintainer = team.members.some((m) => Array.isArray(m.roles) && m.roles.includes('maintainer'));
+        if (!hasMaintainer) push('team.members: at least one member must hold the maintainer role');
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+/** Load + parse + validate. Missing file and broken JSON are distinct errors. */
+export async function loadConfig(cwd) {
+  const path = join(cwd, CONFIG_RELPATH);
+  let raw;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    return { ok: false, missing: true, errors: [`${CONFIG_RELPATH} not found — run /forge:init`], config: null };
+  }
+  let cfg;
+  try {
+    cfg = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, missing: false, errors: [`${CONFIG_RELPATH} is not valid JSON: ${err.message}`], config: null };
+  }
+  const v = validateConfig(cfg);
+  return { ok: v.ok, missing: false, errors: v.errors, config: cfg };
+}

--- a/plugin/scripts/lib/exec.mjs
+++ b/plugin/scripts/lib/exec.mjs
@@ -1,0 +1,51 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Windows-safe process runner. Always argv arrays, never a shell string —
+ * untrusted content cannot become shell syntax (spec §13 anti-injection).
+ *
+ * The `.cmd`/`.bat` EINVAL lesson: Node refuses to spawn cmd scripts without
+ * a shell (CVE-2024-27980 fix). We never pass shell:true with interpolated
+ * strings; instead cmd scripts are routed through cmd.exe with an argv array.
+ */
+export function run(command, args = [], options = {}) {
+  let cmd = command;
+  let argv = args;
+  if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(command)) {
+    cmd = process.env.ComSpec || 'cmd.exe';
+    argv = ['/d', '/s', '/c', command, ...args];
+  }
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(cmd, argv, { shell: false, windowsHide: true, ...options });
+    } catch (err) {
+      resolve({ ok: false, code: -1, stdout: '', stderr: String(err && err.message || err) });
+      return;
+    }
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (d) => { stdout += d; });
+    child.stderr?.on('data', (d) => { stderr += d; });
+    child.on('error', (err) => resolve({ ok: false, code: -1, stdout, stderr: String(err && err.message || err) }));
+    child.on('close', (code) => resolve({ ok: code === 0, code, stdout, stderr }));
+  });
+}
+
+/**
+ * gh CLI wrapper factory. The exec function is injectable so every consumer
+ * (init, doctor) is testable with scripted responses instead of a live gh.
+ */
+export function makeGh(execFn = run) {
+  return async function gh(args, { parseJson = false } = {}) {
+    const res = await execFn('gh', args);
+    if (parseJson && res.ok) {
+      try {
+        return { ...res, json: JSON.parse(res.stdout) };
+      } catch {
+        return { ...res, ok: false, json: null, stderr: `gh returned unparseable JSON for: gh ${args.join(' ')}` };
+      }
+    }
+    return res;
+  };
+}

--- a/plugin/scripts/lib/jsonfile.mjs
+++ b/plugin/scripts/lib/jsonfile.mjs
@@ -1,0 +1,44 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+/** Read a JSON file; returns null when missing, throws on broken JSON. */
+export async function readJson(path) {
+  let raw;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+  return JSON.parse(raw);
+}
+
+export async function writeJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2) + '\n', 'utf8');
+}
+
+/**
+ * Deep-merge `patch` into the JSON file at `path`, creating it if missing.
+ * Only keys present in the patch are touched — everything else in the file
+ * survives byte-for-byte semantically (the no-clobber rule for settings).
+ */
+export async function mergeJson(path, patch) {
+  const current = (await readJson(path)) ?? {};
+  const merged = deepMerge(current, patch);
+  await writeJson(path, merged);
+  return merged;
+}
+
+function deepMerge(base, patch) {
+  if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) return patch;
+  const out = { ...base };
+  for (const [k, v] of Object.entries(patch)) {
+    const existing = out[k];
+    if (existing && typeof existing === 'object' && !Array.isArray(existing) && v && typeof v === 'object' && !Array.isArray(v)) {
+      out[k] = deepMerge(existing, v);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}

--- a/plugin/scripts/lib/ticket.mjs
+++ b/plugin/scripts/lib/ticket.mjs
@@ -1,0 +1,32 @@
+/**
+ * Branch-name conventions (spec §2 git conventions).
+ * Work branches:  <type>/<issue#>-<kebab-slug>            e.g. feat/15-button
+ * Agent children: <work-branch>--<role>                   e.g. feat/15-button--implementer
+ * Spikes:         spike/<issue#>-<slug>   (never merge)
+ * Hotfix:         hotfix/<issue#>-<slug>  (incident-exempt in situation gating)
+ * Environment branches come from deploy.environments; main is main.
+ */
+const WORK_TYPES = ['feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'perf', 'spike', 'hotfix'];
+// slug = alnum runs joined by single hyphens, so `--` can never be part of a
+// slug and always delimits the agent-child role suffix
+const BRANCH_RE = new RegExp(`^(${WORK_TYPES.join('|')})/(\\d+)-([a-z0-9]+(?:-[a-z0-9]+)*)(?:--([a-z][a-z-]*))?$`);
+
+export function parseBranch(name, { environments = ['staging', 'production'] } = {}) {
+  if (typeof name !== 'string' || name.length === 0 || name === 'HEAD') {
+    return { kind: 'unknown', ticket: null };
+  }
+  if (name === 'main') return { kind: 'main', ticket: null };
+  if (environments.includes(name)) return { kind: 'env', env: name, ticket: null };
+
+  const m = BRANCH_RE.exec(name);
+  if (!m) return { kind: 'unknown', ticket: null };
+  const [, type, num, slug, role] = m;
+  return {
+    kind: type === 'spike' ? 'spike' : type === 'hotfix' ? 'hotfix' : 'work',
+    type,
+    ticket: Number(num),
+    slug,
+    role: role ?? null,
+    isAgentChild: role != null,
+  };
+}

--- a/plugin/scripts/statusline.mjs
+++ b/plugin/scripts/statusline.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Claude Code status line (spec §7, plan T7 — minimal SP1 form).
+ * Prints: `forge #<ticket> <branch>` — or `forge <branch>` when the branch
+ * carries no ticket. A status line must never break a session: any error
+ * prints nothing and exits 0. Situation-aware upgrade lands with SP3.
+ */
+import { run } from './lib/exec.mjs';
+import { parseBranch } from './lib/ticket.mjs';
+
+async function readStdin() {
+  let data = '';
+  for await (const chunk of process.stdin) data += chunk;
+  return data;
+}
+
+try {
+  const raw = await readStdin();
+  let cwd = process.cwd();
+  try {
+    const payload = JSON.parse(raw);
+    cwd = payload?.workspace?.current_dir || payload?.cwd || cwd;
+  } catch { /* no/invalid payload — fall back to cwd */ }
+
+  const res = await run('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD']);
+  if (!res.ok) process.exit(0);
+  const branch = res.stdout.trim();
+  const parsed = parseBranch(branch);
+  process.stdout.write(parsed.ticket != null ? `forge #${parsed.ticket} ${branch}` : `forge ${branch}`);
+} catch {
+  // silent by design
+}
+process.exit(0);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,983 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6)':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.16: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  vite-node@3.2.4:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6:
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@3.2.7:
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6)
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6
+      vite-node: 3.2.4
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runDoctor } from '../plugin/scripts/doctor.mjs';
+import { fakeGh, fieldsResponse, REPO_VIEW, AUTH_OK } from './helpers/fakegh.mjs';
+
+const noop = () => {};
+const byName = (res, name) => res.results.filter((r) => r.name === name);
+
+async function tmpCwd() {
+  return mkdtemp(join(tmpdir(), 'forge-doc-'));
+}
+
+describe('runDoctor — failure classes (AC-1.4)', () => {
+  it('missing gh auth is a distinct ✗', async () => {
+    const { gh } = fakeGh([['auth status', { ok: false, stderr: 'not logged in' }]]);
+    const res = await runDoctor({ gh, cwd: await tmpCwd(), log: noop });
+    expect(res.ok).toBe(false);
+    expect(byName(res, 'gh-auth')[0]).toMatchObject({ level: 'fail' });
+    expect(byName(res, 'gh-auth')[0].hint).toContain('gh auth login');
+  });
+
+  it('missing project scope is a distinct ✗ with the refresh hint', async () => {
+    const { gh } = fakeGh([
+      ['auth status', { stdout: "  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\n" }],
+      ['repo view', REPO_VIEW],
+      [() => true, { ok: false, stderr: 'x' }],
+    ]);
+    const res = await runDoctor({ gh, cwd: await tmpCwd(), log: noop });
+    expect(byName(res, 'gh-scope')[0]).toMatchObject({ level: 'fail' });
+    expect(byName(res, 'gh-scope')[0].hint).toContain('gh auth refresh');
+  });
+
+  it('missing forge.json is a ✗ pointing at /forge:init', async () => {
+    const { gh } = fakeGh([['auth status', AUTH_OK], ['repo view', REPO_VIEW], [() => true, { ok: false, stderr: 'x' }]]);
+    const res = await runDoctor({ gh, cwd: await tmpCwd(), log: noop });
+    const cfgFails = byName(res, 'config');
+    expect(cfgFails[0]).toMatchObject({ level: 'fail' });
+    expect(cfgFails[0].hint).toContain('/forge:init');
+  });
+
+  it('dangling field/option ids are a ✗ naming each dangling path', async () => {
+    const cwd = await tmpCwd();
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed), 'utf8');
+    await writeFile(join(cwd, '.gitignore'), '.forge/\n', 'utf8');
+
+    // live board is missing the size field and one status option
+    const liveFields = [
+      { id: committed.board.fields.status.id, name: 'Status', options: [
+        { id: committed.board.fields.status.options.backlog, name: 'Backlog' },
+        { id: committed.board.fields.status.options.done, name: 'Done' }] },
+      { id: committed.board.fields.priority.id, name: 'Priority', options: Object.entries(committed.board.fields.priority.options).map(([n, id]) => ({ id, name: n })) },
+      { id: committed.board.fields.type.id, name: 'Type', options: Object.entries(committed.board.fields.type.options).map(([n, id]) => ({ id, name: n })) },
+    ];
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      [(j) => j.includes('fields(first: 50)'), fieldsResponse(14, liveFields)],
+      [() => true, { ok: false, stderr: '404' }],
+    ]);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    const board = byName(res, 'board')[0];
+    expect(board.level).toBe('fail');
+    expect(board.msg).toContain('size.id');
+    expect(board.msg).toContain('status.options.inProgress');
+  });
+
+  it('missing .forge/ gitignore entry is a ✗', async () => {
+    const { gh } = fakeGh([['auth status', AUTH_OK], ['repo view', REPO_VIEW], [() => true, { ok: false, stderr: 'x' }]]);
+    const res = await runDoctor({ gh, cwd: await tmpCwd(), log: noop });
+    expect(byName(res, 'gitignore')[0]).toMatchObject({ level: 'fail' });
+  });
+
+  it('branch protection / secret scanning absent are ⚠ not ✗', async () => {
+    const cwd = await tmpCwd();
+    await writeFile(join(cwd, '.gitignore'), '.forge/\n', 'utf8');
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      [(j) => j.startsWith('api repos/') && j.includes('/protection'), { ok: false, stderr: '404' }],
+      [(j) => j.startsWith('api repos/'), { stdout: JSON.stringify({ security_and_analysis: { secret_scanning: { status: 'disabled' } } }) }],
+      [() => true, { ok: false, stderr: 'x' }],
+    ]);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'branch-protection')[0].level).toBe('warn');
+    expect(byName(res, 'secret-scanning')[0].level).toBe('warn');
+  });
+});
+
+describe('runDoctor — healthy repo shape', () => {
+  it('all green (✓/⚠ only) against a fully consistent setup', async () => {
+    const cwd = await tmpCwd();
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    committed.board.deliveryLogIssue = 15;
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed), 'utf8');
+    await writeFile(join(cwd, '.gitignore'), '.forge/\n', 'utf8');
+    // make it a git repo so the git check passes
+    const { run } = await import('../plugin/scripts/lib/exec.mjs');
+    await run('git', ['-C', cwd, 'init', '-q']);
+
+    const liveFields = Object.entries(committed.board.fields).map(([key, f]) => ({
+      id: f.id,
+      name: key[0].toUpperCase() + key.slice(1),
+      options: Object.entries(f.options).map(([n, id]) => ({ id, name: n })),
+    }));
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      [(j) => j.includes('fields(first: 50)'), fieldsResponse(14, liveFields)],
+      ['issue view 15', { stdout: JSON.stringify({ state: 'OPEN' }) }],
+      [(j) => j.startsWith('api repos/') && j.includes('/protection'), { stdout: '{}' }],
+      [(j) => j.startsWith('api repos/'), { stdout: JSON.stringify({ security_and_analysis: { secret_scanning: { status: 'enabled' } } }) }],
+    ]);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(res.results.filter((r) => r.level === 'fail')).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+});

--- a/tests/helpers/fakegh.mjs
+++ b/tests/helpers/fakegh.mjs
@@ -1,0 +1,40 @@
+import { makeGh } from '../../plugin/scripts/lib/exec.mjs';
+
+/**
+ * Scripted gh for tests. Routes are [predicate(argsJoined, args), response]
+ * pairs checked in order; response is {stdout} (ok defaults true) or a full
+ * {ok, code, stdout, stderr}. Records every call for order/absence asserts.
+ */
+export function fakeGh(routes) {
+  const calls = [];
+  const execFn = async (cmd, args) => {
+    const joined = args.join(' ');
+    calls.push(joined);
+    for (const [pred, res] of routes) {
+      const hit = typeof pred === 'string' ? joined.startsWith(pred) : pred(joined, args);
+      if (hit) {
+        const r = typeof res === 'function' ? res(joined, args) : res;
+        return { ok: r.ok ?? true, code: r.code ?? (r.ok === false ? 1 : 0), stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+      }
+    }
+    return { ok: false, code: 1, stdout: '', stderr: `fakeGh: unrouted call: gh ${joined}` };
+  };
+  return { gh: makeGh(execFn), calls };
+}
+
+/** Build a ProjectsV2 fields-query response from simple field specs. */
+export function fieldsResponse(itemsCount, fields) {
+  return {
+    stdout: JSON.stringify({
+      data: {
+        node: {
+          items: { totalCount: itemsCount },
+          fields: { nodes: fields.map((f) => ({ __typename: 'ProjectV2SingleSelectField', id: f.id, name: f.name, options: f.options })) },
+        },
+      },
+    }),
+  };
+}
+
+export const REPO_VIEW = { stdout: JSON.stringify({ owner: { login: 'dngioidev' }, name: 'forge', defaultBranchRef: { name: 'main' } }) };
+export const AUTH_OK = { stdout: 'github.com\n  ✓ Logged in\n  - Token scopes: \'gist\', \'project\', \'read:org\', \'repo\'\n' };

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runInit, parseArgs } from '../plugin/scripts/init.mjs';
+import { readJson } from '../plugin/scripts/lib/jsonfile.mjs';
+import { fakeGh, fieldsResponse, REPO_VIEW, AUTH_OK } from './helpers/fakegh.mjs';
+
+const noop = () => {};
+
+// Live board #8 shapes (mirrors the committed .claude/forge.json)
+const BOARD8 = {
+  projectId: 'PVT_kwHOCkJQ784BdZrh',
+  fields: [
+    { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7emI', name: 'Status', options: [
+      { id: '04db063a', name: 'Backlog' }, { id: '29224f44', name: 'In progress' }, { id: '7d8a60b9', name: 'Done' }] },
+    { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7esI', name: 'Priority', options: [
+      { id: '66c7f4b7', name: 'P0' }, { id: '23a624d0', name: 'P1' }, { id: 'd9b45a49', name: 'P2' }] },
+    { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7esU', name: 'Size', options: [
+      { id: 'd2a09967', name: 'XS' }, { id: '0a97017a', name: 'S' }, { id: '88715f78', name: 'M' }, { id: 'e0e2c48d', name: 'L' }, { id: 'ec65bb19', name: 'XL' }] },
+    { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7euY', name: 'Type', options: [
+      { id: 'cc17fc25', name: 'Epic' }, { id: '54a8e89d', name: 'Item' }, { id: '8b7b608b', name: 'Bug' }, { id: 'd572a031', name: 'Test' }] },
+  ],
+};
+
+const FRESH_FULL_FIELDS = [
+  { id: 'PVTSSF_new1', name: 'Status', options: [
+    { id: 's1', name: 'Backlog' }, { id: 's2', name: 'Ready' }, { id: 's3', name: 'In progress' },
+    { id: 's4', name: 'In review' }, { id: 's5', name: 'Blocked / Needs decision' }, { id: 's6', name: 'Done' }] },
+  { id: 'PVTSSF_new2', name: 'Priority', options: [{ id: 'p1', name: 'P0' }, { id: 'p2', name: 'P1' }, { id: 'p3', name: 'P2' }] },
+  { id: 'PVTSSF_new3', name: 'Size', options: [{ id: 'z1', name: 'XS' }, { id: 'z2', name: 'S' }] },
+  { id: 'PVTSSF_new4', name: 'Type', options: [{ id: 't1', name: 'Epic' }, { id: 't2', name: 'Item' }] },
+];
+
+async function tmpCwd() {
+  return mkdtemp(join(tmpdir(), 'forge-init-'));
+}
+
+describe('parseArgs', () => {
+  it('parses project, create-project, statusline', () => {
+    expect(parseArgs(['--project', '8', '--statusline'])).toMatchObject({ project: 8, statusline: true });
+    expect(parseArgs(['--create-project', 'my board'])).toMatchObject({ createProject: 'my board' });
+  });
+});
+
+describe('runInit — fresh bootstrap (AC-1.2)', () => {
+  function freshRoutes() {
+    let fieldsCall = 0;
+    return [
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project create', { stdout: JSON.stringify({ id: 'PVT_new', number: 9, title: 'forge' }) }],
+      [(j) => j.startsWith('api graphql') && j.includes('fields(first: 50)'), () => {
+        fieldsCall += 1;
+        // first discovery: built-in status only, empty project; re-discovery: full set
+        return fieldsCall === 1
+          ? fieldsResponse(0, [{ id: 'PVTSSF_new1', name: 'Status', options: [{ id: 'a', name: 'Todo' }, { id: 'b', name: 'In Progress' }, { id: 'c', name: 'Done' }] }])
+          : fieldsResponse(0, FRESH_FULL_FIELDS);
+      }],
+      [(j) => j.includes('updateProjectV2Field'), { stdout: JSON.stringify({ data: { updateProjectV2Field: { projectV2Field: { id: 'PVTSSF_new1', options: [] } } } }) }],
+      [(j) => j.includes('createProjectV2Field'), { stdout: JSON.stringify({ data: { createProjectV2Field: { projectV2Field: { id: 'PVTSSF_x', options: [] } } } }) }],
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/42\n' }],
+    ];
+  }
+
+  it('creates project, standard fields, delivery log, forge.json, gitignore', async () => {
+    const cwd = await tmpCwd();
+    const { gh, calls } = fakeGh(freshRoutes());
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--create-project', 'forge', '--skip-doctor']) });
+    expect(res.ok).toBe(true);
+
+    // status replaced (empty project, ADR-0001) and 3 custom fields created
+    expect(calls.some((c) => c.includes('updateProjectV2Field'))).toBe(true);
+    expect(calls.filter((c) => c.includes('createProjectV2Field')).length).toBe(3);
+
+    const cfg = await readJson(join(cwd, '.claude', 'forge.json'));
+    expect(cfg.board.projectNumber).toBe(9);
+    expect(cfg.board.deliveryLogIssue).toBe(42);
+    expect(cfg.board.fields.status.options).toMatchObject({ backlog: 's1', ready: 's2', inProgress: 's3', inReview: 's4', blocked: 's5', done: 's6' });
+    expect(cfg.team.members[0]).toMatchObject({ github: 'dngioidev', roles: ['maintainer'] });
+    expect(cfg.features).toMatchObject({ graph: false, deploy: false });
+
+    const gi = await readFile(join(cwd, '.gitignore'), 'utf8');
+    expect(gi).toContain('.forge/');
+  });
+
+  it('AC-1.2: re-run is a no-op — no create/update mutations fire', async () => {
+    const cwd = await tmpCwd();
+    // first run
+    const first = fakeGh(freshRoutes());
+    await runInit({ gh: first.gh, cwd, log: noop, args: parseArgs(['--create-project', 'forge', '--skip-doctor']) });
+
+    // second run: project now discovered by number from config; fields complete
+    const second = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project view 9', { stdout: JSON.stringify({ id: 'PVT_new', number: 9, title: 'forge' }) }],
+      [(j) => j.includes('fields(first: 50)'), fieldsResponse(3, FRESH_FULL_FIELDS)],
+    ]);
+    const res = await runInit({ gh: second.gh, cwd, log: noop, args: parseArgs(['--skip-doctor']) });
+    expect(res.ok).toBe(true);
+    expect(second.calls.some((c) => c.includes('createProjectV2Field'))).toBe(false);
+    expect(second.calls.some((c) => c.includes('updateProjectV2Field'))).toBe(false);
+    expect(second.calls.some((c) => c.startsWith('issue create'))).toBe(false);
+
+    const gi = await readFile(join(cwd, '.gitignore'), 'utf8');
+    expect(gi.match(/\.forge\//g).length).toBe(1); // appended exactly once
+  });
+
+  it('resumes after partial failure: only missing fields get created', async () => {
+    const cwd = await tmpCwd();
+    const partial = [
+      { id: 'PVTSSF_new1', name: 'Status', options: FRESH_FULL_FIELDS[0].options },
+      FRESH_FULL_FIELDS[1], // priority already exists from the failed run
+    ];
+    const { gh, calls } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project view 9', { stdout: JSON.stringify({ id: 'PVT_new', number: 9, title: 'forge' }) }],
+      [(j) => j.includes('fields(first: 50)'), (() => {
+        let n = 0;
+        return () => { n += 1; return n === 1 ? fieldsResponse(0, partial) : fieldsResponse(0, FRESH_FULL_FIELDS); };
+      })()],
+      [(j) => j.includes('createProjectV2Field'), { stdout: JSON.stringify({ data: { createProjectV2Field: { projectV2Field: { id: 'x', options: [] } } } }) }],
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/7\n' }],
+    ]);
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--project', '9', '--skip-doctor']) });
+    expect(res.ok).toBe(true);
+    const creates = calls.filter((c) => c.includes('createProjectV2Field'));
+    expect(creates.length).toBe(2); // size + type only — priority not recreated
+  });
+});
+
+describe('runInit — adopt mode (AC-1.3)', () => {
+  it('discovers board #8 into a board block identical to the committed forge.json', async () => {
+    const cwd = await tmpCwd();
+    // seed the committed config (without deliveryLogIssue, as committed today)
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed, null, 2), 'utf8');
+
+    const { gh, calls } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project view 8', { stdout: JSON.stringify({ id: BOARD8.projectId, number: 8, title: 'forge - AI dev platform' }) }],
+      [(j) => j.includes('fields(first: 50)'), fieldsResponse(14, BOARD8.fields)],
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/15\n' }],
+    ]);
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--skip-doctor']) });
+    expect(res.ok).toBe(true);
+
+    // live board has items -> status options must NOT be replaced (ADR-0001)
+    expect(calls.some((c) => c.includes('updateProjectV2Field'))).toBe(false);
+
+    const cfg = await readJson(join(cwd, '.claude', 'forge.json'));
+    expect(cfg.board.projectNumber).toBe(committed.board.projectNumber);
+    expect(cfg.board.projectId).toBe(committed.board.projectId);
+    expect(cfg.board.fields).toEqual(committed.board.fields); // AC-1.3 exact match
+    expect(cfg.board.deliveryLogIssue).toBe(15);
+    // adopt never clobbers existing consumer config
+    expect(cfg.conventions).toEqual(committed.conventions);
+  });
+});
+
+describe('runInit — failure modes', () => {
+  it('fails with a clear message when gh is unauthenticated', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh([['auth status', { ok: false, stderr: 'not logged in' }]]);
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs([]) });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('gh auth login');
+  });
+
+  it('fails when neither --project nor --create-project resolves', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+    ]);
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--skip-doctor']) });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('--project');
+  });
+});

--- a/tests/lib/config.test.mjs
+++ b/tests/lib/config.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { validateConfig, loadConfig } from '../../plugin/scripts/lib/config.mjs';
+
+function validCfg() {
+  return {
+    board: {
+      projectNumber: 8,
+      projectId: 'PVT_kwHOCkJQ784BdZrh',
+      fields: {
+        status: { id: 'PVTSSF_a', options: { backlog: '1', inProgress: '2', done: '3' } },
+        priority: { id: 'PVTSSF_b', options: { p0: '1', p1: '2', p2: '3' } },
+        size: { id: 'PVTSSF_c', options: { s: '1', m: '2' } },
+        type: { id: 'PVTSSF_d', options: { epic: '1', item: '2' } },
+      },
+    },
+    conventions: { verify: 'pnpm verify' },
+    features: { graph: true },
+    team: { members: [{ github: 'dngioidev', roles: ['maintainer'] }] },
+  };
+}
+
+describe('validateConfig', () => {
+  it('accepts a complete valid config', () => {
+    expect(validateConfig(validCfg())).toEqual({ ok: true, errors: [] });
+  });
+
+  it('AC-1.4: rejects a non-object root', () => {
+    expect(validateConfig([]).ok).toBe(false);
+    expect(validateConfig(null).ok).toBe(false);
+  });
+
+  it('AC-1.4: flags missing board block and bad ids', () => {
+    const noBoard = validateConfig({});
+    expect(noBoard.errors).toContain('board: missing block');
+
+    const cfg = validCfg();
+    cfg.board.projectId = 'nope';
+    cfg.board.fields.status.id = 'wrong';
+    const r = validateConfig(cfg);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes('board.projectId'))).toBe(true);
+    expect(r.errors.some((e) => e.includes('board.fields.status.id'))).toBe(true);
+  });
+
+  it('AC-1.4: flags every missing field key, not just the first', () => {
+    const cfg = validCfg();
+    delete cfg.board.fields.priority;
+    delete cfg.board.fields.type;
+    const r = validateConfig(cfg);
+    expect(r.errors).toContain('board.fields.priority: missing');
+    expect(r.errors).toContain('board.fields.type: missing');
+  });
+
+  it('flags empty options and non-boolean features', () => {
+    const cfg = validCfg();
+    cfg.board.fields.size.options = {};
+    cfg.features.graph = 'yes';
+    const r = validateConfig(cfg);
+    expect(r.errors.some((e) => e.includes('size.options'))).toBe(true);
+    expect(r.errors.some((e) => e.includes('features.graph'))).toBe(true);
+  });
+
+  it('requires at least one maintainer when team.members present', () => {
+    const cfg = validCfg();
+    cfg.team.members = [{ github: 'alice', roles: ['developer'] }];
+    const r = validateConfig(cfg);
+    expect(r.errors.some((e) => e.includes('maintainer'))).toBe(true);
+  });
+});
+
+describe('loadConfig', () => {
+  it('AC-1.4: distinct errors for missing file vs broken JSON', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-cfg-'));
+    const missing = await loadConfig(dir);
+    expect(missing.missing).toBe(true);
+    expect(missing.errors[0]).toContain('/forge:init');
+
+    await mkdir(join(dir, '.claude'), { recursive: true });
+    await writeFile(join(dir, '.claude', 'forge.json'), '{ not json', 'utf8');
+    const broken = await loadConfig(dir);
+    expect(broken.missing).toBe(false);
+    expect(broken.ok).toBe(false);
+    expect(broken.errors[0]).toContain('not valid JSON');
+  });
+
+  it('loads and validates the real committed forge.json shape', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-cfg-'));
+    await mkdir(join(dir, '.claude'), { recursive: true });
+    await writeFile(join(dir, '.claude', 'forge.json'), JSON.stringify(validCfg()), 'utf8');
+    const r = await loadConfig(dir);
+    expect(r.ok).toBe(true);
+    expect(r.config.board.projectNumber).toBe(8);
+  });
+});

--- a/tests/lib/exec.test.mjs
+++ b/tests/lib/exec.test.mjs
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { run, makeGh } from '../../plugin/scripts/lib/exec.mjs';
+
+describe('run', () => {
+  it('runs a real process and captures stdout', async () => {
+    const res = await run(process.execPath, ['-e', 'console.log("hi")']);
+    expect(res.ok).toBe(true);
+    expect(res.stdout.trim()).toBe('hi');
+  });
+
+  it('reports nonzero exit codes as not ok', async () => {
+    const res = await run(process.execPath, ['-e', 'process.exit(3)']);
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe(3);
+  });
+
+  it('resolves (never throws) for a missing binary', async () => {
+    const res = await run('definitely-not-a-real-binary-xyz', []);
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe(-1);
+  });
+
+  it('the .cmd EINVAL lesson: cmd scripts are routed through cmd.exe on Windows', async function () {
+    if (process.platform !== 'win32') return; // Windows-only regression
+    const { mkdtemp, writeFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = await mkdtemp(join(tmpdir(), 'forge-exec-'));
+    const script = join(dir, 'hello.cmd');
+    await writeFile(script, '@echo cmd-ok\r\n', 'utf8');
+    const res = await run(script, []);
+    expect(res.ok).toBe(true);
+    expect(res.stdout).toContain('cmd-ok');
+  });
+});
+
+describe('makeGh', () => {
+  it('is injectable: consumers can script gh responses', async () => {
+    const calls = [];
+    const gh = makeGh(async (cmd, args) => {
+      calls.push([cmd, ...args]);
+      return { ok: true, code: 0, stdout: '{"title":"forge - AI dev platform"}', stderr: '' };
+    });
+    const res = await gh(['project', 'view', '8'], { parseJson: true });
+    expect(calls[0][0]).toBe('gh');
+    expect(res.json.title).toContain('forge');
+  });
+
+  it('flags unparseable JSON instead of throwing', async () => {
+    const gh = makeGh(async () => ({ ok: true, code: 0, stdout: 'not json', stderr: '' }));
+    const res = await gh(['x'], { parseJson: true });
+    expect(res.ok).toBe(false);
+    expect(res.json).toBe(null);
+  });
+});

--- a/tests/lib/jsonfile.test.mjs
+++ b/tests/lib/jsonfile.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readJson, writeJson, mergeJson } from '../../plugin/scripts/lib/jsonfile.mjs';
+
+describe('jsonfile', () => {
+  it('readJson returns null for missing files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-json-'));
+    expect(await readJson(join(dir, 'nope.json'))).toBe(null);
+  });
+
+  it('writeJson creates parent directories and round-trips', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-json-'));
+    const p = join(dir, 'a', 'b', 'x.json');
+    await writeJson(p, { hello: 1 });
+    expect(await readJson(p)).toEqual({ hello: 1 });
+  });
+
+  it('AC-1.5: mergeJson never clobbers unrelated keys (settings no-clobber)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-json-'));
+    const p = join(dir, 'settings.json');
+    await writeJson(p, {
+      permissions: { allow: ['Bash(pnpm verify)'] },
+      env: { FOO: 'bar' },
+      statusLine: { type: 'command', command: 'old-command' },
+    });
+    await mergeJson(p, { statusLine: { type: 'command', command: 'node statusline.mjs' } });
+    const after = await readJson(p);
+    expect(after.permissions.allow).toEqual(['Bash(pnpm verify)']);
+    expect(after.env.FOO).toBe('bar');
+    expect(after.statusLine.command).toBe('node statusline.mjs');
+  });
+
+  it('mergeJson creates the file when missing', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-json-'));
+    const p = join(dir, 'new.json');
+    const merged = await mergeJson(p, { a: { b: 2 } });
+    expect(merged).toEqual({ a: { b: 2 } });
+    expect(await readJson(p)).toEqual({ a: { b: 2 } });
+  });
+
+  it('deep-merges nested objects but replaces arrays and scalars', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-json-'));
+    const p = join(dir, 'deep.json');
+    await writeJson(p, { a: { keep: 1, replace: [1, 2] }, s: 'x' });
+    await mergeJson(p, { a: { replace: [3] }, s: 'y' });
+    expect(await readJson(p)).toEqual({ a: { keep: 1, replace: [3] }, s: 'y' });
+  });
+});

--- a/tests/lib/ticket.test.mjs
+++ b/tests/lib/ticket.test.mjs
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { parseBranch } from '../../plugin/scripts/lib/ticket.mjs';
+
+describe('parseBranch', () => {
+  it('AC-1.5: parses a work branch into type/ticket/slug', () => {
+    expect(parseBranch('feat/15-button')).toMatchObject({ kind: 'work', type: 'feat', ticket: 15, slug: 'button', role: null, isAgentChild: false });
+  });
+
+  it('parses every conventional type', () => {
+    for (const t of ['feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'perf']) {
+      expect(parseBranch(`${t}/7-x`).ticket).toBe(7);
+    }
+  });
+
+  it('AC-1.5: parses an agent child branch (--role suffix)', () => {
+    expect(parseBranch('feat/15-button--implementer')).toMatchObject({ kind: 'work', ticket: 15, role: 'implementer', isAgentChild: true });
+  });
+
+  it('classifies spike and hotfix branches as their own kinds', () => {
+    expect(parseBranch('spike/22-animation-lib').kind).toBe('spike');
+    expect(parseBranch('hotfix/31-login-500').kind).toBe('hotfix');
+  });
+
+  it('classifies main and environment branches', () => {
+    expect(parseBranch('main').kind).toBe('main');
+    expect(parseBranch('staging')).toMatchObject({ kind: 'env', env: 'staging' });
+    expect(parseBranch('production', { environments: ['production'] }).kind).toBe('env');
+  });
+
+  it('rejects non-conforming names, detached HEAD, and empties', () => {
+    expect(parseBranch('random-branch').kind).toBe('unknown');
+    expect(parseBranch('feat/no-number').kind).toBe('unknown');
+    expect(parseBranch('feature/15-x').kind).toBe('unknown');
+    expect(parseBranch('HEAD').kind).toBe('unknown');
+    expect(parseBranch('').kind).toBe('unknown');
+    expect(parseBranch(undefined).kind).toBe('unknown');
+  });
+});

--- a/tests/manifests.test.mjs
+++ b/tests/manifests.test.mjs
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('plugin manifests (AC-1.1 structural half)', () => {
+  it('marketplace.json parses and points at the plugin dir', async () => {
+    const m = JSON.parse(await readFile(join(root, '.claude-plugin', 'marketplace.json'), 'utf8'));
+    expect(m.name).toBe('forge');
+    expect(Array.isArray(m.plugins)).toBe(true);
+    expect(m.plugins[0]).toMatchObject({ name: 'forge', source: './plugin' });
+  });
+
+  it('plugin.json parses with required keys', async () => {
+    const p = JSON.parse(await readFile(join(root, 'plugin', '.claude-plugin', 'plugin.json'), 'utf8'));
+    expect(p.name).toBe('forge');
+    expect(p.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(typeof p.description).toBe('string');
+  });
+
+  it('command files exist for every /forge:<verb> the plugin claims', async () => {
+    for (const cmd of ['init', 'doctor']) {
+      const md = await readFile(join(root, 'plugin', 'commands', `${cmd}.md`), 'utf8');
+      expect(md.length).toBeGreaterThan(50);
+    }
+  });
+});

--- a/tests/statusline.test.mjs
+++ b/tests/statusline.test.mjs
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { run } from '../plugin/scripts/lib/exec.mjs';
+
+const script = join(dirname(fileURLToPath(import.meta.url)), '..', 'plugin', 'scripts', 'statusline.mjs');
+
+async function runStatusline(payload) {
+  const { spawn } = await import('node:child_process');
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [script], { windowsHide: true });
+    let stdout = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.on('close', (code) => resolve({ code, stdout }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+async function gitRepoOnBranch(branch) {
+  const dir = await mkdtemp(join(tmpdir(), 'forge-sl-'));
+  await run('git', ['-C', dir, 'init', '-q', '-b', 'main']);
+  await run('git', ['-C', dir, 'config', 'user.email', 't@t.t']);
+  await run('git', ['-C', dir, 'config', 'user.name', 't']);
+  await run('git', ['-C', dir, 'commit', '--allow-empty', '-q', '-m', 'x']);
+  if (branch !== 'main') await run('git', ['-C', dir, 'checkout', '-q', '-b', branch]);
+  return dir;
+}
+
+describe('statusline (AC-1.5)', () => {
+  it('prints forge #<ticket> <branch> on a work branch', async () => {
+    const dir = await gitRepoOnBranch('feat/12-widget');
+    const res = await runStatusline({ workspace: { current_dir: dir } });
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe('forge #12 feat/12-widget');
+  });
+
+  it('prints forge <branch> when the branch has no ticket', async () => {
+    const dir = await gitRepoOnBranch('main');
+    const res = await runStatusline({ workspace: { current_dir: dir } });
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe('forge main');
+  });
+
+  it('never breaks the session: non-git dir -> empty output, exit 0', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-sl-'));
+    const res = await runStatusline({ workspace: { current_dir: dir } });
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe('');
+  });
+
+  it('never breaks the session: garbage stdin -> exit 0', async () => {
+    const { spawn } = await import('node:child_process');
+    const res = await new Promise((resolve) => {
+      const child = spawn(process.execPath, [script], { windowsHide: true });
+      let stdout = '';
+      child.stdout.on('data', (d) => { stdout += d; });
+      child.on('close', (code) => resolve({ code, stdout }));
+      child.stdin.write('not json at all');
+      child.stdin.end();
+    });
+    expect(res.code).toBe(0);
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.mjs'],
+    watch: false,
+  },
+});


### PR DESCRIPTION
Closes #1 (SP1, plan: docs/plans/2026-07-16-sp1-plugin-skeleton.md)

## Commits → issue map
- chore(repo): scaffolding — pnpm, vitest, CI matrix (#1)
- feat(plugin): skeleton — manifests, lib, init, doctor, statusline (#1)
- docs(adr): ADR-0001 status options + forge.json refresh (#1)

## AC checklist
- [x] **AC-1.1** (structural half): manifests parse + command files exist (tests); live marketplace install to be dogfooded from the cms checkout after merge
- [x] **AC-1.2**: fresh bootstrap end-to-end + idempotent re-run + partial-failure resume — test-verified with scripted gh
- [x] **AC-1.3**: adopt mode against real board #8 — live run produced ids byte-identical to the committed forge.json (+deliveryLogIssue #15); also test-verified
- [x] **AC-1.4**: doctor — one distinct ✗ per failure class (auth, scope, config missing/invalid, dangling ids, gitignore), ⚠ for advisory checks — test-verified per class
- [x] **AC-1.5**: status line renders `forge #1 feat/1-plugin-skeleton` live; parser + no-clobber merge test-verified; wired to settings.local.json (machine-specific path never committed)
- [ ] **AC-1.6**: CI green on windows-latest + ubuntu-latest — this PR's checks

## Honest verification
- 46/46 tests green locally (Windows). gh fully mocked in tests; live proofs run against board #8 (adopt + doctor healthy: 8✓ 2⚠ — the ⚠ are branch protection + secret scanning, both one-time repo settings for the owner).
- ADR-0001 spike verified live on a scratch project (created + deleted): Status options ARE mutable via updateProjectV2Field, but replacement mints new option ids → replace on empty projects only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x