### PR TITLE
feat: SP5 plan + execute — ledger, mechanical gates, skills (#7)

### DIFF
--- a/docs/plans/2026-07-16-sp5-plan-execute.md
+++ b/docs/plans/2026-07-16-sp5-plan-execute.md
@@ -16,12 +16,19 @@
 ## Tasks
 
 - **T1 — ledger lib** + tests (parse/init/mark/next; CRLF-safe).
+  **Files:** plugin/scripts/lib/ledger.mjs, tests/lib/ledger.test.mjs
 - **T2 — acgate** + tests (vitest JSON fixture; pass/missing/failing-AC cases; plan-file AC extraction).
+  **Files:** plugin/scripts/gates/acgate.mjs, tests/gates/acgate.test.mjs
 - **T3 — plandrift** + tests (declared+scope+default-allow; deviation naming; injected git exec).
+  **Files:** plugin/scripts/gates/plandrift.mjs, tests/gates/plandrift.test.mjs
 - **T4 — depguard** + tests (new/existing/removed diff; registry existence/age/downloads via injected fetch; npm-only v1).
+  **Files:** plugin/scripts/gates/depguard.mjs, tests/gates/depguard.test.mjs
 - **T5 — testintent** + tests (removed expect-lines in existing files flag; additions pass; new files pass; injected git exec).
+  **Files:** plugin/scripts/gates/testintent.mjs, tests/gates/testintent.test.mjs
 - **T6 — skills**: `forge:plan` (template with machine-parseable sections), `forge:execute` (scoper → test-architect → implementer → reviewer loop, fix waves, ledger + resume, per-task gates), `forge:ship` update (mechanical gate invocations replace the degraded notes).
+  **Files:** plugin/skills/plan/SKILL.md, plugin/skills/execute/SKILL.md, plugin/skills/ship/SKILL.md
 - **T7 — ship**: PR, trail, ritual; gates dogfooded on this very branch where applicable (plandrift vs this plan's own Files lists).
+  **Files:** docs/
 
 ## Out of scope
 

--- a/plugin/scripts/gates/acgate.mjs
+++ b/plugin/scripts/gates/acgate.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * AC gate (spec §13): every AC id must appear in ≥1 PASSING test title in the
+ * runner's JSON output. Machine evidence only — role reports are never
+ * consulted. Vitest JSON reporter format (v1).
+ */
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/** Extract AC-<ticket>.<n> ids from a plan file's **AC map:** sections (or anywhere in the text). */
+export function extractAcIds(planText, ticket = null) {
+  const re = ticket ? new RegExp(`\\bAC-${ticket}\\.\\d+\\b`, 'g') : /\bAC-\d+[a-z]?\.\d+\b/g;
+  return [...new Set((planText ?? '').match(re) ?? [])];
+}
+
+/** Flatten vitest JSON results into [{title, fullName, passed}]. */
+export function flattenResults(vitestJson) {
+  const out = [];
+  for (const file of vitestJson.testResults ?? []) {
+    for (const t of file.assertionResults ?? []) {
+      out.push({ title: t.title ?? '', fullName: t.fullName ?? t.title ?? '', passed: t.status === 'passed' });
+    }
+  }
+  return out;
+}
+
+export function checkAcCoverage(acIds, tests) {
+  const missing = [];
+  const failing = [];
+  for (const id of acIds) {
+    const hits = tests.filter((t) => t.title.includes(id) || t.fullName.includes(id));
+    if (hits.length === 0) missing.push(id);
+    else if (!hits.some((t) => t.passed)) failing.push(id);
+  }
+  return { ok: missing.length === 0 && failing.length === 0, missing, failing, covered: acIds.length - missing.length - failing.length };
+}
+
+export function parseArgs(argv) {
+  const a = { plan: null, ticket: null, results: null, acs: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--plan') a.plan = argv[++i];
+    else if (argv[i] === '--ticket') a.ticket = Number(argv[++i]);
+    else if (argv[i] === '--results') a.results = argv[++i];
+    else if (argv[i] === '--acs') a.acs = argv[++i];
+  }
+  return a;
+}
+
+export async function runAcGate(args, log = console.log) {
+  let acIds;
+  if (args.acs) acIds = args.acs.split(',').map((s) => s.trim()).filter(Boolean);
+  else if (args.plan) acIds = extractAcIds(await readFile(args.plan, 'utf8'), args.ticket);
+  else return { ok: false, error: 'need --acs "AC-7.1,…" or --plan <file> [--ticket N]' };
+  if (acIds.length === 0) return { ok: false, error: 'no AC ids found — the plan must map ACs (AC-<ticket>.<n>) to tests' };
+  if (!args.results) return { ok: false, error: '--results <vitest-json-file> is required (run: vitest run --reporter=json --outputFile=<file>)' };
+
+  const json = JSON.parse(await readFile(args.results, 'utf8'));
+  const check = checkAcCoverage(acIds, flattenResults(json));
+  for (const id of acIds) {
+    const state = check.missing.includes(id) ? '✗ no test' : check.failing.includes(id) ? '✗ failing' : '✓';
+    log(`${state.padEnd(10)} ${id}`);
+  }
+  log(check.ok ? `ac-gate: all ${acIds.length} ACs covered by passing tests` : `ac-gate: ${check.missing.length} unmapped, ${check.failing.length} failing`);
+  return { ...check, acIds };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  runAcGate(parseArgs(process.argv.slice(2))).then((res) => {
+    if (res.error) console.error(res.error);
+    process.exit(res.ok ? 0 : 1);
+  });
+}

--- a/plugin/scripts/gates/depguard.mjs
+++ b/plugin/scripts/gates/depguard.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Dependency-existence guard (spec §13): every NEW package must exist on the
+ * registry, be ≥ MIN_AGE_DAYS old, and clear a download floor — blocks
+ * hallucinated-package (slopsquatting) supply-chain attacks. npm-only v1.
+ */
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run } from '../lib/exec.mjs';
+
+export const MIN_AGE_DAYS = 90;
+export const MIN_WEEKLY_DOWNLOADS = 500;
+
+export function collectDeps(pkg) {
+  return { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}), ...(pkg.optionalDependencies ?? {}) };
+}
+
+/** New deps = in branch package.json but not in base's. */
+export function newDeps(basePkg, branchPkg) {
+  const base = collectDeps(basePkg ?? {});
+  const branch = collectDeps(branchPkg ?? {});
+  return Object.keys(branch).filter((name) => !(name in base));
+}
+
+export async function checkPackage(name, { fetchFn = fetch, now = Date.now() } = {}) {
+  const meta = await fetchFn(`https://registry.npmjs.org/${encodeURIComponent(name)}`);
+  if (!meta.ok) return { name, ok: false, reason: meta.status === 404 ? 'does not exist on the registry (possible hallucinated package)' : `registry lookup failed (${meta.status})` };
+  const data = await meta.json();
+  const created = Date.parse(data.time?.created ?? '');
+  if (!Number.isFinite(created)) return { name, ok: false, reason: 'no creation date in registry metadata' };
+  const ageDays = Math.floor((now - created) / 86_400_000);
+  if (ageDays < MIN_AGE_DAYS) return { name, ok: false, reason: `only ${ageDays} days old (< ${MIN_AGE_DAYS} — young packages are the slopsquatting vector)` };
+
+  const dl = await fetchFn(`https://api.npmjs.org/downloads/point/last-week/${encodeURIComponent(name)}`);
+  if (dl.ok) {
+    const { downloads } = await dl.json();
+    if (Number.isFinite(downloads) && downloads < MIN_WEEKLY_DOWNLOADS) {
+      return { name, ok: false, reason: `${downloads} weekly downloads (< ${MIN_WEEKLY_DOWNLOADS})` };
+    }
+  } // downloads API unavailable → age + existence already checked; don't hard-fail
+  return { name, ok: true, ageDays };
+}
+
+export async function runDepGuard({ cwd, base = 'main', execFn = run, fetchFn = fetch, log = console.log }) {
+  const baseRaw = await execFn('git', ['-C', cwd, 'show', `${base}:package.json`]);
+  const basePkg = baseRaw.ok ? JSON.parse(baseRaw.stdout) : {};
+  let branchPkg = {};
+  try { branchPkg = JSON.parse(await readFile(resolve(cwd, 'package.json'), 'utf8')); } catch { /* no package.json */ }
+
+  const added = newDeps(basePkg, branchPkg);
+  if (added.length === 0) {
+    log('dep-guard: no new dependencies');
+    return { ok: true, added: [], violations: [] };
+  }
+  const results = [];
+  for (const name of added) results.push(await checkPackage(name, { fetchFn }));
+  const violations = results.filter((r) => !r.ok);
+  for (const r of results) log(`${r.ok ? '✓' : '✗'} ${r.name}${r.ok ? ` (${r.ageDays}d old)` : ` — ${r.reason}`}`);
+  if (violations.length) log('dep-guard: violations — remove the package or escalate with justification (spec §7)');
+  return { ok: violations.length === 0, added, violations };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const base = process.argv.includes('--base') ? process.argv[process.argv.indexOf('--base') + 1] : 'main';
+  runDepGuard({ cwd: process.cwd(), base }).then((res) => process.exit(res.ok ? 0 : 1));
+}

