### PR TITLE
feat: SP2 board automation — seven board scripts + forge:board skill (#2)

### DIFF
--- a/plugin/commands/board-status.md
+++ b/plugin/commands/board-status.md
@@ -1,0 +1,11 @@
+---
+description: Print the forge catch-up card — situation, counts, blocked/in-progress items, open PRs, next action
+---
+
+Run:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/board/status.mjs"
+```
+
+Relay the card verbatim (it is already terse). If anything is 🚩 blocked, surface those first — they are waiting on a human decision.

--- a/plugin/commands/ticket.md
+++ b/plugin/commands/ticket.md
@@ -1,0 +1,16 @@
+---
+description: Quick ticket create — issue + board placement + fields in one step
+---
+
+Create a ticket on the forge board from the user's description.
+
+1. Derive from the request (ask only for what's genuinely ambiguous): title (imperative, concise), body (1–3 sentence description + acceptance criteria bullets when clear), type (`item`/`bug`/`epic`/`test`), priority (`p0` urgent / `p1` normal / `p2` later), size (`xs`–`xl`), parent epic number if the user names one.
+2. Run:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/board/create.mjs" --title "<title>" --body "<body>" --type <type> --priority <p> --size <s> --status backlog [--parent <epic#>] [--assignee <login>]
+```
+
+3. Report the created issue number + link. The script is idempotent — an existing issue with the same title is reused, never duplicated.
+
+This is the create-wrapper only; judgment-heavy triage (dedup search, AC quality, correct typing of vague reports) is `forge:triage` (SP3).

--- a/plugin/scripts/board/comment.mjs
+++ b/plugin/scripts/board/comment.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * board comment — ticket-trail comment, idempotent per phase marker
+ * (spec §6 ticket-trail law; plan T4, AC-2.3).
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+import { upsertMarkedComment } from '../lib/issues.mjs';
+
+export const PHASES = ['started', 'spec', 'plan', 'pr', 'gate-fail', 'escalation', 'ci-green', 'merged', 'note'];
+
+export function parseArgs(argv) {
+  const a = { issue: null, phase: null, body: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
+    else if (argv[i] === '--phase') a.phase = argv[++i];
+    else if (argv[i] === '--body') a.body = argv[++i];
+  }
+  return a;
+}
+
+export async function runComment(ctx, args, log = console.log) {
+  if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
+  if (!PHASES.includes(args.phase)) return { ok: false, error: `unknown phase '${args.phase}' — valid: ${PHASES.join(', ')}` };
+  if (!args.body) return { ok: false, error: '--body is required' };
+
+  const content = `**forge trail** — ${args.body}`;
+  const res = await upsertMarkedComment(ctx.gh, ctx.owner, ctx.repo, args.issue, `trail:${args.phase}`, content);
+  if (!res.ok) return res;
+  log(`#${args.issue} trail:${args.phase} ${res.action}`);
+  return res;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const res = await runComment(ctx, parseArgs(process.argv.slice(2)));
+    if (!res.ok) { console.error(`comment failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/board/create.mjs
+++ b/plugin/scripts/board/create.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * board create — issue + parent sub-issue + board item + fields + assignee,
+ * one command, resumable (spec §6 idempotency law; plan T2, AC-2.1).
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+import { getIssueNode, addSubIssue } from '../lib/issues.mjs';
+
+export function parseArgs(argv) {
+  const a = { title: null, body: '', type: 'item', priority: 'p1', size: 'm', status: 'backlog', parent: null, assignee: null };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--title') a.title = argv[++i];
+    else if (k === '--body') a.body = argv[++i];
+    else if (k === '--type') a.type = argv[++i];
+    else if (k === '--priority') a.priority = argv[++i];
+    else if (k === '--size') a.size = argv[++i];
+    else if (k === '--status') a.status = argv[++i];
+    else if (k === '--parent') a.parent = Number(argv[++i]);
+    else if (k === '--assignee') a.assignee = argv[++i];
+  }
+  return a;
+}
+
+export async function runCreate(ctx, args, log = console.log) {
+  if (!args.title) return { ok: false, error: '--title is required' };
+  // validate option keys up front so we fail before creating anything
+  for (const [f, k] of [['type', args.type], ['priority', args.priority], ['size', args.size], ['status', args.status]]) {
+    const r = ctx.resolveOption(f, k);
+    if (!r.ok) return { ok: false, error: r.error };
+  }
+
+  // 1. issue: find by exact title first (never duplicate)
+  const found = await ctx.gh(
+    ['issue', 'list', '--state', 'all', '--limit', '100', '--search', `"${args.title}" in:title`, '--json', 'number,title,url'],
+    { parseJson: true },
+  );
+  if (!found.ok) return { ok: false, error: found.stderr || 'issue list failed' };
+  let issue = found.json.find((i) => i.title === args.title) ?? null;
+  if (issue) {
+    log(`issue: exists #${issue.number} (resuming)`);
+  } else {
+    const createArgs = ['issue', 'create', '--title', args.title, '--body', args.body];
+    if (args.assignee) createArgs.push('--assignee', args.assignee);
+    const created = await ctx.gh(createArgs);
+    if (!created.ok) return { ok: false, error: created.stderr || 'issue create failed' };
+    const url = created.stdout.trim().split(/\r?\n/).pop();
+    const num = Number((/\/issues\/(\d+)/.exec(url) ?? [])[1]);
+    issue = { number: num, url };
+    log(`issue: created #${num}`);
+  }
+
+  // 2. parent sub-issue link (skip when already parented)
+  if (args.parent != null) {
+    const child = await getIssueNode(ctx.gh, ctx.owner, ctx.repo, issue.number);
+    if (!child.ok) return { ok: false, error: child.error };
+    if (child.parentNumber === args.parent) {
+      log(`parent: already linked to #${args.parent}`);
+    } else if (child.parentNumber != null) {
+      log(`parent: linked to #${child.parentNumber}, leaving as-is (wanted #${args.parent})`);
+    } else {
+      const parent = await getIssueNode(ctx.gh, ctx.owner, ctx.repo, args.parent);
+      if (!parent.ok) return { ok: false, error: parent.error };
+      const linked = await addSubIssue(ctx.gh, parent.id, child.id);
+      if (!linked.ok) return { ok: false, error: linked.error };
+      log(`parent: linked #${issue.number} under #${args.parent}`);
+    }
+  }
+
+  // 3. board item
+  const existing = await ctx.findItemByIssue(issue.number);
+  if (!existing.ok) return { ok: false, error: existing.error };
+  let itemId = existing.item?.id ?? null;
+  if (itemId) {
+    log('board: item exists');
+  } else {
+    const url = issue.url ?? `https://github.com/${ctx.owner}/${ctx.repo}/issues/${issue.number}`;
+    const added = await ctx.addItemByUrl(url);
+    if (!added.ok) return { ok: false, error: added.error };
+    itemId = added.itemId;
+    log('board: item added');
+  }
+
+  // 4. fields — set only what differs (resume-friendly)
+  for (const [fieldKey, wanted] of [['type', args.type], ['priority', args.priority], ['size', args.size], ['status', args.status]]) {
+    const current = existing.item ? ctx.itemFieldKey(existing.item, fieldKey) : null;
+    if (current === wanted) continue;
+    const set = await ctx.setSelect(itemId, fieldKey, wanted);
+    if (!set.ok) return { ok: false, error: set.error };
+    log(`field: ${fieldKey}=${wanted}`);
+  }
+
+  return { ok: true, number: issue.number, itemId };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const res = await runCreate(ctx, parseArgs(process.argv.slice(2)));
+    if (!res.ok) { console.error(`create failed: ${res.error}`); process.exit(1); }
+    console.log(`created/verified #${res.number}`);
+  });
+}

