### PR TITLE
feat: SP6 ideate + brainstorm + spike + design (#8)

### DIFF
--- a/plugin/scripts/design/speclint.mjs
+++ b/plugin/scripts/design/speclint.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Visual-spec lint (spec §4 item 11): a design doc must carry every mandatory
+ * section — sections are grammar, not decoration. Used by forge:design before
+ * the decision comment and by design-reviewer/ship afterwards.
+ */
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const MANDATORY_SECTIONS = [
+  'States matrix',
+  'Breakpoints',
+  'Themes',
+  'A11y contract',
+  'Motion',
+  'Token delta',
+];
+
+const REQUIRED_STATES = ['default', 'hover', 'focus', 'active', 'disabled', 'loading', 'empty', 'error'];
+
+export function lintSpec(text) {
+  const problems = [];
+  for (const s of MANDATORY_SECTIONS) {
+    if (!new RegExp(`^##\\s+${s}\\b`, 'mi').test(text ?? '')) problems.push(`missing section: ## ${s}`);
+  }
+  if (/^##\s+States matrix/mi.test(text ?? '')) {
+    for (const st of REQUIRED_STATES) {
+      if (!new RegExp(`^\\|\\s*${st}\\b`, 'mi').test(text)) problems.push(`states matrix missing row: ${st}`);
+    }
+  }
+  // token governance tripwire: raw hex colors outside the token-delta section are one-offs
+  const tokenDeltaIdx = (text ?? '').search(/^##\s+Token delta/mi);
+  const beforeDelta = tokenDeltaIdx >= 0 ? text.slice(0, tokenDeltaIdx) : (text ?? '');
+  const hexes = [...beforeDelta.matchAll(/#[0-9a-fA-F]{6}\b/g)].map((m) => m[0]);
+  for (const h of [...new Set(hexes)]) problems.push(`one-off value ${h} — reference a token instead (token governance)`);
+  return { ok: problems.length === 0, problems };
+}
+
+export async function runSpecLint(path, log = console.log) {
+  let text;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch {
+    return { ok: false, problems: [`spec not readable: ${path}`] };
+  }
+  const res = lintSpec(text);
+  for (const p of res.problems) log(`✗ ${p}`);
+  log(res.ok ? 'spec-lint: all mandatory sections present' : `spec-lint: ${res.problems.length} problem(s)`);
+  return res;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const path = process.argv[2];
+  if (!path) { console.error('usage: speclint.mjs <docs/design/spec.md>'); process.exit(2); }
+  runSpecLint(path).then((res) => process.exit(res.ok ? 0 : 1));
+}

--- a/plugin/skills/brainstorm/SKILL.md
+++ b/plugin/skills/brainstorm/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: brainstorm
+description: Ticketed feature → design spec with self-review and the owner approval gate. Use before planning any non-trivial feature; the approved spec feeds forge:plan.
+---
+
+# forge:brainstorm
+
+Ticketed feature → approved design spec (spec §4 item 3). The spec is the thinking; the plan is the contract; don't blur them.
+
+## Steps
+
+1. **Decomposition-first** for multi-system asks: if the ticket spans systems, split the spec into sub-designs with explicit seams before designing any one part.
+2. **Explore before committing**: consider ≥2 approaches; record the losing one and why in one paragraph (future-you's ADR material). Genuinely open questions → a `forge:spike` first, not guesses.
+3. **Write the spec** into `conventions.specsDir` (`<date>-<slug>.md`): problem, constraints, chosen design, alternatives considered, risks, out-of-scope. Terse over thorough-looking.
+4. **Self-review pass** before the gate: internal contradictions, unstated assumptions, missing failure modes, "why is this needed at all". Fix what you find; note what you fixed.
+5. **Approval gate** — a spec approval is a scheduled decision comment (spec §7), same mechanism as every human decision:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/board/escalate.mjs" --issue <n> --reason "spec approval: <spec link>" --options "approve|request changes" --recommend approve --context "<3-line summary>"
+```
+
+6. **Wait for the resolved answer** (`escalate.mjs --check --issue <n>`): "approve" → move the ticket back to `inProgress`, commit the spec (`docs(spec): … (#n)`), update the route index, trail `--phase spec`, hand to `forge:plan`. "request changes" → address, update the same decision thread, repeat.
+
+Never start planning from an unapproved spec — the gate is the point.

--- a/plugin/skills/design/SKILL.md
+++ b/plugin/skills/design/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: design
+description: UI ticket → token-grounded mockup variants → human pick → committed visual spec. Use for UI-flagged tickets before forge:plan (NEW-component mode; iterate/system modes arrive with the graph).
+---
+
+# forge:design
+
+Ticketed UI feature → approved visual spec in `docs/design/` (spec §4 item 11). **NEW mode only until SP8** — iterating an existing component or changing tokens system-wide needs the graph's `who_uses`; until then those route through a spike + owner decision.
+
+## Steps
+
+1. **Load the real tokens** (the repo's design-token source). Every visual decision references them; a value that isn't a token goes in the token-delta proposal, never inline.
+2. **Generate 2–3 genuinely distinct variants** (designer role card): different layout/interaction approaches, each as working HTML/component code, each covering the states matrix, ≥3 widths, all configured themes, with the a11y contract designed in.
+3. **Present variants** for the human pick via the decision mechanism (spec §7):
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/board/escalate.mjs" --issue <n> --reason "design pick: <component>" --options "variant A — <one-liner>|variant B — <one-liner>|variant C — <one-liner>" --context "<where to view them>"
+```
+
+4. **On the resolved pick** (`escalate.mjs --check`): move the ticket back to `inProgress`, graduate the chosen variant into `docs/design/<date>-<component>.md` using the template (`plugin/templates/visual-spec.md` — every section filled, including the token delta with any proposed new tokens).
+5. **Lint before committing**: `node "${CLAUDE_PLUGIN_ROOT}/scripts/design/speclint.mjs" docs/design/<file>.md` — missing sections or one-off values are not committable.
+6. Commit (`docs(design): … (#n)`), route index, trail `--phase spec` with the link. The spec now feeds `forge:plan`; `design-reviewer` validates the implementation against it at execute/ship.
+
+**Token governance:** new tokens enter only through this spec's approval. Mockup code is design-lane output — it reaches production only through plan → execute with tests, never copied straight in.

--- a/plugin/skills/ideate/SKILL.md
+++ b/plugin/skills/ideate/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: ideate
+description: Whole feature area → decomposed epic + child tickets with ACs and board placement. Use for feature areas and product ideas; single items go to forge:triage instead.
+---
+
+# forge:ideate
+
+Raw idea / feature area → the ticket tree, so work starts ticket-first (spec §4 item 1).
+
+## Steps
+
+1. **Ground in product context**: read `docs/product/` (vision, roadmap, PRDs) when present — proposals must serve the recorded direction, not drift from it. No product docs → say so and proceed from the request alone.
+2. **Feature brainstorm**: enumerate what the area could include; mark each item in/out with one line of reasoning. Divergent first, then cut hard — an epic with 12 children is a planning failure, aim for 3–7.
+3. **Dedup** (spec §4): search open items and the board before creating anything; overlaps get linked, not duplicated.
+4. **Decompose**: each child independently shippable where possible; explicit dependency notes where not (build order = dependency order).
+5. **Per child**: title (imperative), 2–5 verifiable ACs, type/size/priority, UI-flag note when it needs the design lane.
+6. **Create the tree** via the board scripts — epic first, then children with `--parent`:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/board/create.mjs" --title "…" --type epic --priority p1 --size l --status backlog
+node "${CLAUDE_PLUGIN_ROOT}/scripts/board/create.mjs" --title "…" --type item --parent <epic#> --priority p1 --size m --status backlog [--assignee <per team policy>]
+```
+
+7. Refresh the epic digest (`digest.mjs --epic <n>`), trail-comment the epic with the decomposition rationale, and report the tree with links.
+
+Escalate (decision comment) when the area implies a direction change from `docs/product/` — that's the owner's call, not ideation's.

--- a/plugin/skills/ship/SKILL.md
+++ b/plugin/skills/ship/SKILL.md
@@ -9,7 +9,7 @@ Branch → PR with gates, then the post-merge ritual. Since SP5 the core gates a
 
 ## Pre-PR checklist (in order — a failed gate stops the ritual)
 
-1. **Conventions lint** (spec §2): branch matches `<type>/<issue#>-<slug>`; every commit `type(scope): subject (#issue)` ≤72 chars; intended PR title is conventional-format with the issue ref.
+1. **Conventions lint** (spec §2): branch matches `<type>/<issue#>-<slug>`; every commit `type(scope): subject (#issue)` ≤72 chars; intended PR title is conventional-format with the issue ref. **Spike branches never ship** — a `spike/…` branch asking for a PR is refused outright (spec §4 item 12: findings merge as ADRs, code is re-implemented via plan/execute).
 2. **Rebase on main**; run the configured verify command — must pass locally.
 3. **Commits→issues map**: every commit has a ticket; otherwise apply the unplanned-work rule (trail `note` or triage).
 4. **Mechanical gates** (spec §13):

--- a/plugin/skills/spike/SKILL.md
+++ b/plugin/skills/spike/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: spike
+description: Time-boxed research — throwaway exploration on a spike branch that never merges; the deliverable is a findings doc or ADR. Use for "which library", "is X possible", "prototype this" questions.
+---
+
+# forge:spike
+
+Finding out, not building (spec §4 item 12). Opposite rules from the Build lane, on purpose.
+
+## Rules
+
+- **Time-boxed**: agree the box up front (default: half a day). When it expires, write up what you have — "inconclusive, here's what we learned" is a legitimate finding.
+- **Branch**: `spike/<issue#>-<slug>`. It **never merges** — forge:ship refuses spike branches; the branch is deleted after the write-up. Code quality rules don't apply here; TDD doesn't apply here.
+- **Ticket-first still applies**: spikes have tickets (type `item`, the question as the title, "decision recorded" as the AC).
+
+## Steps
+
+1. State the question and the decision it feeds in one sentence each — a spike without a decision attached is procrastination.
+2. Explore on the spike branch: prototype, measure, read source, try the API. Optimize for information per hour.
+3. Write the finding as a numbered ADR in `docs/decisions/` (next number; context → finding → decision → consequences) or, when it's purely informational, a findings note the brainstorm spec links to.
+4. Route index + trail comment (`--phase note`, link the ADR) + close or hand the ticket to its consumer (brainstorm/plan).
+5. Delete the spike branch: `git branch -D spike/<…>` — anything worth keeping is *re-implemented properly* through plan/execute, never cherry-picked.
+
+Escalate when the finding invalidates an approved spec or implies spend (paid services, new infra) — that's a decision, not a finding.

--- a/plugin/templates/visual-spec.md
+++ b/plugin/templates/visual-spec.md
@@ -1,0 +1,45 @@
+# Visual spec — {{COMPONENT}} (#{{TICKET}})
+
+<!-- forge visual-spec template (spec §4 item 11). Every section below is
+mandatory — speclint.mjs enforces their presence; design-reviewer validates
+the implementation against their content. -->
+
+## Summary
+One paragraph: what this is, where it lives, the chosen variant's rationale.
+
+## States matrix
+| state | normal content | long content | extreme content |
+| --- | --- | --- | --- |
+| default | | | |
+| hover | | | |
+| focus | | | |
+| active | | | |
+| disabled | | | |
+| loading | | | |
+| empty | | | |
+| error | | | |
+
+## Breakpoints
+Rendered at (≥3 widths): mobile 375 · tablet 768 · desktop 1280. Notes per width.
+
+## Themes
+Rendered in every configured theme (light / dark / …). Token-driven differences only.
+
+## A11y contract
+- Focus order:
+- Roles / accessible names:
+- Contrast pairs (token references):
+- Target sizes:
+- Reduced motion behavior:
+
+## Motion
+| element | property | duration token | easing token | reduced-motion |
+| --- | --- | --- | --- | --- |
+
+## Token delta
+- Tokens used:
+- New tokens proposed (token governance — these enter only through this spec's approval):
+- One-off values: none (by definition — a one-off is a finding)
+
+## Graph ripple
+_(iterate/system modes — SP8. For NEW components: "new component, no consumers yet.")_

--- a/tests/design/speclint.test.mjs
+++ b/tests/design/speclint.test.mjs
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { lintSpec, MANDATORY_SECTIONS } from '../../plugin/scripts/design/speclint.mjs';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function completeSpec() {
+  return [
+    '# Visual spec — Button (#15)',
+    '## Summary', 'A button.',
+    '## States matrix',
+    '| state | normal content | long content | extreme content |',
+    '| --- | --- | --- | --- |',
+    ...['default', 'hover', 'focus', 'active', 'disabled', 'loading', 'empty', 'error'].map((s) => `| ${s} | ok | ok | ok |`),
+    '## Breakpoints', '375 / 768 / 1280.',
+    '## Themes', 'light + dark via tokens.',
+    '## A11y contract', '- Focus order: natural',
+    '## Motion', '| el | prop | duration | easing | reduced |',
+    '## Token delta', '- Tokens used: color.accent (#aabbcc is fine here)',
+  ].join('\n');
+}
+
+describe('speclint (AC-6.5)', () => {
+  it('the shipped template itself passes the lint', async () => {
+    const tpl = await readFile(join(root, 'plugin', 'templates', 'visual-spec.md'), 'utf8');
+    const res = lintSpec(tpl);
+    expect(res.problems).toEqual([]);
+  });
+
+  it('a complete spec passes', () => {
+    expect(lintSpec(completeSpec())).toMatchObject({ ok: true, problems: [] });
+  });
+
+  it('names each missing section', () => {
+    const res = lintSpec('# Visual spec\n## Summary\nwords\n## Themes\nok');
+    expect(res.ok).toBe(false);
+    for (const s of MANDATORY_SECTIONS.filter((s) => s !== 'Themes')) {
+      expect(res.problems.some((p) => p.includes(s)), s).toBe(true);
+    }
+  });
+
+  it('names missing states-matrix rows', () => {
+    const spec = completeSpec().replace('| loading | ok | ok | ok |\n', '');
+    const res = lintSpec(spec);
+    expect(res.problems).toContain('states matrix missing row: loading');
+  });
+
+  it('token governance: raw hex outside Token delta is a one-off finding; inside is fine', () => {
+    const bad = completeSpec().replace('375 / 768 / 1280.', 'border color #ff0000 at 375.');
+    const res = lintSpec(bad);
+    expect(res.problems.some((p) => p.includes('#ff0000'))).toBe(true);
+    expect(lintSpec(completeSpec()).ok).toBe(true); // hex inside Token delta allowed
+  });
+});


### PR DESCRIPTION
Closes #8 (SP6, plan: docs/plans/2026-07-17-sp6-ideate-brainstorm-spike-design.md)

## AC checklist
- [x] **AC-6.1** forge:ideate — product-grounded, dedup-first, epic tree via create.mjs with parent links
- [x] **AC-6.2** forge:brainstorm — decomposition-first, self-review, approval gate = scheduled decision comment (escalate.mjs), proceeds only from a resolved answer
- [x] **AC-6.3** forge:spike — spike/ branches never merge (ship lint line added), findings → numbered ADR + route index
- [x] **AC-6.4** forge:design NEW mode — variants → decision-comment pick → visual spec from template, token governance; iterate/system explicitly deferred to SP8
- [x] **AC-6.5** speclint — mandatory sections + states rows + one-off-hex tripwire; the shipped template lints clean (test + live run)
- [ ] **AC-6.6** CI green win+linux — this PR's checks

## Gates (run on this branch)
plandrift ✓ (all files declared) · testintent ✓ (one ship SKILL line changed — not a test) · depguard ✓ (no new deps)

## Honest verification
172/172 tests locally (Windows). Skills are markdown — per the spec's dogfooding rule they retire their superpowers counterparts only after real use; the first live ideate/brainstorm run is the next real feature. **After this merges, the spec's migration condition is met: ship, plan+execute, and brainstorm all have forge counterparts — superpowers can be uninstalled from cms (owner action, cms checkout).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x