--- a/plugin/scripts/gates/plandrift.mjs
+++ b/plugin/scripts/gates/plandrift.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Plan-drift gate (spec §13): the branch's touched files vs the plan's
+ * declared **Files:** lists + scoper extensions (.forge/scope.json) +
+ * default-allowed globs. Deviation ⇒ escalate, not silently accept.
+ */
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run } from '../lib/exec.mjs';
+import { readJson } from '../lib/jsonfile.mjs';
+
+/** Always allowed: the artifacts every task legitimately produces. */
+export const DEFAULT_ALLOW = ['tests/', 'docs/', '.forge/', 'CHANGELOG.md', 'pnpm-lock.yaml', 'package-lock.json'];
+
+/** Pull file paths from every `**Files:**` line in the plan. */
+export function extractPlanFiles(planText) {
+  const files = [];
+  for (const m of (planText ?? '').matchAll(/\*\*Files:\*\*\s*(.+)$/gm)) {
+    for (const raw of m[1].split(/[,\s]+/)) {
+      const f = raw.replace(/[`()]/g, '').trim();
+      if (f && !f.startsWith('+')) files.push(f);
+    }
+  }
+  return [...new Set(files)];
+}
+
+export function isAllowed(file, declared, scopeExtra, allowPrefixes) {
+  const norm = file.replaceAll('\\', '/');
+  if (allowPrefixes.some((p) => (p.endsWith('/') ? norm.startsWith(p) : norm === p))) return true;
+  const all = [...declared, ...scopeExtra];
+  return all.some((d) => {
+    const dn = d.replaceAll('\\', '/');
+    return dn === norm || (dn.endsWith('/') && norm.startsWith(dn)) || norm.startsWith(dn.replace(/\*+$/, ''));
+  });
+}
+
+export async function runPlanDrift({ cwd, planPath, base = 'main', execFn = run, log = console.log }) {
+  const planText = await readFile(resolve(cwd, planPath), 'utf8').catch(() => null);
+  if (!planText) return { ok: false, error: `plan not readable: ${planPath}` };
+  const declared = extractPlanFiles(planText);
+  if (declared.length === 0) return { ok: false, error: 'plan declares no **Files:** lists — plan-drift needs them (forge:plan template)' };
+
+  const scope = (await readJson(join(cwd, '.forge', 'scope.json')).catch(() => null)) ?? {};
+  const scopeExtra = scope.files ?? [];
+
+  const diff = await execFn('git', ['-C', cwd, 'diff', '--name-only', `${base}...HEAD`]);
+  if (!diff.ok) return { ok: false, error: `git diff failed: ${diff.stderr}` };
+  const touched = diff.stdout.split(/\r?\n/).filter(Boolean);
+
+  const deviations = touched.filter((f) => !isAllowed(f, declared, scopeExtra, DEFAULT_ALLOW));
+  for (const d of deviations) log(`✗ off-plan: ${d}`);
+  if (deviations.length) {
+    log(`plan-drift: ${deviations.length} file(s) outside the plan + blast radius — escalate (spec §7) or update the plan/scope before shipping`);
+  } else {
+    log(`plan-drift: clean (${touched.length} touched, all declared/allowed)`);
+  }
+  return { ok: deviations.length === 0, deviations, touched: touched.length };
+}
+
+export function parseArgs(argv) {
+  const a = { plan: null, base: 'main' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--plan') a.plan = argv[++i];
+    else if (argv[i] === '--base') a.base = argv[++i];
+  }
+  return a;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.plan) { console.error('--plan <file> is required'); process.exit(2); }
+  runPlanDrift({ cwd: process.cwd(), planPath: args.plan, base: args.base }).then((res) => {
+    if (res.error) console.error(res.error);
+    process.exit(res.ok ? 0 : 1);
+  });
+}

--- a/plugin/scripts/gates/testintent.mjs
+++ b/plugin/scripts/gates/testintent.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Test-intent gate (spec §13 anti-gaming law): weakening, deleting, or
+ * loosening an existing assertion requires explicit reviewer sign-off.
+ * Detector: assertion lines REMOVED from pre-existing test files. Pure
+ * additions and brand-new test files pass untouched.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run } from '../lib/exec.mjs';
+
+const ASSERTION_RE = /\b(expect|assert|toBe|toEqual|toMatch|toContain|toThrow|rejects|resolves)\b/;
+
+/** Parse `git diff -U0` output into per-file removed assertion lines. */
+export function findWeakenings(diffText, newFiles = []) {
+  const weakenings = [];
+  let file = null;
+  for (const line of (diffText ?? '').split(/\r?\n/)) {
+    const header = /^\+\+\+ b\/(.+)$/.exec(line);
+    if (header) { file = header[1]; continue; }
+    if (!file || newFiles.includes(file)) continue;
+    if (line.startsWith('-') && !line.startsWith('---') && ASSERTION_RE.test(line)) {
+      weakenings.push({ file, line: line.slice(1).trim() });
+    }
+  }
+  return weakenings;
+}
+
+export async function runTestIntent({ cwd, base = 'main', testGlob = 'tests/', execFn = run, log = console.log }) {
+  const status = await execFn('git', ['-C', cwd, 'diff', '--name-status', `${base}...HEAD`, '--', testGlob]);
+  if (!status.ok) return { ok: false, error: `git diff failed: ${status.stderr}` };
+  const newFiles = status.stdout.split(/\r?\n/).filter((l) => l.startsWith('A')).map((l) => l.split(/\s+/)[1]);
+
+  const diff = await execFn('git', ['-C', cwd, 'diff', '-U0', `${base}...HEAD`, '--', testGlob]);
+  if (!diff.ok) return { ok: false, error: `git diff failed: ${diff.stderr}` };
+
+  const weakenings = findWeakenings(diff.stdout, newFiles);
+  for (const w of weakenings) log(`✗ assertion removed/changed in existing test: ${w.file} — ${w.line.slice(0, 80)}`);
+  if (weakenings.length) {
+    log(`test-intent: ${weakenings.length} assertion change(s) in pre-existing tests — requires explicit reviewer sign-off in the PR (anti-gaming law, spec §13)`);
+  } else {
+    log('test-intent: clean — no existing assertions weakened');
+  }
+  return { ok: weakenings.length === 0, weakenings };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const base = process.argv.includes('--base') ? process.argv[process.argv.indexOf('--base') + 1] : 'main';
+  runTestIntent({ cwd: process.cwd(), base }).then((res) => {
+    if (res.error) console.error(res.error);
+    process.exit(res.ok ? 0 : 1);
+  });
+}

--- a/plugin/scripts/lib/ledger.mjs
+++ b/plugin/scripts/lib/ledger.mjs
@@ -1,0 +1,76 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+
+/**
+ * Execute ledger (spec §4 item 5): .forge/progress.md — human-readable,
+ * survives compaction, powers the resume protocol. Checklist grammar:
+ *   - [ ] T1 — description        (pending)
+ *   - [~] T2 — description        (in progress)
+ *   - [x] T3 — description        (done)
+ * Notes lines are indented under a task and preserved verbatim.
+ */
+export const LEDGER_RELPATH = join('.forge', 'progress.md');
+const TASK_RE = /^- \[( |~|x)\] (\S+) — (.*)$/;
+
+export function parseLedger(text) {
+  const tasks = [];
+  let current = null;
+  for (const line of (text ?? '').split(/\r?\n/)) {
+    const m = TASK_RE.exec(line);
+    if (m) {
+      current = { id: m[2], status: m[1] === 'x' ? 'done' : m[1] === '~' ? 'in-progress' : 'pending', title: m[3], notes: [] };
+      tasks.push(current);
+    } else if (current && /^ {2,}\S/.test(line)) {
+      current.notes.push(line.trim());
+    }
+  }
+  return tasks;
+}
+
+export function renderLedger(header, tasks) {
+  const mark = { pending: ' ', 'in-progress': '~', done: 'x' };
+  const lines = [header.trim(), ''];
+  for (const t of tasks) {
+    lines.push(`- [${mark[t.status]}] ${t.id} — ${t.title}`);
+    for (const n of t.notes) lines.push(`  ${n}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+export async function initLedger(cwd, { ticket, planPath, tasks }) {
+  const path = join(cwd, LEDGER_RELPATH);
+  try {
+    const existing = await readFile(path, 'utf8');
+    if (parseLedger(existing).length > 0) return { ok: true, existed: true, tasks: parseLedger(existing) };
+  } catch { /* fresh */ }
+  const list = tasks.map((t) => ({ id: t.id, status: 'pending', title: t.title, notes: [] }));
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, renderLedger(`# forge execute ledger — #${ticket}\n\nPlan: ${planPath}`, list), 'utf8');
+  return { ok: true, existed: false, tasks: list };
+}
+
+export async function markTask(cwd, id, status, note = null) {
+  const path = join(cwd, LEDGER_RELPATH);
+  const text = await readFile(path, 'utf8');
+  const tasks = parseLedger(text);
+  const task = tasks.find((t) => t.id === id);
+  if (!task) return { ok: false, error: `no task '${id}' in the ledger — ids: ${tasks.map((t) => t.id).join(', ')}` };
+  task.status = status;
+  if (note) task.notes.push(note);
+  const header = text.split(/\r?\n- \[/)[0];
+  await writeFile(path, renderLedger(header, tasks), 'utf8');
+  return { ok: true, task };
+}
+
+/** Resume protocol entry point: the first task that isn't done. */
+export async function nextTask(cwd) {
+  let text;
+  try {
+    text = await readFile(join(cwd, LEDGER_RELPATH), 'utf8');
+  } catch {
+    return { ok: true, task: null, empty: true };
+  }
+  const tasks = parseLedger(text);
+  const next = tasks.find((t) => t.status !== 'done') ?? null;
+  return { ok: true, task: next, done: tasks.filter((t) => t.status === 'done').length, total: tasks.length };
+}

--- a/plugin/skills/execute/SKILL.md
+++ b/plugin/skills/execute/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: execute
+description: Plan → branch, task by task — scoper → failing tests → implement → review, with the ledger, per-task gates, and the resume protocol. Use after forge:plan.
+---
+
+# forge:execute
+
+Plan → working branch. Order is law (spec §4 item 5); the ledger makes any session resumable.
+
+## Setup
+
+1. Branch per git conventions: `<type>/<issue#>-<slug>` cut from up-to-date main.
+2. Init the ledger: `.forge/progress.md` with one line per plan task (lib/ledger.mjs grammar: `- [ ] T1 — title`). Trail-comment `--phase started`.
+
+## Per-task loop (mark `[~]` at start, `[x]` + note at end)
+
+1. **Scope** (`scoper` role when the radius is unclear): confirm the task's Files list; legitimate extra surface goes into `.forge/scope.json` — never silently.
+2. **Failing tests first** (`test-architect` role or its card discipline): AC-ID-titled tests from the task's test plan; confirm each fails for the expected reason. Bug fixes: regression test first, no exceptions.
+3. **Implement** (`implementer` role or its card discipline): make them pass; scoped test run + full verify green.
+4. **Per-task review** (`reviewer`; + `design-reviewer` on UI tasks when `features.designReview`): findings fixed or ticketed before the next task.
+5. New dependency? Run the dep guard *now*, not at ship: `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/depguard.mjs"`.
+
+## Whole-branch finish
+
+1. Fix waves until the full-branch review (reviewer + security cards) is clean.
+2. Pre-ship gates (also run by forge:ship):
+   - `gates/plandrift.mjs --plan <plan>` — off-plan files ⇒ escalate or extend scope.json with a reviewer-visible note
+   - `gates/testintent.mjs` — weakened existing assertions ⇒ reviewer sign-off in the PR or revert
+   - `vitest run --reporter=json --outputFile=.forge/results.json` then `gates/acgate.mjs --plan <plan> --ticket <n> --results .forge/results.json`
+3. Hand to `forge:ship`.
+
+## Resume protocol (spec §4 — no human re-briefing)
+
+A fresh session: read `.forge/progress.md` (ledger `next()` = first non-done task) → read `.forge/decisions/` for resolved answers (`escalate.mjs --check`) → `git status`/log to verify branch state matches the ledger → continue the loop from that task.
+
+## Escalation triggers here (spec §7)
+
+Same gate failing twice · blast radius beyond the plan · reviewer/implementer deadlock · any denylist-blocked need. `escalate.mjs`, then stop.

--- a/plugin/skills/plan/SKILL.md
+++ b/plugin/skills/plan/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: plan
+description: Spec → task-by-task implementation plan with machine-parseable sections (Files lists, AC map, test plans). Use after a spec is approved and before execute.
+---
+
+# forge:plan
+
+Spec → plan in the consumer's plans dir (`conventions.plansDir`). The plan is a **contract**: plan-drift and the AC gate parse it mechanically at ship — its sections are grammar, not decoration.
+
+## Plan template (machine-parseable parts are load-bearing)
+
+```markdown
+# <name> — Implementation Plan
+**Epic:** #<n> · **Spec:** <link> · **Branch:** <type>/<n>-<slug> · **Verify:** <cmd>
+
+## Acceptance criteria
+- **AC-<n>.1** — <verifiable statement>            ← ids used in test titles
+…
+
+## Tasks
+### T1 — <title>
+**Files:** path/one.mjs, path/two/ , tests/one.test.mjs   ← plan-drift parses these lines
+**AC map:** AC-<n>.1, AC-<n>.3                            ← acgate parses these
+<approach, key code sketch>
+**Test plan:** cases, edge matrix (incl. Windows paths/CRLF where relevant), layers per spec §13
+**Done:** <criteria>
+```
+
+## Rules
+
+1. Every task carries a `**Files:**` line (dirs end with `/`) and an `**AC map:**` line; every AC id appears in ≥1 task.
+2. `test-architect` drafts the test-plan sections — AC-ID-titled tests (`test('AC-7.2: …')`) so the runner output satisfies the gate.
+3. `features.e2e` repos: critical-path E2E cases go in the test plan of the task that completes the path.
+4. Bug tickets: the regression test is T1, before any fix task.
+5. **Plan gate is auto by default** — commit the plan to main (`docs(plan): … (#n)`), update the route index, trail-comment the ticket (`--phase plan`), and proceed to execute. Only pause for sign-off when `team.policy.approvals.plan` exists.
+6. Scoper narrows before planning when the blast radius is unclear — its file list feeds the Files lines; write `.forge/scope.json` (`{"files":[…]}`) when execute discovers legitimate extra surface.

--- a/plugin/skills/ship/SKILL.md
+++ b/plugin/skills/ship/SKILL.md
@@ -5,19 +5,24 @@ description: Branch → PR → merged ritual with gates, trail comments, and the
 
 # forge:ship
 
-Branch → PR with gates, then the post-merge ritual. Gates run degraded until later sub-projects upgrade them in place (spec §12 staged gates): role-card reviewer/security passes arrive with SP4, plan-based AC mapping + plan-drift with SP5, deploy-readiness with SP4b.
+Branch → PR with gates, then the post-merge ritual. Since SP5 the core gates are **mechanical scripts** — run them, don't re-argue them. (Still staged: deploy-readiness runs via the consumer workflow, SP4b.)
 
 ## Pre-PR checklist (in order — a failed gate stops the ritual)
 
-1. **Conventions lint** (spec §2): branch matches `<type>/<issue#>-<slug>`; every commit `type(scope): subject (#issue)` ≤72 chars; intended PR title is conventional-format with the issue ref. Fix violations before anything else.
-2. **Rebase on main**; run the configured verify command (`conventions.verify`) — must pass locally.
-3. **Commits→issues map**: list each commit and its ticket. Any commit with no ticket → stop; apply the unplanned-work rule (trail `note` or a new ticket via triage).
-4. **Security pass (degraded)**: review the full branch diff yourself, adversarially — injection, secrets, shell interpolation of untrusted strings, new dependencies (existence + age), CI/hook attack surface. Journal any finding: `review-finding`.
-5. **AC check (degraded)**: every AC on the ticket maps to a passing test or a documented manual verification in the PR body. No honest map → not ready.
-6. **Honest verification statement** for the PR body: what was run, what passed, what was NOT verified. Never overstate.
-7. Open the PR: title conventional, body = `Closes #<n>` + commits→issues map + AC checklist + honest verification.
-8. Trail: `comment.mjs --phase pr`; when checks finish: `--phase ci-green` (or `--phase gate-fail` with the cause + fix, then repeat).
-9. **CI-green check**: never ask for merge with failing checks.
+1. **Conventions lint** (spec §2): branch matches `<type>/<issue#>-<slug>`; every commit `type(scope): subject (#issue)` ≤72 chars; intended PR title is conventional-format with the issue ref.
+2. **Rebase on main**; run the configured verify command — must pass locally.
+3. **Commits→issues map**: every commit has a ticket; otherwise apply the unplanned-work rule (trail `note` or triage).
+4. **Mechanical gates** (spec §13):
+   - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/plandrift.mjs" --plan <plan>` — off-plan files ⇒ escalate or a reviewer-visible `.forge/scope.json` extension
+   - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/testintent.mjs"` — weakened existing assertions ⇒ explicit reviewer sign-off in the PR body, or revert
+   - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/depguard.mjs"` — new-dependency violations ⇒ remove or escalate
+   - **AC gate**: `vitest run --reporter=json --outputFile=.forge/results.json` then `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/acgate.mjs" --plan <plan> --ticket <n> --results .forge/results.json` — every AC id in a passing test, machine evidence only
+5. **Security pass** (`security` role card on the full branch diff): findings journaled; criticals escalate.
+6. **Review pass** (`reviewer` role card; `design-reviewer` for UI when `features.designReview`).
+7. **Honest verification statement** for the PR body: what ran, what passed, what was NOT verified. Never overstate.
+8. Open the PR: `Closes #<n>` + commits→issues map + AC checklist + honest verification.
+9. Trail: `--phase pr`; on checks: `--phase ci-green` or `--phase gate-fail` (cause + fix, repeat).
+10. **CI-green check**: never ask for merge with failing checks.
 
 ## Escalation triggers during ship (spec §7 — halt, don't improvise)
 

--- a/tests/gates/acgate.test.mjs
+++ b/tests/gates/acgate.test.mjs
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { extractAcIds, flattenResults, checkAcCoverage } from '../../plugin/scripts/gates/acgate.mjs';
+
+const RESULTS = {
+  testResults: [
+    { assertionResults: [
+      { title: 'AC-7.1: ledger round-trips', fullName: 'ledger > AC-7.1: ledger round-trips', status: 'passed' },
+      { title: 'AC-7.2: gate refuses missing acs', fullName: 'gate > AC-7.2: gate refuses missing acs', status: 'failed' },
+      { title: 'unrelated test', fullName: 'misc > unrelated test', status: 'passed' },
+    ] },
+  ],
+};
+
+describe('ac gate (AC-5.2)', () => {
+  it('extracts AC ids from plan text, optionally scoped to a ticket', () => {
+    const plan = '- **AC-7.1** — a\n- **AC-7.2** — b\n**AC map:** AC-7.1, AC-7.2\nAlso mentions AC-3.4 from another epic.';
+    expect(extractAcIds(plan, 7).sort()).toEqual(['AC-7.1', 'AC-7.2']);
+    expect(extractAcIds(plan)).toContain('AC-3.4');
+  });
+
+  it('passes only when every AC id has a passing test; names missing and failing', () => {
+    const tests = flattenResults(RESULTS);
+    const all = checkAcCoverage(['AC-7.1', 'AC-7.2', 'AC-7.3'], tests);
+    expect(all.ok).toBe(false);
+    expect(all.failing).toEqual(['AC-7.2']);
+    expect(all.missing).toEqual(['AC-7.3']);
+    const good = checkAcCoverage(['AC-7.1'], tests);
+    expect(good).toMatchObject({ ok: true, covered: 1 });
+  });
+
+  it('a failing test with the id does not count as coverage even when another test passes without it', () => {
+    const tests = flattenResults(RESULTS);
+    expect(checkAcCoverage(['AC-7.2'], tests).ok).toBe(false);
+  });
+});

--- a/tests/gates/depguard.test.mjs
+++ b/tests/gates/depguard.test.mjs
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { newDeps, checkPackage, runDepGuard, MIN_AGE_DAYS } from '../../plugin/scripts/gates/depguard.mjs';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const noop = () => {};
+const NOW = Date.parse('2026-07-16T00:00:00Z');
+
+function fetchFor(registry) {
+  return async (url) => {
+    if (url.startsWith('https://registry.npmjs.org/')) {
+      const name = decodeURIComponent(url.split('/').pop());
+      const pkg = registry[name];
+      if (!pkg) return { ok: false, status: 404 };
+      return { ok: true, json: async () => ({ time: { created: pkg.created } }) };
+    }
+    if (url.startsWith('https://api.npmjs.org/downloads')) {
+      const name = decodeURIComponent(url.split('/').pop());
+      const pkg = registry[name];
+      return { ok: true, json: async () => ({ downloads: pkg?.downloads ?? 0 }) };
+    }
+    return { ok: false, status: 500 };
+  };
+}
+
+describe('dep guard (AC-5.4)', () => {
+  it('newDeps diffs dependencies + devDependencies vs base', () => {
+    const base = { dependencies: { a: '1' }, devDependencies: { vitest: '3' } };
+    const branch = { dependencies: { a: '1', 'left-pad': '1' }, devDependencies: { vitest: '3', 'brand-new': '0.0.1' } };
+    expect(newDeps(base, branch).sort()).toEqual(['brand-new', 'left-pad']);
+    expect(newDeps(branch, base)).toEqual([]); // removals are fine
+  });
+
+  it('checkPackage: nonexistent, too-young, low-downloads, healthy', async () => {
+    const fetchFn = fetchFor({
+      healthy: { created: '2020-01-01T00:00:00Z', downloads: 100000 },
+      young: { created: '2026-07-01T00:00:00Z', downloads: 100000 },
+      obscure: { created: '2020-01-01T00:00:00Z', downloads: 3 },
+    });
+    expect((await checkPackage('ghost-pkg', { fetchFn, now: NOW })).reason).toContain('does not exist');
+    expect((await checkPackage('young', { fetchFn, now: NOW })).reason).toContain(`< ${MIN_AGE_DAYS}`);
+    expect((await checkPackage('obscure', { fetchFn, now: NOW })).reason).toContain('weekly downloads');
+    expect((await checkPackage('healthy', { fetchFn, now: NOW })).ok).toBe(true);
+  });
+
+  it('runDepGuard: only new deps are checked; violations fail the gate', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-dep-'));
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ dependencies: { existing: '1', 'ghost-pkg': '1' } }), 'utf8');
+    const execFn = async (cmd, args) => ({ ok: true, stdout: JSON.stringify({ dependencies: { existing: '1' } }), stderr: '' });
+    const res = await runDepGuard({ cwd, execFn, fetchFn: fetchFor({}), log: noop });
+    expect(res.ok).toBe(false);
+    expect(res.added).toEqual(['ghost-pkg']);
+    expect(res.violations[0].reason).toContain('does not exist');
+  });
+
+  it('runDepGuard: no new deps passes without registry calls', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-dep-'));
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ dependencies: { existing: '1' } }), 'utf8');
+    let fetched = 0;
+    const execFn = async () => ({ ok: true, stdout: JSON.stringify({ dependencies: { existing: '1' } }), stderr: '' });
+    const res = await runDepGuard({ cwd, execFn, fetchFn: async () => { fetched++; return { ok: false, status: 500 }; }, log: noop });
+    expect(res.ok).toBe(true);
+    expect(fetched).toBe(0);
+  });
+});

