### PR TITLE
feat: SP4c release management — forge:release (#6)

### DIFF
--- a/plugin/scripts/lib/exec.mjs
+++ b/plugin/scripts/lib/exec.mjs
@@ -8,10 +8,21 @@ import { spawn } from 'node:child_process';
  * a shell (CVE-2024-27980 fix). We never pass shell:true with interpolated
  * strings; instead cmd scripts are routed through cmd.exe with an argv array.
  */
-export function run(command, args = [], options = {}) {
+export async function run(command, args = [], options = {}) {
+  const first = await spawnOnce(command, args, options);
+  // Windows: bare commands that are .cmd/.bat shims (pnpm, npm, npx…) fail
+  // ENOENT without a shell — retry routed through cmd.exe, still argv-only.
+  if (!first.ok && first.code === -1 && process.platform === 'win32'
+      && /ENOENT/.test(first.stderr) && !/[\\/]/.test(command) && !/\.(exe|cmd|bat)$/i.test(command)) {
+    return spawnOnce(command, args, options, true);
+  }
+  return first;
+}
+
+function spawnOnce(command, args = [], options = {}, viaComSpec = false) {
   let cmd = command;
   let argv = args;
-  if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(command)) {
+  if (process.platform === 'win32' && (viaComSpec || /\.(cmd|bat)$/i.test(command))) {
     cmd = process.env.ComSpec || 'cmd.exe';
     argv = ['/d', '/s', '/c', command, ...args];
   }

--- a/plugin/scripts/release/core.mjs
+++ b/plugin/scripts/release/core.mjs
@@ -1,0 +1,91 @@
+/**
+ * Release core (spec §4 item 7 + §2 git conventions) — pure functions:
+ * conventional-commit parsing, bump derivation, changelog + release-body
+ * rendering. No I/O here; the runner owns side effects.
+ */
+const TYPES = ['feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'perf'];
+const COMMIT_RE = /^(\w+)(\(([^)]*)\))?(!)?:\s*(.+)$/;
+
+export function parseCommit(subject) {
+  const m = COMMIT_RE.exec(subject ?? '');
+  if (!m || !TYPES.includes(m[1])) return null;
+  const tickets = [...(m[5] ?? '').matchAll(/#(\d+)/g)].map((x) => Number(x[1]));
+  return {
+    type: m[1],
+    scope: m[3] ?? null,
+    breaking: m[4] === '!',
+    subject: m[5].trim(),
+    tickets,
+  };
+}
+
+/** fix→patch, feat→minor, breaking→major; highest wins. Null when nothing releasable. */
+export function deriveBump(commits) {
+  let bump = null;
+  for (const c of commits) {
+    const parsed = typeof c === 'string' ? parseCommit(c) : c;
+    if (!parsed) continue;
+    if (parsed.breaking || /BREAKING CHANGE/.test(parsed.body ?? '')) return 'major';
+    if (parsed.type === 'feat' && bump !== 'major') bump = 'minor';
+    else if (parsed.type === 'fix' && bump === null) bump = 'patch';
+    else if (bump === null && TYPES.includes(parsed.type)) bump = 'patch'; // chore/docs/etc alone → patch
+  }
+  return bump;
+}
+
+export function nextVersion(current, bump) {
+  if (!current) return '0.1.0';
+  const [maj, min, pat] = current.replace(/^v/, '').split('.').map(Number);
+  if (bump === 'major') return `${maj + 1}.0.0`;
+  if (bump === 'minor') return `${maj}.${min + 1}.0`;
+  return `${maj}.${min}.${pat + 1}`;
+}
+
+const GROUP_TITLES = { feat: 'Features', fix: 'Fixes', perf: 'Performance', refactor: 'Refactoring', docs: 'Docs', test: 'Tests', chore: 'Chores' };
+
+export function groupChanges(subjects) {
+  const groups = {};
+  for (const s of subjects) {
+    const c = parseCommit(s);
+    if (!c) continue;
+    const key = GROUP_TITLES[c.type] ?? 'Other';
+    (groups[key] ??= []).push(c);
+  }
+  return groups;
+}
+
+export function renderChangelogSection(version, date, groups, repoUrl) {
+  const lines = [`## v${version} — ${date}`, ''];
+  for (const [title, items] of Object.entries(groups)) {
+    lines.push(`### ${title}`, '');
+    for (const c of items) {
+      const refs = c.tickets.map((t) => (repoUrl ? `[#${t}](${repoUrl}/issues/${t})` : `#${t}`)).join(' ');
+      lines.push(`- ${c.subject}${c.breaking ? ' **[breaking]**' : ''}${refs ? ` (${refs})` : ''}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/** Generated release-description shape (spec §2 git conventions). */
+export function renderReleaseBody({ version, summary, groups, repoUrl, infraChanged, migrations, imageDigest }) {
+  const lines = [summary, ''];
+  for (const [title, items] of Object.entries(groups)) {
+    lines.push(`### ${title}`, '');
+    for (const c of items) {
+      const refs = c.tickets.map((t) => (repoUrl ? `[#${t}](${repoUrl}/issues/${t})` : `#${t}`)).join(' ');
+      lines.push(`- ${c.subject}${c.breaking ? ' **[breaking]**' : ''}${refs ? ` (${refs})` : ''}`);
+    }
+    lines.push('');
+  }
+  lines.push('### Deploy notes', '');
+  lines.push(`- Infra changed: ${infraChanged ? '**yes** — review \`infra/\` diff before promoting' : 'no'}`);
+  lines.push(`- Migrations to run: ${migrations ? '**yes**' : 'no'}`);
+  if (imageDigest) lines.push(`- Image: \`${imageDigest}\` (retagged \`v${version}\` — the exact bytes staging verified)`);
+  return lines.join('\n');
+}
+
+export function summarize(groups, version) {
+  const counts = Object.entries(groups).map(([t, items]) => `${items.length} ${t.toLowerCase()}`).join(', ');
+  return `v${version}: ${counts || 'maintenance release'}.`;
+}

--- a/plugin/scripts/release/readiness.mjs
+++ b/plugin/scripts/release/readiness.mjs
@@ -1,0 +1,54 @@
+import { read as readJournal } from '../lib/journal.mjs';
+
+/**
+ * Computed release-readiness checklist (spec §13) — forge:release refuses
+ * unless every applicable item passes. Items whose feature is off skip with
+ * an explicit note; degraded items (pre-SP5 AC map) are labeled degraded.
+ */
+export async function computeReadiness({ cwd, execFn, config, verifyCmd }) {
+  const items = [];
+  const pass = (name, msg) => items.push({ name, level: 'pass', msg });
+  const skip = (name, msg) => items.push({ name, level: 'skip', msg });
+  const failItem = (name, msg) => items.push({ name, level: 'fail', msg });
+
+  const git = (...args) => execFn('git', args);
+
+  const branch = await git('rev-parse', '--abbrev-ref', 'HEAD');
+  if (!branch.ok || branch.stdout.trim() !== 'main') failItem('branch', `releases cut from main only (on '${branch.stdout.trim()}')`);
+  else pass('branch', 'on main');
+
+  const dirty = await git('status', '--porcelain');
+  if (!dirty.ok || dirty.stdout.trim() !== '') failItem('worktree', 'working tree not clean');
+  else pass('worktree', 'clean');
+
+  await git('fetch', 'origin', 'main', '--quiet');
+  const behind = await git('rev-list', '--count', 'HEAD..origin/main');
+  if (!behind.ok || Number(behind.stdout.trim()) > 0) failItem('sync', `behind origin/main by ${behind.stdout.trim() || '?'} commit(s)`);
+  else pass('sync', 'up to date with origin/main');
+
+  if (verifyCmd) {
+    const [cmd, ...args] = verifyCmd.split(/\s+/);
+    const verify = await execFn(cmd, args);
+    if (!verify.ok) failItem('verify', `'${verifyCmd}' failed`);
+    else pass('verify', `'${verifyCmd}' green`);
+  } else {
+    skip('verify', 'no verify command configured');
+  }
+
+  const journal = await readJournal(cwd, { kinds: ['review-finding'] });
+  const criticals = journal.events.filter((e) => e.severity === 'critical' && e.resolved !== true);
+  if (criticals.length) failItem('findings', `${criticals.length} open critical finding(s) in the journal`);
+  else pass('findings', 'no open critical findings');
+
+  items.push({ name: 'ac-gate', level: 'skip', msg: 'degraded until SP5 — AC map verified at ship time, not re-checked here' });
+
+  if (config?.features?.deploy === true) {
+    skip('staging-smoke', 'deploy repo — verify the staging smoke passed for the release SHA before promoting (mechanical check lands with workflow status API wiring)');
+  } else {
+    skip('staging-smoke', 'features.deploy off');
+  }
+  if (config?.features?.designReview === true) skip('visual-baselines', 'designReview repo — confirm baselines clean');
+  else skip('visual-baselines', 'features.designReview off');
+
+  return { ok: items.every((i) => i.level !== 'fail'), items };
+}

--- a/plugin/scripts/release/release.mjs
+++ b/plugin/scripts/release/release.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * forge:release runner (spec §4 item 7): readiness → bump → CHANGELOG →
+ * annotated tag → GitHub Release → image retag / npm publish. Release NAMES
+ * artifacts, it never builds them. `--dry-run` previews without writing.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { loadConfig } from '../lib/config.mjs';
+import { getRepoInfo } from '../lib/board.mjs';
+import { computeReadiness } from './readiness.mjs';
+import { deriveBump, nextVersion, groupChanges, renderChangelogSection, renderReleaseBody, summarize } from './core.mjs';
+
+export function parseArgs(argv) {
+  return { dryRun: argv.includes('--dry-run') };
+}
+
+export async function runRelease(ctx, args, log = console.log) {
+  const { cwd, gh, execFn = run } = ctx;
+  const git = (...a) => execFn('git', a);
+  const cfg = await loadConfig(cwd);
+  const config = cfg.ok ? cfg.config : {};
+  const repo = await getRepoInfo(gh);
+  const repoUrl = repo.ok ? `https://github.com/${repo.owner}/${repo.name}` : null;
+
+  // 1. readiness
+  const readiness = await computeReadiness({ cwd, execFn, config, verifyCmd: config.conventions?.verify });
+  for (const i of readiness.items) log(`${i.level === 'pass' ? '✓' : i.level === 'skip' ? '·' : '✗'} ${i.name.padEnd(16)} ${i.msg}`);
+  if (!readiness.ok) return { ok: false, error: 'release-readiness checklist failed (see above)' };
+
+  // 2. delta since last tag
+  const lastTag = await git('describe', '--tags', '--abbrev=0', '--match', 'v*');
+  const tag = lastTag.ok ? lastTag.stdout.trim() : null;
+  const range = tag ? `${tag}..HEAD` : 'HEAD';
+  const logRes = await git('log', range, '--format=%s');
+  if (!logRes.ok) return { ok: false, error: 'git log failed' };
+  const subjects = logRes.stdout.split(/\r?\n/).filter(Boolean).filter((s) => !s.startsWith('chore(release)'));
+  if (subjects.length === 0) return { ok: false, error: `no releasable commits since ${tag ?? 'the beginning'}` };
+
+  const bump = deriveBump(subjects);
+  if (!bump) return { ok: false, error: 'no conventional commits in the delta — nothing to release' };
+  const version = tag ? nextVersion(tag, bump) : '0.1.0';
+  const groups = groupChanges(subjects);
+
+  // deploy notes
+  const diffRange = tag ? `${tag}..HEAD` : 'HEAD';
+  const changed = await git('diff', '--name-only', ...(tag ? [tag, 'HEAD'] : ['HEAD'])); // full-tree list on first release
+  const files = changed.ok ? changed.stdout.split(/\r?\n/) : [];
+  const infraChanged = files.some((f) => f.startsWith('infra/'));
+  const migrations = config.deploy?.migrations != null && files.some((f) => f.includes('migrations/'));
+
+  // image digest (deploy repos): the staging-built image for HEAD, if any
+  let imageDigest = null;
+  if (config.features?.deploy === true && repo.ok) {
+    const head = await git('rev-parse', 'HEAD');
+    if (head.ok) imageDigest = `ghcr.io/${repo.owner.toLowerCase()}/${repo.name}:sha-${head.stdout.trim()}`;
+  }
+
+  const date = new Date().toISOString().slice(0, 10);
+  const section = renderChangelogSection(version, date, groups, repoUrl);
+  const body = renderReleaseBody({ version, summary: summarize(groups, version), groups, repoUrl, infraChanged, migrations, imageDigest });
+
+  if (args.dryRun) {
+    log(`\n— dry run — would release v${version} (${bump} bump from ${tag ?? 'no prior tag'})`);
+    log(section);
+    return { ok: true, dryRun: true, version, bump, body };
+  }
+
+  // 3. changelog commit
+  const clPath = join(cwd, 'CHANGELOG.md');
+  let cl = '';
+  try { cl = await readFile(clPath, 'utf8'); } catch { cl = '# Changelog\n\n'; }
+  const marker = '# Changelog\n\n';
+  const updated = cl.startsWith(marker) ? marker + section + '\n' + cl.slice(marker.length) : section + '\n' + cl;
+  await writeFile(clPath, updated, 'utf8');
+  const add = await git('add', 'CHANGELOG.md');
+  const commit = add.ok && (await git('commit', '-m', `chore(release): v${version}`));
+  if (!commit.ok) return { ok: false, error: 'changelog commit failed' };
+
+  // 4. annotated tag + push
+  const tagged = await git('tag', '-a', `v${version}`, '-m', `v${version}`);
+  if (!tagged.ok) return { ok: false, error: `tag failed: ${tagged.stderr}` };
+  const pushed = await git('push', 'origin', 'main', `v${version}`);
+  if (!pushed.ok) return { ok: false, error: `push failed: ${pushed.stderr}` };
+
+  // 5. GitHub Release
+  const rel = await gh(['release', 'create', `v${version}`, '--title', `v${version}`, '--notes', body]);
+  if (!rel.ok) return { ok: false, error: `gh release create failed: ${rel.stderr}` };
+
+  // 6. artifact naming
+  const notes = [];
+  if (imageDigest) notes.push(`retag the staging image as v${version}: docker buildx imagetools create -t ${imageDigest.replace(/:sha-.*/, `:v${version}`)} ${imageDigest} (requires registry auth — run where docker is available)`);
+  let pkg = null;
+  try { pkg = JSON.parse(await readFile(join(cwd, 'package.json'), 'utf8')); } catch { /* no package */ }
+  if (pkg && pkg.private !== true) notes.push(`public package — publish with: npm publish (from the v${version} tag)`);
+
+  log(`released v${version}`);
+  for (const n of notes) log(`next: ${n}`);
+  return { ok: true, version, bump, notes };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  runRelease({ gh, cwd: process.cwd() }, parseArgs(process.argv.slice(2))).then((res) => {
+    if (!res.ok) { console.error(`release failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/skills/release/SKILL.md
+++ b/plugin/skills/release/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: release
+description: Cut a named release — semver from conventional commits, CHANGELOG, annotated tag, GitHub Release, artifact naming. Use after merges when the owner wants a release, or before promoting deploy repos to production.
+---
+
+# forge:release
+
+"Merged" → "a deployable artifact with a name" (spec §4 item 7). Release **names** artifacts, it never builds them.
+
+## Timing rule (spec §4)
+
+- **Deploy repos** (`features.deploy`): release *after* the staging merge + smoke pass — there must be a verified digest to name. Production then promotes the release-named digest.
+- **Library/non-deploy repos**: release any time after merge.
+
+## Steps
+
+1. Preview first: `node "${CLAUDE_PLUGIN_ROOT}/scripts/release/release.mjs" --dry-run` — relay the readiness checklist, computed version, and changelog section to the user.
+2. On the user's go: run without `--dry-run`. The script enforces the readiness checklist (refuses on: not-main, dirty tree, behind remote, verify failing, open critical findings, empty delta), prepends CHANGELOG, commits `chore(release): vX.Y.Z`, creates the annotated tag, pushes, and publishes the GitHub Release with the generated description shape (summary · grouped changes with ticket links · deploy notes · image digest).
+3. Relay the follow-ups the script prints: image retag command (deploy repos — run where docker is available) and npm publish (public packages only).
+4. Trail-comment the epic/driving ticket (`--phase note`) with the release link.
+
+Never move or delete an existing `v*` tag; never release from a branch. If the checklist fails, fix the cause — do not bypass.

--- a/tests/lib/exec.test.mjs
+++ b/tests/lib/exec.test.mjs
@@ -17,7 +17,13 @@ describe('run', () => {
   it('resolves (never throws) for a missing binary', async () => {
     const res = await run('definitely-not-a-real-binary-xyz', []);
     expect(res.ok).toBe(false);
-    expect(res.code).toBe(-1);
+    expect(res.code).not.toBe(0); // -1 direct, or cmd.exe's nonzero on the Windows retry path
+  });
+
+  it('bare .cmd-shim commands resolve cross-platform (the pnpm ENOENT lesson)', async () => {
+    const res = await run('pnpm', ['--version']);
+    expect(res.ok).toBe(true);
+    expect(res.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   it('the .cmd EINVAL lesson: cmd scripts are routed through cmd.exe on Windows', async function () {

--- a/tests/release.test.mjs
+++ b/tests/release.test.mjs
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { parseCommit, deriveBump, nextVersion, groupChanges, renderChangelogSection, renderReleaseBody, summarize } from '../plugin/scripts/release/core.mjs';
+import { computeReadiness } from '../plugin/scripts/release/readiness.mjs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { append } from '../plugin/scripts/lib/journal.mjs';
+
+describe('parseCommit + deriveBump (AC-4c.1)', () => {
+  it('parses conventional subjects with scope, breaking, tickets', () => {
+    expect(parseCommit('feat(board): add digest script (#2)')).toMatchObject({ type: 'feat', scope: 'board', breaking: false, tickets: [2] });
+    expect(parseCommit('fix!: drop legacy config (#7)')).toMatchObject({ type: 'fix', breaking: true });
+    expect(parseCommit('merge branch whatever')).toBe(null);
+  });
+
+  it('bump: highest wins; chore-only → patch; nothing → null', () => {
+    expect(deriveBump(['fix: a (#1)'])).toBe('patch');
+    expect(deriveBump(['fix: a', 'feat: b'])).toBe('minor');
+    expect(deriveBump(['feat: b', 'chore!: drop node 20'])).toBe('major');
+    expect(deriveBump(['chore: tidy', 'docs: readme'])).toBe('patch');
+    expect(deriveBump(['random noise', 'Merge pull request #9'])).toBe(null);
+  });
+
+  it('nextVersion: bumps semver; first release is 0.1.0', () => {
+    expect(nextVersion('v1.2.3', 'patch')).toBe('1.2.4');
+    expect(nextVersion('v1.2.3', 'minor')).toBe('1.3.0');
+    expect(nextVersion('v1.2.3', 'major')).toBe('2.0.0');
+    expect(nextVersion(null, 'minor')).toBe('0.1.0');
+  });
+});
+
+describe('changelog + release body (AC-4c.2, AC-4c.4)', () => {
+  const subjects = ['feat(board): digest script (#2)', 'fix: statusline crash (#5)', 'feat!: new config shape (#7)'];
+
+  it('groups by type with linked ticket refs', () => {
+    const groups = groupChanges(subjects);
+    const section = renderChangelogSection('1.1.0', '2026-07-16', groups, 'https://github.com/o/r');
+    expect(section).toContain('## v1.1.0 — 2026-07-16');
+    expect(section).toContain('### Features');
+    expect(section).toContain('[#2](https://github.com/o/r/issues/2)');
+    expect(section).toContain('**[breaking]**');
+    expect(section).toContain('### Fixes');
+  });
+
+  it('release body carries the generated shape incl. deploy notes + digest', () => {
+    const groups = groupChanges(subjects);
+    const body = renderReleaseBody({
+      version: '1.1.0', summary: summarize(groups, '1.1.0'), groups, repoUrl: null,
+      infraChanged: true, migrations: false, imageDigest: 'ghcr.io/o/r:sha-abc',
+    });
+    expect(body).toContain('### Deploy notes');
+    expect(body).toContain('Infra changed: **yes**');
+    expect(body).toContain('Migrations to run: no');
+    expect(body).toContain('ghcr.io/o/r:sha-abc');
+    expect(body).toContain('retagged `v1.1.0`');
+  });
+});
+
+describe('readiness (AC-4c.3)', () => {
+  function gitExec(overrides = {}) {
+    return async (cmd, args) => {
+      const key = `${cmd} ${args.join(' ')}`;
+      for (const [prefix, res] of Object.entries(overrides)) {
+        if (key.startsWith(prefix)) return typeof res === 'function' ? res() : res;
+      }
+      if (key.startsWith('git rev-parse --abbrev-ref')) return { ok: true, stdout: 'main\n', stderr: '' };
+      if (key.startsWith('git status')) return { ok: true, stdout: '', stderr: '' };
+      if (key.startsWith('git fetch')) return { ok: true, stdout: '', stderr: '' };
+      if (key.startsWith('git rev-list')) return { ok: true, stdout: '0\n', stderr: '' };
+      if (key.startsWith('echo-verify')) return { ok: true, stdout: '', stderr: '' };
+      return { ok: true, stdout: '', stderr: '' };
+    };
+  }
+
+  it('all-green readiness passes with feature items skipped', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-rel-'));
+    const r = await computeReadiness({ cwd, execFn: gitExec(), config: { features: {} }, verifyCmd: 'echo-verify ok' });
+    expect(r.ok).toBe(true);
+    expect(r.items.find((i) => i.name === 'staging-smoke').level).toBe('skip');
+    expect(r.items.find((i) => i.name === 'ac-gate').level).toBe('skip');
+  });
+
+  it('refuses: wrong branch, dirty tree, behind remote, verify red, critical findings', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-rel-'));
+    const branch = await computeReadiness({ cwd, execFn: gitExec({ 'git rev-parse --abbrev-ref': { ok: true, stdout: 'feat/6-release\n' } }), config: {}, verifyCmd: null });
+    expect(branch.ok).toBe(false);
+
+    const dirty = await computeReadiness({ cwd, execFn: gitExec({ 'git status': { ok: true, stdout: ' M file\n' } }), config: {}, verifyCmd: null });
+    expect(dirty.ok).toBe(false);
+
+    const behind = await computeReadiness({ cwd, execFn: gitExec({ 'git rev-list': { ok: true, stdout: '2\n' } }), config: {}, verifyCmd: null });
+    expect(behind.ok).toBe(false);
+
+    const red = await computeReadiness({ cwd, execFn: gitExec({ 'pnpm verify': { ok: false, stdout: '', stderr: 'boom' } }), config: {}, verifyCmd: 'pnpm verify' });
+    expect(red.ok).toBe(false);
+
+    const cwd2 = await mkdtemp(join(tmpdir(), 'forge-rel-'));
+    await append(cwd2, 'review-finding', { severity: 'critical', summary: 'injection', role: 'security' });
+    const crit = await computeReadiness({ cwd: cwd2, execFn: gitExec(), config: {}, verifyCmd: null });
+    expect(crit.ok).toBe(false);
+    expect(crit.items.find((i) => i.name === 'findings').msg).toContain('critical');
+  });
+});


### PR DESCRIPTION
Closes #6 (SP4c, plan: docs/plans/2026-07-16-sp4c-release.md)

## AC checklist
- [x] **AC-4c.1** bump derivation: fix/feat/breaking + highest-wins, chore-only→patch, noise→refuse, first release 0.1.0 — test-verified
- [x] **AC-4c.2** CHANGELOG prepend + `chore(release): vX.Y.Z` commit — implemented; grouped/linked rendering test-verified
- [x] **AC-4c.3** readiness checklist — test-verified per refusal class AND live-verified: dry-run from the work branch correctly refused (branch ✗, worktree ✗); after the exec fix, verify ✓ ran green inside the checklist
- [x] **AC-4c.4** annotated tag + GitHub Release with generated description shape (summary/groups/deploy notes/digest); --dry-run previews without writes — render test-verified
- [x] **AC-4c.5** artifact naming: image retag command emitted for deploy repos (never rebuilds), npm publish only when not private — implemented
- [ ] **AC-4c.6** CI green win+linux — this PR's checks

## Bonus fix (unplanned, in-scope — trail `note` on #6)
Live dogfood exposed a Windows exec bug: bare `.cmd`-shim commands (pnpm/npm/npx) failed ENOENT under spawn without shell. `run()` now retries through cmd.exe with argv arrays — regression-tested cross-platform.

## Honest verification
147/147 tests locally (Windows). NOT run live: an actual release (tag+push+GitHub Release) — the natural first live run is releasing forge itself as v0.1.0 after this PR merges, which I propose as the post-merge dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x