--- a/plugin/scripts/board/digest.mjs
+++ b/plugin/scripts/board/digest.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * board digest — epic body carries a managed block with the live child table,
+ * blocked-first (plan T7, AC-2.5). Flow metrics land with SP7.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+import { getSubIssues, getIssueBody, setIssueBody } from '../lib/issues.mjs';
+import { upsertBlock } from '../lib/markers.mjs';
+
+const STATUS_ORDER = ['blocked', 'inReview', 'inProgress', 'ready', 'backlog', 'done'];
+
+export function parseArgs(argv) {
+  const a = { epic: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--epic') a.epic = Number(argv[++i]);
+  }
+  return a;
+}
+
+export function renderChildTable(rows) {
+  const lines = [
+    '### Children',
+    '',
+    '| # | title | status | assignee | state |',
+    '| --- | --- | --- | --- | --- |',
+  ];
+  const rank = (r) => {
+    const i = STATUS_ORDER.indexOf(r.statusKey ?? '');
+    return i === -1 ? STATUS_ORDER.length : i;
+  };
+  for (const r of [...rows].sort((a, b) => rank(a) - rank(b) || a.number - b.number)) {
+    const flag = r.statusKey === 'blocked' ? ' 🚩' : '';
+    lines.push(`| #${r.number} | ${r.title}${flag} | ${r.status ?? '—'} | ${r.assignee ?? '—'} | ${r.state.toLowerCase()} |`);
+  }
+  const blocked = rows.filter((r) => r.statusKey === 'blocked').length;
+  const done = rows.filter((r) => r.statusKey === 'done').length;
+  lines.push('', `${rows.length} children · ${done} done${blocked ? ` · **${blocked} blocked — needs a decision**` : ''}`);
+  return lines.join('\n');
+}
+
+export async function runDigest(ctx, args, log = console.log) {
+  if (!Number.isInteger(args.epic)) return { ok: false, error: '--epic <number> is required' };
+
+  const sub = await getSubIssues(ctx.gh, ctx.owner, ctx.repo, args.epic);
+  if (!sub.ok) return sub;
+  const list = await ctx.listItems();
+  if (!list.ok) return list;
+  const byNumber = new Map(list.items.map((i) => [i.content?.number, i]));
+
+  const rows = sub.children.map((c) => {
+    const item = byNumber.get(c.number);
+    return {
+      number: c.number,
+      title: c.title,
+      state: c.state,
+      status: item?.status ?? null,
+      statusKey: item ? ctx.itemFieldKey(item, 'status') : null,
+      assignee: item?.assignees?.[0] ?? null,
+    };
+  });
+
+  const body = await getIssueBody(ctx.gh, args.epic);
+  if (!body.ok) return body;
+  const updated = upsertBlock(body.body ?? '', 'digest', renderChildTable(rows));
+  if (updated === body.body) {
+    log(`digest: #${args.epic} unchanged`);
+    return { ok: true, changed: false, rows: rows.length };
+  }
+  const set = await setIssueBody(ctx.gh, args.epic, updated);
+  if (!set.ok) return set;
+  log(`digest: #${args.epic} refreshed (${rows.length} children)`);
+  return { ok: true, changed: true, rows: rows.length };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const res = await runDigest(ctx, parseArgs(process.argv.slice(2)));
+    if (!res.ok) { console.error(`digest failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/board/log.mjs
+++ b/plugin/scripts/board/log.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/** board log — delivery-log row on the pinned issue, one per PR (plan T6, AC-2.4b). */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+import { upsertMarkedComment } from '../lib/issues.mjs';
+
+export function parseArgs(argv) {
+  const a = { pr: null, sha: null, title: '', issues: '', date: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--pr') a.pr = Number(argv[++i]);
+    else if (argv[i] === '--sha') a.sha = argv[++i];
+    else if (argv[i] === '--title') a.title = argv[++i];
+    else if (argv[i] === '--issues') a.issues = argv[++i];
+    else if (argv[i] === '--date') a.date = argv[++i];
+  }
+  return a;
+}
+
+export async function runLog(ctx, args, log = console.log) {
+  if (ctx.deliveryLogIssue == null) return { ok: false, error: 'board.deliveryLogIssue not configured — run /forge:init' };
+  if (!Number.isInteger(args.pr)) return { ok: false, error: '--pr is required' };
+  const date = args.date ?? new Date().toISOString().slice(0, 10);
+  const refs = args.issues ? args.issues.split(',').map((s) => `#${s.trim().replace(/^#/, '')}`).join(' ') : '—';
+  const content = `| ${date} | #${args.pr} | ${args.sha ? `\`${args.sha.slice(0, 7)}\`` : '—'} | ${refs} | ${args.title || '—'} |`;
+  const res = await upsertMarkedComment(ctx.gh, ctx.owner, ctx.repo, ctx.deliveryLogIssue, `log:pr-${args.pr}`, content);
+  if (!res.ok) return res;
+  log(`delivery-log row for #${args.pr} ${res.action}`);
+  return res;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const res = await runLog(ctx, parseArgs(process.argv.slice(2)));
+    if (!res.ok) { console.error(`log failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/board/move.mjs
+++ b/plugin/scripts/board/move.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/** board move — status transition by config key (plan T3, AC-2.2). */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+
+export function parseArgs(argv) {
+  const a = { issue: null, status: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
+    else if (argv[i] === '--status') a.status = argv[++i];
+  }
+  return a;
+}
+
+export async function runMove(ctx, args, log = console.log) {
+  if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
+  const opt = ctx.resolveOption('status', args.status ?? '');
+  if (!opt.ok) return { ok: false, error: opt.error };
+
+  const found = await ctx.findItemByIssue(args.issue);
+  if (!found.ok) return { ok: false, error: found.error };
+  if (!found.item) return { ok: false, error: `issue #${args.issue} is not on board #${ctx.projectNumber} — run board create first` };
+
+  if (ctx.itemFieldKey(found.item, 'status') === args.status) {
+    log(`#${args.issue}: already ${args.status}`);
+    return { ok: true, changed: false };
+  }
+  const set = await ctx.setSelect(found.item.id, 'status', args.status);
+  if (!set.ok) return set;
+  log(`#${args.issue}: status -> ${args.status}`);
+  return { ok: true, changed: true };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const res = await runMove(ctx, parseArgs(process.argv.slice(2)));
+    if (!res.ok) { console.error(`move failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/board/receipt.mjs
+++ b/plugin/scripts/board/receipt.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/** board receipt — merge receipt per issue, idempotent (plan T5, AC-2.4a). */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+import { upsertMarkedComment } from '../lib/issues.mjs';
+
+export function parseArgs(argv) {
+  const a = { issue: null, pr: null, sha: null, title: '' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
+    else if (argv[i] === '--pr') a.pr = Number(argv[++i]);
+    else if (argv[i] === '--sha') a.sha = argv[++i];
+    else if (argv[i] === '--title') a.title = argv[++i];
+  }
+  return a;
+}
+
+export async function runReceipt(ctx, args, log = console.log) {
+  if (!Number.isInteger(args.issue) || !Number.isInteger(args.pr)) {
+    return { ok: false, error: '--issue and --pr are required' };
+  }
+  const sha = args.sha ? ` → \`${args.sha.slice(0, 7)}\`` : '';
+  const content = `**forge receipt** — merged via #${args.pr}${sha}${args.title ? ` — ${args.title}` : ''}`;
+  const res = await upsertMarkedComment(ctx.gh, ctx.owner, ctx.repo, args.issue, `receipt:pr-${args.pr}`, content);
+  if (!res.ok) return res;
+  log(`#${args.issue} receipt:pr-${args.pr} ${res.action}`);
+  return res;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const res = await runReceipt(ctx, parseArgs(process.argv.slice(2)));
+    if (!res.ok) { console.error(`receipt failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/board/status.mjs
+++ b/plugin/scripts/board/status.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * board status — minimal catch-up card from board + PR data (plan T8, AC-2.6).
+ * Situation derivation + journal events upgrade this at SP3 (spec §7).
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+
+export async function runStatus(ctx, log = console.log) {
+  const list = await ctx.listItems();
+  if (!list.ok) return list;
+  const items = list.items.filter((i) => i.content?.number != null);
+
+  const byKey = new Map();
+  for (const i of items) {
+    const key = ctx.itemFieldKey(i, 'status') ?? 'none';
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key).push(i);
+  }
+  const count = (k) => (byKey.get(k) ?? []).length;
+  const show = (i) => `#${i.content.number} ${i.title ?? i.content?.title ?? ''}`.trim();
+
+  const prs = await ctx.gh(['pr', 'list', '--state', 'open', '--json', 'number,title,isDraft'], { parseJson: true });
+  const openPrs = prs.ok ? prs.json : [];
+
+  const lines = [];
+  lines.push(`forge status — ${ctx.owner}/${ctx.repo} · board #${ctx.projectNumber}`);
+  const blocked = byKey.get('blocked') ?? [];
+  lines.push(blocked.length ? `situation: awaiting-decision (${blocked.length} blocked)` : (count('inProgress') ? 'situation: building' : 'situation: idle'));
+  lines.push(`counts: backlog ${count('backlog')} · ready ${count('ready')} · in-progress ${count('inProgress')} · in-review ${count('inReview')} · blocked ${blocked.length} · done ${count('done')}`);
+  for (const b of blocked) lines.push(`  🚩 blocked: ${show(b)}`);
+  for (const w of byKey.get('inProgress') ?? []) lines.push(`  ▶ in progress: ${show(w)}`);
+  for (const p of openPrs) lines.push(`  ⇡ open PR: #${p.number} ${p.title}${p.isDraft ? ' (draft)' : ''}`);
+  lines.push(`next: ${blocked.length ? 'answer the blocked decision(s)' : openPrs.length ? 'review/merge the open PR(s)' : count('inProgress') ? 'continue the in-progress work' : 'pick the next ready/backlog item'}`);
+
+  const text = lines.join('\n');
+  log(text);
+  return { ok: true, text };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const res = await runStatus(ctx);
+    if (!res.ok) { console.error(`status failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/lib/boardctx.mjs
+++ b/plugin/scripts/lib/boardctx.mjs
@@ -1,0 +1,79 @@
+import { loadConfig, CONFIG_RELPATH } from './config.mjs';
+import { getRepoInfo, optionKey } from './board.mjs';
+
+/**
+ * Board context: forge.json + repo identity + item operations, resolved once
+ * per script run. Every ID comes from config — no hand-built GraphQL ids
+ * (spec §6). All gh calls flow through the injected wrapper.
+ */
+export async function makeBoardCtx({ gh, cwd }) {
+  const cfg = await loadConfig(cwd);
+  if (!cfg.ok) return { ok: false, error: `${CONFIG_RELPATH} invalid or missing: ${cfg.errors[0]}` };
+  const repo = await getRepoInfo(gh);
+  if (!repo.ok) return { ok: false, error: repo.error };
+  const board = cfg.config.board;
+
+  const ctx = {
+    ok: true,
+    gh,
+    cwd,
+    config: cfg.config,
+    owner: repo.owner,
+    repo: repo.name,
+    projectNumber: board.projectNumber,
+    projectId: board.projectId,
+    fields: board.fields,
+    deliveryLogIssue: board.deliveryLogIssue ?? null,
+
+    /** key -> optionId, with an error that teaches the valid keys. */
+    resolveOption(fieldKey, key) {
+      const field = board.fields[fieldKey];
+      if (!field) return { ok: false, error: `unknown field '${fieldKey}' (valid: ${Object.keys(board.fields).join(', ')})` };
+      const id = field.options[key];
+      if (!id) return { ok: false, error: `unknown ${fieldKey} '${key}' — valid ${fieldKey} keys: ${Object.keys(field.options).join(', ')}` };
+      return { ok: true, fieldId: field.id, optionId: id };
+    },
+
+    async listItems() {
+      const res = await gh(
+        ['project', 'item-list', String(board.projectNumber), '--owner', repo.owner, '--format', 'json', '--limit', '500'],
+        { parseJson: true },
+      );
+      if (!res.ok) return { ok: false, error: res.stderr || 'item-list failed' };
+      return { ok: true, items: res.json.items ?? [] };
+    },
+
+    async findItemByIssue(issueNumber) {
+      const list = await this.listItems();
+      if (!list.ok) return list;
+      return { ok: true, item: list.items.find((i) => i.content?.number === issueNumber) ?? null };
+    },
+
+    async addItemByUrl(url) {
+      const res = await gh(
+        ['project', 'item-add', String(board.projectNumber), '--owner', repo.owner, '--url', url, '--format', 'json'],
+        { parseJson: true },
+      );
+      if (!res.ok) return { ok: false, error: res.stderr || 'item-add failed' };
+      return { ok: true, itemId: res.json.id };
+    },
+
+    async setSelect(itemId, fieldKey, key) {
+      const opt = this.resolveOption(fieldKey, key);
+      if (!opt.ok) return opt;
+      const res = await gh([
+        'project', 'item-edit', '--id', itemId, '--project-id', board.projectId,
+        '--field-id', opt.fieldId, '--single-select-option-id', opt.optionId,
+      ]);
+      if (!res.ok) return { ok: false, error: res.stderr || `set ${fieldKey}=${key} failed` };
+      return { ok: true };
+    },
+
+    /** Current option key of an item's field, from item-list's display name. */
+    itemFieldKey(item, fieldKey) {
+      const name = item?.[fieldKey === 'type' ? 'type' : fieldKey];
+      return typeof name === 'string' ? optionKey(name) : null;
+    },
+  };
+  return ctx;
+}

--- a/plugin/scripts/lib/issues.mjs
+++ b/plugin/scripts/lib/issues.mjs
@@ -1,0 +1,87 @@
+import { markedBody, hasMarker } from './markers.mjs';
+
+/** Issue-level operations shared by board scripts. All gh calls injectable. */
+
+const ISSUE_NODE_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) { id parent { number } }
+  }
+}`;
+
+export async function getIssueNode(gh, owner, repo, number) {
+  const res = await gh(
+    ['api', 'graphql', '-f', `query=${ISSUE_NODE_QUERY}`, '-f', `owner=${owner}`, '-f', `repo=${repo}`, '-F', `number=${number}`],
+    { parseJson: true },
+  );
+  if (!res.ok) return { ok: false, error: res.stderr || `issue #${number} not found` };
+  const issue = res.json.data?.repository?.issue;
+  if (!issue) return { ok: false, error: `issue #${number} not found` };
+  return { ok: true, id: issue.id, parentNumber: issue.parent?.number ?? null };
+}
+
+const ADD_SUB_ISSUE = `mutation($parentId: ID!, $childId: ID!) {
+  addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) { issue { number } }
+}`;
+
+export async function addSubIssue(gh, parentNodeId, childNodeId) {
+  const res = await gh(
+    ['api', 'graphql', '-f', `query=${ADD_SUB_ISSUE}`, '-f', `parentId=${parentNodeId}`, '-f', `childId=${childNodeId}`],
+    { parseJson: true },
+  );
+  if (!res.ok) return { ok: false, error: res.stderr || 'addSubIssue failed' };
+  return { ok: true };
+}
+
+const SUB_ISSUES_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      subIssues(first: 100) { nodes { number title state } }
+    }
+  }
+}`;
+
+export async function getSubIssues(gh, owner, repo, number) {
+  const res = await gh(
+    ['api', 'graphql', '-f', `query=${SUB_ISSUES_QUERY}`, '-f', `owner=${owner}`, '-f', `repo=${repo}`, '-F', `number=${number}`],
+    { parseJson: true },
+  );
+  if (!res.ok) return { ok: false, error: res.stderr || 'subIssues query failed' };
+  return { ok: true, children: res.json.data?.repository?.issue?.subIssues?.nodes ?? [] };
+}
+
+export async function listComments(gh, owner, repo, number) {
+  const res = await gh(['api', `repos/${owner}/${repo}/issues/${number}/comments?per_page=100`], { parseJson: true });
+  if (!res.ok) return { ok: false, error: res.stderr || 'comments list failed' };
+  return { ok: true, comments: res.json };
+}
+
+/**
+ * Idempotency core for every trail/receipt/log comment: find the comment
+ * carrying `marker` and PATCH it, or POST a new one. Never stacks.
+ */
+export async function upsertMarkedComment(gh, owner, repo, number, marker, content) {
+  const list = await listComments(gh, owner, repo, number);
+  if (!list.ok) return list;
+  const body = markedBody(marker, content);
+  const existing = list.comments.find((c) => hasMarker(c.body, marker));
+  if (existing) {
+    const res = await gh(['api', '-X', 'PATCH', `repos/${owner}/${repo}/issues/comments/${existing.id}`, '-f', `body=${body}`]);
+    if (!res.ok) return { ok: false, error: res.stderr || 'comment update failed' };
+    return { ok: true, action: 'updated', id: existing.id };
+  }
+  const res = await gh(['api', `repos/${owner}/${repo}/issues/${number}/comments`, '-f', `body=${body}`], { parseJson: true });
+  if (!res.ok) return { ok: false, error: res.stderr || 'comment create failed' };
+  return { ok: true, action: 'created', id: res.json.id };
+}
+
+export async function getIssueBody(gh, number) {
+  const res = await gh(['issue', 'view', String(number), '--json', 'body,title,state'], { parseJson: true });
+  if (!res.ok) return { ok: false, error: res.stderr || `issue #${number} not found` };
+  return { ok: true, ...res.json };
+}
+
+export async function setIssueBody(gh, number, body) {
+  const res = await gh(['issue', 'edit', String(number), '--body', body]);
+  if (!res.ok) return { ok: false, error: res.stderr || 'issue edit failed' };
+  return { ok: true };
+}

--- a/plugin/scripts/lib/markers.mjs
+++ b/plugin/scripts/lib/markers.mjs
@@ -1,0 +1,31 @@
+/**
+ * Managed-block helpers. Forge only ever rewrites content between its own
+ * markers — everything outside survives byte-for-byte (spec §5/§6 law,
+ * same pattern as the GEMINI.md/AGENTS.md managed blocks).
+ */
+export const begin = (marker) => `<!-- forge:${marker}:begin -->`;
+export const end = (marker) => `<!-- forge:${marker}:end -->`;
+
+/** Replace the marked block in `text`, or append one when absent. */
+export function upsertBlock(text, marker, content) {
+  const b = begin(marker);
+  const e = end(marker);
+  const block = `${b}\n${content}\n${e}`;
+  const re = new RegExp(`${escapeRe(b)}[\\s\\S]*?${escapeRe(e)}`);
+  if (re.test(text)) return text.replace(re, block);
+  const base = text.trimEnd();
+  return base.length ? `${base}\n\n${block}\n` : `${block}\n`;
+}
+
+/** Single-marker comments (trail/receipt/log rows): marker + body. */
+export function markedBody(marker, content) {
+  return `<!-- forge:${marker} -->\n${content}`;
+}
+
+export function hasMarker(text, marker) {
+  return typeof text === 'string' && text.includes(`<!-- forge:${marker} -->`);
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/plugin/skills/board/SKILL.md
+++ b/plugin/skills/board/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: board
+description: Ticket operations for the forge board — create/move/comment/receipt/log/digest/status. Use for ANY board or ticket work instead of raw gh GraphQL; also defines the ticket-trail moments every skill must post.
+---
+
+# forge:board
+
+All ticket/board operations go through `plugin/scripts/board/*` — never hand-build GraphQL in a session (spec §6). Every script is idempotent: re-runs resume or update, never duplicate. IDs come from `.claude/forge.json`.
+
+Run any script as: `node "${CLAUDE_PLUGIN_ROOT}/scripts/board/<script>.mjs" <args>`
+
+| Script | Use | Key args |
+| --- | --- | --- |
+| `create.mjs` | new ticket, fully placed | `--title` `--body` `--type item\|bug\|epic\|test` `--priority p0..p2` `--size xs..xl` `--status backlog` `--parent <epic#>` `--assignee <login>` |
+| `move.mjs` | status transition | `--issue N --status backlog\|ready\|inProgress\|inReview\|blocked\|done` (keys from forge.json) |
+| `comment.mjs` | ticket-trail comment | `--issue N --phase <phase> --body "…"` — same phase twice updates in place |
+| `receipt.mjs` | merge receipt | `--issue N --pr N --sha <sha> --title "…"` |
+| `log.mjs` | delivery-log row | `--pr N --sha <sha> --issues "1,2" --title "…"` |
+| `digest.mjs` | refresh epic child table | `--epic N` — rewrites only the managed block in the epic body |
+| `status.mjs` | catch-up card | no args |
+
+## Ticket-trail moments (platform law, spec §6)
+
+Post `comment.mjs` on the driving ticket at every one of these moments — the owner follows work from the issue, not the session:
+
+- `started` — work begins: branch name, board → inProgress (also run `move.mjs`)
+- `spec` / `plan` — doc ready: link it
+- `pr` — PR opened: link + AC status
+- `gate-fail` — a gate or CI failed: which, why, the fix
+- `escalation` — halted on a human decision (also `move.mjs --status blocked`)
+- `ci-green` — all checks pass, ready for merge
+- `merged` — use `receipt.mjs` + `log.mjs` + `move.mjs --status done` + `digest.mjs --epic <parent>` instead
+- `note` — unplanned in-scope work (the silent-side-work rule)
+
+Bodies are caveman-terse: one or two lines, links over prose.

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { makeBoardCtx } from '../plugin/scripts/lib/boardctx.mjs';
+import { runCreate, parseArgs as createArgs } from '../plugin/scripts/board/create.mjs';
+import { runMove, parseArgs as moveArgs } from '../plugin/scripts/board/move.mjs';
+import { runComment, parseArgs as commentArgs } from '../plugin/scripts/board/comment.mjs';
+import { runReceipt } from '../plugin/scripts/board/receipt.mjs';
+import { runLog } from '../plugin/scripts/board/log.mjs';
+import { runDigest, renderChildTable } from '../plugin/scripts/board/digest.mjs';
+import { runStatus } from '../plugin/scripts/board/status.mjs';
+import { fakeGh, REPO_VIEW } from './helpers/fakegh.mjs';
+
+const noop = () => {};
+
+const CFG = {
+  board: {
+    projectNumber: 8,
+    projectId: 'PVT_test',
+    fields: {
+      status: { id: 'PVTSSF_s', options: { backlog: 'sb', ready: 'sr', inProgress: 'sp', inReview: 'sv', blocked: 'sk', done: 'sd' } },
+      priority: { id: 'PVTSSF_p', options: { p0: 'a', p1: 'b', p2: 'c' } },
+      size: { id: 'PVTSSF_z', options: { xs: '1', s: '2', m: '3', l: '4', xl: '5' } },
+      type: { id: 'PVTSSF_t', options: { epic: 'e', item: 'i', bug: 'g', test: 't' } },
+    },
+    deliveryLogIssue: 15,
+  },
+  team: { members: [{ github: 'dngioidev', roles: ['maintainer'] }] },
+};
+
+async function cwdWithConfig() {
+  const dir = await mkdtemp(join(tmpdir(), 'forge-board-'));
+  await mkdir(join(dir, '.claude'), { recursive: true });
+  await writeFile(join(dir, '.claude', 'forge.json'), JSON.stringify(CFG), 'utf8');
+  return dir;
+}
+
+function itemList(items) {
+  return { stdout: JSON.stringify({ items }) };
+}
+
+async function ctxWith(routes) {
+  const f = fakeGh([['repo view', REPO_VIEW], ...routes]);
+  const ctx = await makeBoardCtx({ gh: f.gh, cwd: await cwdWithConfig() });
+  expect(ctx.ok).toBe(true);
+  return { ctx, calls: f.calls };
+}
+
+describe('boardctx', () => {
+  it('AC-2.2: unknown option key errors with the valid keys', async () => {
+    const { ctx } = await ctxWith([]);
+    const r = ctx.resolveOption('status', 'doing');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('backlog');
+    expect(r.error).toContain('done');
+  });
+});
+
+describe('create (AC-2.1)', () => {
+  const createdIssueUrl = 'https://github.com/dngioidev/forge/issues/20\n';
+  const issueNodes = (child, parent) => [
+    [(j) => j.includes('issue(number: $number)') === false && j.includes('addSubIssue'), { stdout: JSON.stringify({ data: { addSubIssue: { issue: { number: 2 } } } }) }],
+    [(j) => j.startsWith('api graphql') && j.includes('parent { number }') && j.includes('number=20'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_child', parent: parent ? { number: parent } : null } } } }) }],
+    [(j) => j.startsWith('api graphql') && j.includes('parent { number }') && j.includes('number=2'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_parent', parent: null } } } }) }],
+  ];
+
+  it('full flow: issue + parent link + board add + all fields', async () => {
+    const { ctx, calls } = await ctxWith([
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: createdIssueUrl }],
+      ...issueNodes('I_child', null),
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'Build widget', '--parent', '2', '--type', 'item', '--priority', 'p1', '--size', 'm']), noop);
+    expect(res.ok).toBe(true);
+    expect(res.number).toBe(20);
+    expect(calls.some((c) => c.includes('addSubIssue'))).toBe(true);
+    expect(calls.filter((c) => c.startsWith('project item-edit')).length).toBe(4);
+  });
+
+  it('re-run duplicates nothing and resumes only missing steps', async () => {
+    // issue exists, already parented, item on board, type+priority already set — only size+status missing
+    const { ctx, calls } = await ctxWith([
+      ['issue list', { stdout: JSON.stringify([{ number: 20, title: 'Build widget', url: 'https://github.com/dngioidev/forge/issues/20' }]) }],
+      [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_child', parent: { number: 2 } } } } }) }],
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_1', content: { number: 20 }, type: 'Item', priority: 'P1', size: null, status: null }])],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'Build widget', '--parent', '2']), noop);
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.startsWith('issue create'))).toBe(false);
+    expect(calls.some((c) => c.includes('addSubIssue'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('project item-add'))).toBe(false);
+    expect(calls.filter((c) => c.startsWith('project item-edit')).length).toBe(2); // size + status only
+  });
+
+  it('validates option keys before creating anything', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--priority', 'urgent']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('valid priority keys');
+    expect(calls.some((c) => c.startsWith('issue'))).toBe(false);
+  });
+});
+
+describe('move (AC-2.2)', () => {
+  it('moves and is a no-op when already there', async () => {
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_2', content: { number: 5 }, status: 'In progress' }])],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const moved = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'done']), noop);
+    expect(moved).toMatchObject({ ok: true, changed: true });
+    const same = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'inProgress']), noop);
+    expect(same).toMatchObject({ ok: true, changed: false });
+    expect(calls.filter((c) => c.startsWith('project item-edit')).length).toBe(1);
+  });
+
+  it('unknown status errors listing valid keys; off-board issue says run create', async () => {
+    const { ctx } = await ctxWith([[(j) => j.startsWith('project item-list'), itemList([])]]);
+    const bad = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'doing']), noop);
+    expect(bad.error).toContain('valid status keys');
+    const missing = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'done']), noop);
+    expect(missing.error).toContain('board create');
+  });
+});
+
+describe('comment (AC-2.3)', () => {
+  it('creates then updates in place for the same phase', async () => {
+    let comments = [];
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('api repos/') && j.includes('/comments?'), () => ({ stdout: JSON.stringify(comments) })],
+      [(j) => j.startsWith('api -X PATCH'), { stdout: '{}' }],
+      [(j) => j.startsWith('api repos/') && j.endsWith('/comments') === false && j.includes('-f'), (j) => {
+        comments = [{ id: 77, body: '<!-- forge:trail:pr -->\nold' }];
+        return { stdout: JSON.stringify({ id: 77 }) };
+      }],
+    ]);
+    const first = await runComment(ctx, commentArgs(['--issue', '2', '--phase', 'pr', '--body', 'PR #9 opened']), noop);
+    expect(first).toMatchObject({ ok: true, action: 'created' });
+    const second = await runComment(ctx, commentArgs(['--issue', '2', '--phase', 'pr', '--body', 'PR #9 updated']), noop);
+    expect(second).toMatchObject({ ok: true, action: 'updated', id: 77 });
+    expect(calls.filter((c) => c.startsWith('api -X PATCH')).length).toBe(1);
+  });
+
+  it('rejects unknown phases', async () => {
+    const { ctx } = await ctxWith([]);
+    const res = await runComment(ctx, commentArgs(['--issue', '2', '--phase', 'vibes', '--body', 'x']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('valid:');
+  });
+});
+
+describe('receipt + log (AC-2.4)', () => {
+  it('receipt is idempotent by pr marker', async () => {
+    const existing = [{ id: 9, body: '<!-- forge:receipt:pr-16 -->\nold receipt' }];
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.includes('/comments?'), { stdout: JSON.stringify(existing) }],
+      [(j) => j.startsWith('api -X PATCH'), { stdout: '{}' }],
+    ]);
+    const res = await runReceipt(ctx, { issue: 1, pr: 16, sha: '34820ce9c18', title: 'SP1' }, noop);
+    expect(res).toMatchObject({ ok: true, action: 'updated' });
+    expect(calls.some((c) => c.startsWith('api -X PATCH'))).toBe(true);
+  });
+
+  it('log writes the row to the configured delivery-log issue', async () => {
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.includes('/comments?'), { stdout: '[]' }],
+      [(j) => j.includes('/issues/15/comments'), { stdout: JSON.stringify({ id: 1 }) }],
+    ]);
+    const res = await runLog(ctx, { pr: 16, sha: 'abc1234def', title: 'SP1', issues: '1', date: '2026-07-16' }, noop);
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.includes('/issues/15/comments'))).toBe(true);
+  });
+
+  it('log fails clearly when deliveryLogIssue unconfigured', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-board-'));
+    await mkdir(join(dir, '.claude'), { recursive: true });
+    const cfg = structuredClone(CFG);
+    delete cfg.board.deliveryLogIssue;
+    await writeFile(join(dir, '.claude', 'forge.json'), JSON.stringify(cfg), 'utf8');
+    const f = fakeGh([['repo view', REPO_VIEW]]);
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd: dir });
+    const res = await runLog(ctx, { pr: 16 }, noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('/forge:init');
+  });
+});
+
+describe('digest (AC-2.5)', () => {
+  it('renders blocked-first and rewrites only the managed block', async () => {
+    let savedBody = null;
+    const { ctx } = await ctxWith([
+      [(j) => j.includes('subIssues'), { stdout: JSON.stringify({ data: { repository: { issue: { subIssues: { nodes: [
+        { number: 21, title: 'Child A', state: 'OPEN' },
+        { number: 22, title: 'Child B', state: 'OPEN' },
+        { number: 23, title: 'Child C', state: 'CLOSED' },
+      ] } } } } }) }],
+      [(j) => j.startsWith('project item-list'), itemList([
+        { id: 'i21', content: { number: 21 }, status: 'Backlog', assignees: ['dngioidev'] },
+        { id: 'i22', content: { number: 22 }, status: 'Blocked / Needs decision', assignees: [] },
+        { id: 'i23', content: { number: 23 }, status: 'Done', assignees: [] },
+      ])],
+      ['issue view 2', { stdout: JSON.stringify({ body: 'Epic intro stays.', title: 'Epic', state: 'OPEN' }) }],
+      [(j, args) => j.startsWith('issue edit'), (j, args) => { savedBody = args[args.indexOf('--body') + 1]; return { stdout: '' }; }],
+    ]);
+    const res = await runDigest(ctx, { epic: 2 }, noop);
+    expect(res).toMatchObject({ ok: true, changed: true, rows: 3 });
+    expect(savedBody).toContain('Epic intro stays.');
+    const blockedIdx = savedBody.indexOf('#22');
+    expect(blockedIdx).toBeGreaterThan(-1);
+    expect(blockedIdx).toBeLessThan(savedBody.indexOf('#21'));
+    expect(savedBody).toContain('1 blocked — needs a decision');
+    expect(savedBody).toContain('forge:digest:begin');
+  });
+
+  it('renderChildTable is stable for empty epics', () => {
+    const out = renderChildTable([]);
+    expect(out).toContain('0 children');
+  });
+});
+
+describe('status (AC-2.6)', () => {
+  it('prints counts, blocked first as the situation, and next action', async () => {
+    const { ctx } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([
+        { id: 'a', content: { number: 1 }, title: 'One', status: 'Done' },
+        { id: 'b', content: { number: 2 }, title: 'Two', status: 'In progress' },
+        { id: 'c', content: { number: 3 }, title: 'Three', status: 'Blocked / Needs decision' },
+      ])],
+      ['pr list', { stdout: JSON.stringify([{ number: 17, title: 'feat: x', isDraft: false }]) }],
+    ]);
+    const res = await runStatus(ctx, noop);
+    expect(res.ok).toBe(true);
+    expect(res.text).toContain('situation: awaiting-decision (1 blocked)');
+    expect(res.text).toContain('🚩 blocked: #3 Three');
+    expect(res.text).toContain('▶ in progress: #2 Two');
+    expect(res.text).toContain('⇡ open PR: #17');
+    expect(res.text).toContain('next: answer the blocked decision(s)');
+  });
+});