--- a/tests/gates/plandrift.test.mjs
+++ b/tests/gates/plandrift.test.mjs
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extractPlanFiles, isAllowed, runPlanDrift, DEFAULT_ALLOW } from '../../plugin/scripts/gates/plandrift.mjs';
+
+const noop = () => {};
+
+describe('plan-drift gate (AC-5.3)', () => {
+  it('extracts Files lists from plan tasks (files, dirs, backticks)', () => {
+    const plan = '### T1\n**Files:** `plugin/scripts/lib/ledger.mjs`, tests/lib/ledger.test.mjs\n### T2\n**Files:** plugin/scripts/gates/ , docs/x.md';
+    const files = extractPlanFiles(plan);
+    expect(files).toContain('plugin/scripts/lib/ledger.mjs');
+    expect(files).toContain('plugin/scripts/gates/');
+  });
+
+  it('isAllowed: declared exact + dir prefixes + scope extras + default allow', () => {
+    const declared = ['src/a.mjs', 'src/widgets/'];
+    expect(isAllowed('src/a.mjs', declared, [], DEFAULT_ALLOW)).toBe(true);
+    expect(isAllowed('src/widgets/deep/b.mjs', declared, [], DEFAULT_ALLOW)).toBe(true);
+    expect(isAllowed('tests/anything.test.mjs', declared, [], DEFAULT_ALLOW)).toBe(true);
+    expect(isAllowed('src/rogue.mjs', declared, [], DEFAULT_ALLOW)).toBe(false);
+    expect(isAllowed('src/rogue.mjs', declared, ['src/rogue.mjs'], DEFAULT_ALLOW)).toBe(true);
+  });
+
+});
+
+describe('plan-drift end-to-end', () => {
+  const noop2 = () => {};
+  async function setup(planBody) {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-drift-'));
+    await mkdir(join(cwd, 'docs'), { recursive: true });
+    await writeFile(join(cwd, 'docs', 'plan.md'), planBody, 'utf8');
+    return cwd;
+  }
+  const gitWith = (files) => async (cmd, args) => ({ ok: true, stdout: files.join('\n') + '\n', stderr: '' });
+
+  it('names deviations and fails', async () => {
+    const cwd = await setup('### T1\n**Files:** src/a.mjs\n');
+    const res = await runPlanDrift({ cwd, planPath: 'docs/plan.md', execFn: gitWith(['src/a.mjs', 'src/rogue.mjs']), log: noop2 });
+    expect(res.ok).toBe(false);
+    expect(res.deviations).toEqual(['src/rogue.mjs']);
+  });
+
+  it('scope.json extension + default-allowed dirs pass', async () => {
+    const cwd = await setup('### T1\n**Files:** src/a.mjs\n');
+    await mkdir(join(cwd, '.forge'), { recursive: true });
+    await writeFile(join(cwd, '.forge', 'scope.json'), JSON.stringify({ files: ['src/extra.mjs'] }), 'utf8');
+    const res = await runPlanDrift({ cwd, planPath: 'docs/plan.md', execFn: gitWith(['src/a.mjs', 'src/extra.mjs', 'tests/a.test.mjs', 'docs/notes.md']), log: noop2 });
+    expect(res).toMatchObject({ ok: true, deviations: [] });
+  });
+
+  it('refuses a plan with no Files lists', async () => {
+    const cwd = await setup('# plan with no file contract\n');
+    const res = await runPlanDrift({ cwd, planPath: 'docs/plan.md', execFn: gitWith([]), log: noop2 });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('**Files:**');
+  });
+});

