### PR TITLE
feat: SP4b deploy layer — scaffold, env-branch workflows, readiness gate (#5)

### DIFF
--- a/plugin/commands/deploy-init.md
+++ b/plugin/commands/deploy-init.md
@@ -1,0 +1,11 @@
+---
+description: Install the deploy scaffold — digest-pinned Dockerfile, compose, terraform skeleton, environment-branch workflows, smoke script — and wire forge.json
+---
+
+Install the deploy layer into this repo (spec §10). Ask the user for the app name (default: repo name) and healthcheck path (default: `/healthz`) if not obvious, then run:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/deploy/init.mjs" --stack node --app "<name>" --healthcheck "/healthz"
+```
+
+The script never overwrites existing files — it places only what's missing and reports both lists. After it finishes, relay the three human steps it prints (environment branches + protection, cloud deploy insert points, repo variables) — those are owner actions the platform must not do itself.

--- a/plugin/scripts/deploy/init.mjs
+++ b/plugin/scripts/deploy/init.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * /forge:deploy-init (spec §10): copy the deploy scaffold into a consumer
+ * repo — missing files only, never overwrite — substitute placeholders, and
+ * wire the deploy block into forge.json.
+ */
+import { readdir, readFile, writeFile, mkdir, stat, copyFile } from 'node:fs/promises';
+import { join, dirname, resolve, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { loadConfig, CONFIG_RELPATH } from '../lib/config.mjs';
+import { mergeJson } from '../lib/jsonfile.mjs';
+import { getRepoInfo } from '../lib/board.mjs';
+
+const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export function parseArgs(argv) {
+  const a = { stack: 'node', app: null, healthcheck: '/healthz' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--stack') a.stack = argv[++i];
+    else if (argv[i] === '--app') a.app = argv[++i];
+    else if (argv[i] === '--healthcheck') a.healthcheck = argv[++i];
+  }
+  return a;
+}
+
+/** Scaffold file → destination in the consumer repo. */
+function destFor(rel) {
+  if (rel.startsWith('workflows/')) return join('.github', rel);
+  return rel;
+}
+
+async function* walk(dir, base = dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(p, base);
+    else yield relative(base, p).replaceAll('\\', '/');
+  }
+}
+
+export async function runDeployInit(ctx, args, log = console.log) {
+  const { cwd, gh } = ctx;
+  const cfg = await loadConfig(cwd);
+  if (!cfg.ok) return { ok: false, error: `${CONFIG_RELPATH} invalid or missing — run /forge:init first` };
+
+  const stackDir = join(PLUGIN_ROOT, 'templates', 'deploy', args.stack);
+  try {
+    await stat(stackDir);
+  } catch {
+    return { ok: false, error: `unknown stack '${args.stack}' — available: node` };
+  }
+
+  const repo = await getRepoInfo(gh);
+  if (!repo.ok) return { ok: false, error: repo.error };
+  const app = args.app ?? repo.name;
+  const registry = `ghcr.io/${repo.owner.toLowerCase()}`;
+  const verify = cfg.config.conventions?.verify ?? 'pnpm verify';
+  const substitute = (text) => text
+    .replaceAll('{{APP}}', app)
+    .replaceAll('{{HEALTHCHECK}}', args.healthcheck)
+    .replaceAll('{{REGISTRY}}', registry)
+    .replaceAll('{{VERIFY}}', verify);
+
+  const placed = [];
+  const skipped = [];
+  for await (const rel of walk(stackDir)) {
+    const dest = join(cwd, destFor(rel));
+    try {
+      await stat(dest);
+      skipped.push(destFor(rel));
+      continue; // never overwrite (AC-4b.1)
+    } catch { /* missing — place it */ }
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, substitute(await readFile(join(stackDir, rel), 'utf8')), 'utf8');
+    placed.push(destFor(rel));
+  }
+
+  // smoke script: consumer-local copy so workflows can run it without the plugin
+  const smokeDest = join(cwd, 'scripts', 'forge-smoke.mjs');
+  try {
+    await stat(smokeDest);
+  } catch {
+    await mkdir(dirname(smokeDest), { recursive: true });
+    await copyFile(join(PLUGIN_ROOT, 'scripts', 'deploy', 'smoke.mjs'), smokeDest);
+    placed.push('scripts/forge-smoke.mjs');
+  }
+
+  // forge.json: deploy block + feature flag (merge — user edits survive)
+  await mergeJson(join(cwd, CONFIG_RELPATH), {
+    features: { deploy: true },
+    deploy: cfg.config.deploy ?? {
+      docker: { file: 'Dockerfile', compose: 'docker-compose.yml', healthcheck: args.healthcheck },
+      terraform: { dir: 'infra/', stateBackend: 'gcs' },
+      environments: [
+        { name: 'staging', branch: 'staging', deploy: 'on-push' },
+        { name: 'production', branch: 'production', deploy: 'promote' },
+      ],
+    },
+  });
+
+  // .gitignore: terraform local dirs
+  const giPath = join(cwd, '.gitignore');
+  let gi = '';
+  try { gi = await readFile(giPath, 'utf8'); } catch { /* none */ }
+  const giAdds = ['.terraform/', '*.tfstate', '*.tfstate.*'].filter((r) => !gi.split(/\r?\n/).some((l) => l.trim() === r));
+  if (giAdds.length) await writeFile(giPath, gi.trimEnd() + (gi.trim() ? '\n' : '') + giAdds.join('\n') + '\n', 'utf8');
+
+  for (const p of placed) log(`placed: ${p}`);
+  for (const s of skipped) log(`kept existing: ${s}`);
+  log('');
+  log('next (human steps, spec §10):');
+  log('  1. create + protect the environment branches:  git branch staging && git push -u origin staging  (repeat for production; protect both — merging into them IS the deploy authorization)');
+  log('  2. wire your cloud deploy at the INSERT points in .github/workflows/deploy-*.yml');
+  log('  3. set repo variables STAGING_URL / PRODUCTION_URL; fill infra/ REPLACE-ME values');
+  return { ok: true, placed, skipped };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  runDeployInit({ gh, cwd: process.cwd() }, parseArgs(process.argv.slice(2))).then((res) => {
+    if (!res.ok) { console.error(`deploy-init failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/deploy/smoke.mjs
+++ b/plugin/scripts/deploy/smoke.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Smoke test (spec §10): poll a healthcheck URL until healthy or out of
+ * retries. Used by the deploy workflows post-deploy and runnable locally.
+ * Exit codes: 0 healthy · 1 unhealthy after retries · 2 bad arguments.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export function parseArgs(argv) {
+  const a = { url: null, retries: 10, timeout: 60_000 };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--url') a.url = argv[++i];
+    else if (argv[i] === '--retries') a.retries = Number(argv[++i]);
+    else if (argv[i] === '--timeout') a.timeout = Number(argv[++i]);
+  }
+  return a;
+}
+
+export async function smoke({ url, retries, timeout, fetchFn = fetch, log = console.log, sleepMs = null }) {
+  if (!url || !/^https?:\/\//.test(url)) return { code: 2, error: `--url must be an http(s) URL, got '${url}'` };
+  if (!Number.isFinite(retries) || retries < 1) return { code: 2, error: '--retries must be >= 1' };
+  const deadline = Date.now() + timeout;
+  const perTryDelay = Math.max(500, Math.floor(timeout / retries / 2));
+  for (let i = 1; i <= retries; i++) {
+    try {
+      const res = await fetchFn(url, { signal: AbortSignal.timeout(5000) });
+      if (res.ok) {
+        log(`smoke: healthy (${res.status}) after ${i} attempt(s)`);
+        return { code: 0, attempts: i };
+      }
+      log(`smoke: attempt ${i}/${retries} — HTTP ${res.status}`);
+    } catch (err) {
+      log(`smoke: attempt ${i}/${retries} — ${err.message}`);
+    }
+    if (Date.now() > deadline) break;
+    if (i < retries) await new Promise((r) => setTimeout(r, sleepMs ?? perTryDelay));
+  }
+  return { code: 1, error: `unhealthy after ${retries} attempts / ${timeout}ms` };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  smoke(parseArgs(process.argv.slice(2))).then((res) => {
+    if (res.code !== 0) console.error(`smoke failed: ${res.error}`);
+    process.exit(res.code);
+  });
+}

--- a/plugin/scripts/doctor.mjs
+++ b/plugin/scripts/doctor.mjs
@@ -4,7 +4,7 @@
  * One distinct check per failure class; ✗ = exit 1, ⚠ = advisory.
  */
 import { join, resolve } from 'node:path';
-import { readFile, readdir } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import { run, makeGh } from './lib/exec.mjs';
 import { loadConfig, CONFIG_RELPATH } from './lib/config.mjs';
@@ -94,6 +94,26 @@ export async function runDoctor(ctx) {
   } catch { /* no workflows dir */ }
   if (hasVerifyWf) results.push(ok('ci-verify', 'verify workflow present'));
   else results.push(warn('ci-verify', 'no verify workflow in .github/workflows', 'run /forge:init (installs the CI template, spec §6)'));
+
+  // deploy layer files (warn-level, only when features.deploy is on)
+  if (cfg.ok && cfg.config.features?.deploy === true) {
+    const d = cfg.config.deploy ?? {};
+    const expected = [
+      d.docker?.file ?? 'Dockerfile',
+      d.docker?.compose ?? 'docker-compose.yml',
+      d.terraform?.dir ?? 'infra/',
+      '.github/workflows/deploy-staging.yml',
+      '.github/workflows/deploy-production.yml',
+      '.github/workflows/deploy-readiness.yml',
+      'scripts/forge-smoke.mjs',
+    ];
+    const missing = [];
+    for (const rel of expected) {
+      try { await stat(join(cwd, rel)); } catch { missing.push(rel); }
+    }
+    if (missing.length === 0) results.push(ok('deploy', 'deploy layer files present'));
+    else results.push(warn('deploy', `features.deploy is on but missing: ${missing.join(', ')}`, 'run /forge:deploy-init'));
+  }
 
   // statusline wired (info-level) — local settings first (that's where init writes it)
   const settingsLocal = await readJson(join(cwd, '.claude', 'settings.local.json')).catch(() => null);

--- a/plugin/templates/deploy/node/.dockerignore
+++ b/plugin/templates/deploy/node/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.git
+.forge
+.github
+docs
+tests
+*.md
+.env*
+*.pem
+*.key
+*.tfstate*
+.terraform
+infra

--- a/plugin/templates/deploy/node/Dockerfile
+++ b/plugin/templates/deploy/node/Dockerfile
@@ -1,0 +1,23 @@
+# forge deploy scaffold — node stack (spec §10)
+# Build-once law: this image is built by the staging workflow, tagged with the
+# commit SHA; production re-deploys the same digest, never rebuilds.
+FROM node:22-alpine@sha256:b74031e546d7f4faf561d797ac1b76beccac856a042815ca77db4fd047581605 AS build
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm build
+
+FROM node:22-alpine@sha256:b74031e546d7f4faf561d797ac1b76beccac856a042815ca77db4fd047581605
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup -S app && adduser -S app -G app
+COPY --from=build --chown=app:app /app/dist ./dist
+COPY --from=build --chown=app:app /app/package.json ./
+COPY --from=build --chown=app:app /app/node_modules ./node_modules
+USER app
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080{{HEALTHCHECK}} || exit 1
+CMD ["node", "dist/server.js"]

--- a/plugin/templates/deploy/node/docker-compose.yml
+++ b/plugin/templates/deploy/node/docker-compose.yml
@@ -1,0 +1,14 @@
+# Local run — environment zero (spec §10). `docker compose up` and you have
+# the app exactly as production runs it, minus cloud wiring.
+services:
+  {{APP}}:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      NODE_ENV: production
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080{{HEALTHCHECK}}"]
+      interval: 30s
+      timeout: 3s
+      retries: 3

--- a/plugin/templates/deploy/node/infra/envs/production/main.tf
+++ b/plugin/templates/deploy/node/infra/envs/production/main.tf
@@ -1,0 +1,16 @@
+# forge deploy scaffold — production environment.
+terraform {
+  required_version = ">= 1.7"
+
+  backend "gcs" {
+    bucket = "REPLACE-ME-tfstate-bucket"
+    prefix = "{{APP}}/production"
+  }
+}
+
+module "observability" {
+  source          = "../../modules/observability"
+  app             = "{{APP}}"
+  environment     = "production"
+  healthcheck_url = "REPLACE-ME-production-url{{HEALTHCHECK}}"
+}

--- a/plugin/templates/deploy/node/infra/envs/staging/main.tf
+++ b/plugin/templates/deploy/node/infra/envs/staging/main.tf
@@ -1,0 +1,18 @@
+# forge deploy scaffold — staging environment (prod-shaped, smaller sizing).
+# State is remote with locking and secret-bearing: never committed, never
+# sent to CLI backends (spec §10/§13).
+terraform {
+  required_version = ">= 1.7"
+
+  backend "gcs" {
+    bucket = "REPLACE-ME-tfstate-bucket"
+    prefix = "{{APP}}/staging"
+  }
+}
+
+module "observability" {
+  source          = "../../modules/observability"
+  app             = "{{APP}}"
+  environment     = "staging"
+  healthcheck_url = "REPLACE-ME-staging-url{{HEALTHCHECK}}"
+}

--- a/plugin/templates/deploy/node/infra/modules/observability/main.tf
+++ b/plugin/templates/deploy/node/infra/modules/observability/main.tf
@@ -1,0 +1,20 @@
+# forge observability minimum (spec §10): uptime check + error alert +
+# cloud budget alert per environment — an incident pages the deploy approver
+# instead of waiting for a user report. GCP reference implementation; swap the
+# resources for your provider, keep the three signals.
+variable "app" { type = string }
+variable "environment" { type = string }
+variable "healthcheck_url" { type = string }
+
+# 1. Uptime check against the environment's healthcheck
+# resource "google_monitoring_uptime_check_config" "health" { … }
+
+# 2. Log-based error alert
+# resource "google_monitoring_alert_policy" "errors" { … }
+
+# 3. Budget alert — a cost anomaly is an incident signal (spec §10)
+# resource "google_billing_budget" "budget" { … }
+
+# Stubs are intentional: wiring needs project/notification-channel ids that
+# are per-consumer one-time setup. terraform validate passes on the module
+# shape; fill the resources when the repo first deploys.

--- a/plugin/templates/deploy/node/workflows/deploy-production.yml
+++ b/plugin/templates/deploy/node/workflows/deploy-production.yml
@@ -1,0 +1,45 @@
+# forge deploy scaffold — production promotes, it does not rebuild (spec §10).
+# The human merge into this branch IS the deploy authorization
+# (team.policy.approvals.deploy). The image deployed is the digest the staging
+# workflow built for this exact commit; it builds only when no prior image
+# exists (single-environment chains).
+name: deploy-production
+
+on:
+  push:
+    branches: [production]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  promote-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Resolve the staging-built image for this commit (build-once law)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          if docker pull {{REGISTRY}}/{{APP}}:sha-${{ github.sha }}; then
+            echo "IMAGE={{REGISTRY}}/{{APP}}:sha-${{ github.sha }}" >> "$GITHUB_ENV"
+          else
+            echo "::notice::no staging build for ${{ github.sha }} — single-env chain, building now"
+            docker build -t {{REGISTRY}}/{{APP}}:sha-${{ github.sha }} .
+            docker push {{REGISTRY}}/{{APP}}:sha-${{ github.sha }}
+            echo "IMAGE={{REGISTRY}}/{{APP}}:sha-${{ github.sha }}" >> "$GITHUB_ENV"
+          fi
+      # ── per-cloud deploy insert point ─────────────────────────────────────
+      # Replace with your provider's deploy of "$IMAGE" (see staging workflow
+      # for the Cloud Run reference example).
+      - name: Deploy to production (INSERT your cloud deploy here)
+        run: |
+          echo "::warning::deploy step not wired yet — see the insert point comment in this workflow"
+      - name: Smoke test
+        run: node scripts/forge-smoke.mjs --url "${PRODUCTION_URL}{{HEALTHCHECK}}" --retries 10 --timeout 60000
+        env:
+          PRODUCTION_URL: ${{ vars.PRODUCTION_URL }}

--- a/plugin/templates/deploy/node/workflows/deploy-readiness.yml
+++ b/plugin/templates/deploy/node/workflows/deploy-readiness.yml
@@ -1,0 +1,47 @@
+# forge deploy scaffold — the deploy-readiness gate (spec §10): a branch that
+# breaks the image or the terraform plan doesn't ship. Path-filtered for cost.
+name: deploy-readiness
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'src/**'
+      - 'infra/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: readiness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Build image and boot against the healthcheck
+        run: |
+          docker build -t readiness-check .
+          docker run -d --name app -p 8080:8080 readiness-check
+          node scripts/forge-smoke.mjs --url "http://127.0.0.1:8080{{HEALTHCHECK}}" --retries 15 --timeout 90000
+          docker logs app
+
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      - name: fmt + validate + plan (dry-run — apply is human-gated, spec §10)
+        run: |
+          terraform fmt -check -recursive
+          for env in envs/*/; do
+            (cd "$env" && terraform init -backend=false -input=false && terraform validate)
+          done

--- a/plugin/templates/deploy/node/workflows/deploy-staging.yml
+++ b/plugin/templates/deploy/node/workflows/deploy-staging.yml
@@ -1,0 +1,41 @@
+# forge deploy scaffold — staging deploys ON DEMAND via this branch (spec §10).
+# main never deploys. Merge main → staging when a live check is needed; that
+# push (and only that) builds the image and deploys.
+name: deploy-staging
+
+on:
+  push:
+    branches: [staging]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  build-deploy-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Build image (SHA-tagged — the digest production will promote)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker build -t {{REGISTRY}}/{{APP}}:sha-${{ github.sha }} .
+          docker push {{REGISTRY}}/{{APP}}:sha-${{ github.sha }}
+          docker inspect --format='{{index .RepoDigests 0}}' {{REGISTRY}}/{{APP}}:sha-${{ github.sha }}
+      # ── per-cloud deploy insert point ─────────────────────────────────────
+      # Replace this step with your provider's deploy. Cloud Run reference:
+      #   - uses: google-github-actions/auth@<sha>            # workload identity
+      #   - run: gcloud run deploy {{APP}}-staging \
+      #       --image {{REGISTRY}}/{{APP}}:sha-${{ github.sha }} \
+      #       --region <region> --project <project>
+      - name: Deploy to staging (INSERT your cloud deploy here)
+        run: |
+          echo "::warning::deploy step not wired yet — see the insert point comment in this workflow"
+      - name: Smoke test
+        run: node scripts/forge-smoke.mjs --url "${STAGING_URL}{{HEALTHCHECK}}" --retries 10 --timeout 60000
+        env:
+          STAGING_URL: ${{ vars.STAGING_URL }}

--- a/tests/deploy.test.mjs
+++ b/tests/deploy.test.mjs
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runDeployInit, parseArgs } from '../plugin/scripts/deploy/init.mjs';
+import { smoke } from '../plugin/scripts/deploy/smoke.mjs';
+import { readJson } from '../plugin/scripts/lib/jsonfile.mjs';
+import { runDoctor } from '../plugin/scripts/doctor.mjs';
+import { fakeGh, REPO_VIEW, AUTH_OK } from './helpers/fakegh.mjs';
+
+const noop = () => {};
+
+const BASE_CFG = {
+  board: { projectNumber: 8, projectId: 'PVT_x', fields: {
+    status: { id: 'PVTSSF_1', options: { backlog: 'a' } },
+    priority: { id: 'PVTSSF_2', options: { p0: 'b' } },
+    size: { id: 'PVTSSF_3', options: { s: 'c' } },
+    type: { id: 'PVTSSF_4', options: { epic: 'd' } },
+  } },
+  conventions: { verify: 'pnpm verify' },
+};
+
+async function cwdWithConfig() {
+  const dir = await mkdtemp(join(tmpdir(), 'forge-deploy-'));
+  await mkdir(join(dir, '.claude'), { recursive: true });
+  await writeFile(join(dir, '.claude', 'forge.json'), JSON.stringify(BASE_CFG), 'utf8');
+  return dir;
+}
+
+describe('deploy-init (AC-4b.1, AC-4b.2)', () => {
+  it('places the full scaffold with substitutions and wires forge.json', async () => {
+    const cwd = await cwdWithConfig();
+    const { gh } = fakeGh([['repo view', REPO_VIEW]]);
+    const res = await runDeployInit({ gh, cwd }, parseArgs(['--app', 'myapp', '--healthcheck', '/health']), noop);
+    expect(res.ok).toBe(true);
+
+    const dockerfile = await readFile(join(cwd, 'Dockerfile'), 'utf8');
+    expect(dockerfile).toContain('node:22-alpine@sha256:');
+    expect(dockerfile).toContain('USER app');
+    expect(dockerfile).toContain('/health ');
+
+    const staging = await readFile(join(cwd, '.github', 'workflows', 'deploy-staging.yml'), 'utf8');
+    expect(staging).toContain('branches: [staging]');
+    expect(staging).toContain('ghcr.io/dngioidev/myapp:sha-');
+    for (const token of ['{{APP}}', '{{HEALTHCHECK}}', '{{REGISTRY}}', '{{VERIFY}}']) {
+      expect(staging).not.toContain(token);
+    }
+
+    const production = await readFile(join(cwd, '.github', 'workflows', 'deploy-production.yml'), 'utf8');
+    expect(production).toContain('branches: [production]');
+    expect(production).toContain('docker pull'); // promote path — build only as fallback
+
+    await stat(join(cwd, 'scripts', 'forge-smoke.mjs'));
+    await stat(join(cwd, 'infra', 'envs', 'staging', 'main.tf'));
+    await stat(join(cwd, 'infra', 'modules', 'observability', 'main.tf'));
+
+    const cfg = await readJson(join(cwd, '.claude', 'forge.json'));
+    expect(cfg.features.deploy).toBe(true);
+    expect(cfg.deploy.environments[0]).toMatchObject({ name: 'staging', deploy: 'on-push' });
+    expect(cfg.deploy.environments[1]).toMatchObject({ name: 'production', deploy: 'promote' });
+    expect(cfg.conventions.verify).toBe('pnpm verify'); // untouched
+
+    const gi = await readFile(join(cwd, '.gitignore'), 'utf8');
+    expect(gi).toContain('.terraform/');
+    expect(gi).toContain('*.tfstate');
+  });
+
+  it('never overwrites existing files (re-run = all kept, none placed)', async () => {
+    const cwd = await cwdWithConfig();
+    const { gh } = fakeGh([['repo view', REPO_VIEW]]);
+    await runDeployInit({ gh, cwd }, parseArgs([]), noop);
+    // user customizes their Dockerfile
+    await writeFile(join(cwd, 'Dockerfile'), '# customized\n', 'utf8');
+    const second = await runDeployInit({ gh, cwd }, parseArgs([]), noop);
+    expect(second.ok).toBe(true);
+    expect(second.placed).toEqual([]);
+    expect((await readFile(join(cwd, 'Dockerfile'), 'utf8'))).toBe('# customized\n');
+  });
+
+  it('unknown stack errors with the available list', async () => {
+    const cwd = await cwdWithConfig();
+    const { gh } = fakeGh([['repo view', REPO_VIEW]]);
+    const res = await runDeployInit({ gh, cwd }, parseArgs(['--stack', 'rust']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('node');
+  });
+});
+
+describe('smoke (AC-4b.4)', () => {
+  it('healthy on first 200', async () => {
+    const res = await smoke({ url: 'http://x/healthz', retries: 3, timeout: 5000, sleepMs: 1, log: noop, fetchFn: async () => ({ ok: true, status: 200 }) });
+    expect(res).toMatchObject({ code: 0, attempts: 1 });
+  });
+
+  it('retries through failures then succeeds', async () => {
+    let n = 0;
+    const res = await smoke({ url: 'http://x/healthz', retries: 5, timeout: 5000, sleepMs: 1, log: noop, fetchFn: async () => (++n < 3 ? { ok: false, status: 503 } : { ok: true, status: 200 }) });
+    expect(res).toMatchObject({ code: 0, attempts: 3 });
+  });
+
+  it('exit 1 when never healthy; exit 2 on bad args', async () => {
+    const res = await smoke({ url: 'http://x/healthz', retries: 2, timeout: 1000, sleepMs: 1, log: noop, fetchFn: async () => { throw new Error('ECONNREFUSED'); } });
+    expect(res.code).toBe(1);
+    expect((await smoke({ url: 'not-a-url', retries: 2, timeout: 1000, log: noop })).code).toBe(2);
+  });
+});
+
+describe('doctor deploy checks (AC-4b.5)', () => {
+  it('warns with the missing list when features.deploy is on but files absent', async () => {
+    const cwd = await cwdWithConfig();
+    const cfg = { ...BASE_CFG, features: { deploy: true } };
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(cfg), 'utf8');
+    await writeFile(join(cwd, '.gitignore'), '.forge/\n', 'utf8');
+    const { gh } = fakeGh([['auth status', AUTH_OK], ['repo view', REPO_VIEW], [() => true, { ok: false, stderr: 'x' }]]);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    const dep = res.results.find((r) => r.name === 'deploy');
+    expect(dep.level).toBe('warn');
+    expect(dep.msg).toContain('Dockerfile');
+    expect(dep.hint).toContain('deploy-init');
+  });
+
+  it('ok after deploy-init has run', async () => {
+    const cwd = await cwdWithConfig();
+    const { gh } = fakeGh([['repo view', REPO_VIEW]]);
+    await runDeployInit({ gh, cwd }, parseArgs([]), noop);
+    await writeFile(join(cwd, '.gitignore'), (await readFile(join(cwd, '.gitignore'), 'utf8')) + '.forge/\n', 'utf8');
+    const d = fakeGh([['auth status', AUTH_OK], ['repo view', REPO_VIEW], [() => true, { ok: false, stderr: 'x' }]]);
+    const res = await runDoctor({ gh: d.gh, cwd, log: noop });
+    const dep = res.results.find((r) => r.name === 'deploy');
+    expect(dep.level).toBe('ok');
+  });
+});


### PR DESCRIPTION
Closes #5 (SP4b, plan: docs/plans/2026-07-16-sp4b-deploy-layer.md)

## AC checklist
- [x] **AC-4b.1** deploy-init: full scaffold placed with substitutions, copy-missing-only (customized files survive re-runs), forge.json deploy block + features.deploy wired — test-verified
- [x] **AC-4b.2** env-branch workflows: staging on-push builds SHA-tagged image → ghcr; production pulls the recorded digest (build-once) with single-env-chain fallback build; SHA-pinned actions; per-cloud deploy insert points with Cloud Run reference — structurally test-verified
- [x] **AC-4b.3** deploy-readiness gate: path-filtered image-build + healthcheck boot; terraform fmt/validate per env — structurally verified
- [x] **AC-4b.4** smoke: retry/timeout/exit-code contract — test-verified (first-hit, retry-then-healthy, never-healthy, bad-args)
- [x] **AC-4b.5** doctor deploy checks behind features.deploy — test-verified (missing-list warn, post-init ok)
- [ ] **AC-4b.6** CI green win+linux — this PR's checks

## Honest verification
139/139 tests locally (Windows). NOT verified live: an actual docker build / terraform run (no docker or terraform on this machine) — templates are structurally tested (substitution, digest pins, branch triggers, no leftover forge placeholders), and the readiness workflow will exercise the real build the first time a deploy-enabled consumer opens a PR. The per-cloud deploy step is an explicit INSERT point by design — wiring cloud auth is a consumer one-time human step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x