--- a/tests/lib/markers.test.mjs
+++ b/tests/lib/markers.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { upsertBlock, markedBody, hasMarker, begin, end } from '../../plugin/scripts/lib/markers.mjs';
+
+describe('markers', () => {
+  it('appends a block to text without one, preserving existing content', () => {
+    const out = upsertBlock('Epic body here.', 'digest', '| table |');
+    expect(out).toContain('Epic body here.');
+    expect(out).toContain(`${begin('digest')}\n| table |\n${end('digest')}`);
+  });
+
+  it('AC-2.5: replaces only inside the markers on re-run', () => {
+    const v1 = upsertBlock('Intro text.\n\nOutro text.', 'digest', 'OLD');
+    const v2 = upsertBlock(v1, 'digest', 'NEW');
+    expect(v2).toContain('Intro text.');
+    expect(v2).toContain('NEW');
+    expect(v2).not.toContain('OLD');
+    expect(v2.match(new RegExp('forge:digest:begin', 'g')).length).toBe(1);
+  });
+
+  it('handles empty starting text', () => {
+    const out = upsertBlock('', 'digest', 'X');
+    expect(out.startsWith(begin('digest'))).toBe(true);
+  });
+
+  it('markedBody/hasMarker round-trip', () => {
+    const b = markedBody('trail:pr', 'hello');
+    expect(hasMarker(b, 'trail:pr')).toBe(true);
+    expect(hasMarker(b, 'trail:plan')).toBe(false);
+    expect(hasMarker(null, 'trail:pr')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2 (SP2, plan: docs/plans/2026-07-16-sp2-board-automation.md)

## AC checklist
- [x] **AC-2.1** create: issue + sub-issue parent + board add + fields + assignee, one command; re-run resumes only missing steps — test-verified (full, resume, validate-first)
- [x] **AC-2.2** move: status by config key; unknown key errors listing valid keys — test-verified
- [x] **AC-2.3** comment: trail comment idempotent per phase — test-verified AND dogfooded live on #2 (created → updated in place)
- [x] **AC-2.4** receipt + log: idempotent by PR marker; log targets board.deliveryLogIssue (#15) — test-verified
- [x] **AC-2.5** digest: managed block, blocked-first child table, body outside markers untouched — test-verified
- [x] **AC-2.6** status: catch-up card dogfooded live against board #8 — situation/counts/next all correct
- [ ] **AC-2.7** CI green win+linux — this PR's checks

## Honest verification
64/64 tests locally (Windows). Live dogfood: `status.mjs` card and `comment.mjs` create→update on issue #2 ran against the real board. `receipt`/`log`/`digest`/`move --status done` get their live run as this very PR's ship ritual after merge — the platform ships itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x