--- a/tests/gates/testintent.test.mjs
+++ b/tests/gates/testintent.test.mjs
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { findWeakenings, runTestIntent } from '../../plugin/scripts/gates/testintent.mjs';
+
+const noop = () => {};
+
+const DIFF_WEAKENED = [
+  'diff --git a/tests/a.test.mjs b/tests/a.test.mjs',
+  '--- a/tests/a.test.mjs',
+  '+++ b/tests/a.test.mjs',
+  '@@ -10,1 +10,0 @@',
+  "-    expect(res.ok).toBe(true);",
+  '@@ -20,0 +20,1 @@',
+  "+    const x = 1;",
+].join('\n');
+
+const DIFF_ADDITIONS_ONLY = [
+  '--- a/tests/a.test.mjs',
+  '+++ b/tests/a.test.mjs',
+  '@@ -20,0 +20,2 @@',
+  "+    expect(more.coverage).toBe(true);",
+  "+    expect(extra).toEqual(1);",
+].join('\n');
+
+describe('test-intent gate (AC-5.5)', () => {
+  it('flags removed assertion lines in pre-existing test files', () => {
+    const w = findWeakenings(DIFF_WEAKENED, []);
+    expect(w.length).toBe(1);
+    expect(w[0]).toMatchObject({ file: 'tests/a.test.mjs' });
+    expect(w[0].line).toContain('expect(res.ok)');
+  });
+
+  it('pure additions pass; new test files pass entirely', () => {
+    expect(findWeakenings(DIFF_ADDITIONS_ONLY, [])).toEqual([]);
+    expect(findWeakenings(DIFF_WEAKENED, ['tests/a.test.mjs'])).toEqual([]); // whole file is new
+  });
+
+  it('non-assertion removals (setup lines) pass', () => {
+    const diff = ['+++ b/tests/a.test.mjs', "-    const helper = makeHelper();"].join('\n');
+    expect(findWeakenings(diff, [])).toEqual([]);
+  });
+
+  it('runTestIntent wires git diffs and fails on weakenings', async () => {
+    const execFn = async (cmd, args) => {
+      if (args.includes('--name-status')) return { ok: true, stdout: 'M\ttests/a.test.mjs\n', stderr: '' };
+      return { ok: true, stdout: DIFF_WEAKENED, stderr: '' };
+    };
+    const res = await runTestIntent({ cwd: '.', execFn, log: noop });
+    expect(res.ok).toBe(false);
+    expect(res.weakenings.length).toBe(1);
+
+    const clean = async (cmd, args) => ({ ok: true, stdout: args.includes('--name-status') ? 'A\ttests/new.test.mjs\n' : DIFF_ADDITIONS_ONLY, stderr: '' });
+    const pass = await runTestIntent({ cwd: '.', execFn: clean, log: noop });
+    expect(pass.ok).toBe(true);
+  });
+});

--- a/tests/lib/ledger.test.mjs
+++ b/tests/lib/ledger.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseLedger, renderLedger, initLedger, markTask, nextTask, LEDGER_RELPATH } from '../../plugin/scripts/lib/ledger.mjs';
+
+const TASKS = [
+  { id: 'T1', title: 'ledger lib' },
+  { id: 'T2', title: 'ac gate' },
+  { id: 'T3', title: 'ship' },
+];
+
+async function tmp() {
+  return mkdtemp(join(tmpdir(), 'forge-ledger-'));
+}
+
+describe('ledger (AC-5.6)', () => {
+  it('init → parse round-trip; re-init keeps existing state', async () => {
+    const cwd = await tmp();
+    const first = await initLedger(cwd, { ticket: 7, planPath: 'docs/plans/x.md', tasks: TASKS });
+    expect(first.existed).toBe(false);
+    expect(first.tasks.length).toBe(3);
+    await markTask(cwd, 'T1', 'done');
+    const again = await initLedger(cwd, { ticket: 7, planPath: 'docs/plans/x.md', tasks: TASKS });
+    expect(again.existed).toBe(true);
+    expect(again.tasks.find((t) => t.id === 'T1').status).toBe('done');
+  });
+
+  it('markTask transitions + notes; unknown id errors with the id list', async () => {
+    const cwd = await tmp();
+    await initLedger(cwd, { ticket: 7, planPath: 'p', tasks: TASKS });
+    await markTask(cwd, 'T1', 'in-progress');
+    await markTask(cwd, 'T1', 'done', 'tests green');
+    const text = await readFile(join(cwd, LEDGER_RELPATH), 'utf8');
+    expect(text).toContain('- [x] T1 — ledger lib');
+    expect(text).toContain('  tests green');
+    const bad = await markTask(cwd, 'T9', 'done');
+    expect(bad.ok).toBe(false);
+    expect(bad.error).toContain('T1, T2, T3');
+  });
+
+  it('nextTask = resume protocol: first non-done; null when all done; empty when no ledger', async () => {
+    const cwd = await tmp();
+    expect((await nextTask(cwd)).empty).toBe(true);
+    await initLedger(cwd, { ticket: 7, planPath: 'p', tasks: TASKS });
+    await markTask(cwd, 'T1', 'done');
+    await markTask(cwd, 'T2', 'in-progress');
+    const n = await nextTask(cwd);
+    expect(n.task.id).toBe('T2'); // in-progress counts as not done
+    expect(n.done).toBe(1);
+    await markTask(cwd, 'T2', 'done');
+    await markTask(cwd, 'T3', 'done');
+    expect((await nextTask(cwd)).task).toBe(null);
+  });
+
+  it('parse is CRLF-safe', () => {
+    const tasks = parseLedger('# h\r\n\r\n- [x] T1 — a\r\n- [ ] T2 — b\r\n  note line\r\n');
+    expect(tasks.length).toBe(2);
+    expect(tasks[1].notes).toEqual(['note line']);
+    expect(renderLedger('# h', tasks)).toContain('- [ ] T2 — b');
+  });
+});


### PR DESCRIPTION
Closes #7 (SP5, plan: docs/plans/2026-07-16-sp5-plan-execute.md)

## AC checklist
- [x] **AC-5.1** forge:plan skill + machine-parseable template (Files / AC map lines) — this epic's own plan retrofitted to it
- [x] **AC-5.2** acgate: AC ids vs vitest JSON, passing-test requirement, missing/failing named — test-verified AND live (5 machinery ACs ✓ against this branch's real results.json)
- [x] **AC-5.3** plandrift: declared + scope.json + default-allow, deviations named — test-verified AND live (14 touched files, clean, against this plan's Files lists)
- [x] **AC-5.4** depguard: exists/age/downloads for new deps only — test-verified AND live (no new deps ✓)
- [x] **AC-5.5** testintent: removed assertions in pre-existing tests flagged, additions/new files pass — test-verified AND live (clean ✓)
- [x] **AC-5.6** ledger: init/mark/next resume protocol, CRLF-safe — test-verified
- [ ] **AC-5.7** skills shipped + CI green win+linux — this PR's checks

## Honest verification
167/167 tests locally (Windows). All four gates ran live against this very branch post-commit. Honest notes: AC-5.1/5.7 are doc/CI ACs with no test mapping (the acgate live run used the five machinery ACs via --acs); forge's own plans number ACs by sub-project (AC-5.x on ticket #7) — consumer repos should use AC-<ticket>.<n> per the template, and the gate supports both via --acs / --plan-without-ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x