### PR TITLE
feat: SP8 graph RAG MCP server — index, tools, incremental (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "verify": "vitest run"
   },
   "devDependencies": {
+    "ts-morph": "^28.0.0",
     "vitest": "^3.2.4"
   }
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -4,5 +4,11 @@
   "description": "AI dev platform: pipeline skills, agent roster with pluggable backends, GitHub Projects board automation, learning loop, graph RAG",
   "author": {
     "name": "dngioi.dev"
+  },
+  "mcpServers": {
+    "forge-graph": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp/graph/server.mjs"]
+    }
   }
 }

--- a/plugin/mcp/graph/db.mjs
+++ b/plugin/mcp/graph/db.mjs
@@ -1,0 +1,85 @@
+/**
+ * Graph store (spec §9; SP8 T1): SQLite via built-in node:sqlite — no native
+ * builds on Windows, zero deps. Parameterized SQL ONLY; every statement takes
+ * bound values. The embedding column is a schema slot (spec backlog), unused.
+ */
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+export const DB_RELPATH = join('.forge', 'graph.db');
+
+export const NODE_KINDS = ['file', 'component', 'export', 'props-interface', 'token', 'story', 'test', 'icon', 'ticket'];
+export const EDGE_KINDS = ['imports', 'renders', 'uses-token', 'tests', 'documents', 'ticket'];
+
+const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS nodes (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    file TEXT,
+    meta TEXT,
+    embedding BLOB
+  );
+  CREATE INDEX IF NOT EXISTS idx_nodes_kind_name ON nodes(kind, name);
+  CREATE INDEX IF NOT EXISTS idx_nodes_file ON nodes(file);
+  CREATE TABLE IF NOT EXISTS edges (
+    src TEXT NOT NULL,
+    dst TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    PRIMARY KEY (src, dst, kind)
+  );
+  CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst, kind);
+`;
+
+export function openDb(cwd, { memory = false } = {}) {
+  let db;
+  if (memory) {
+    db = new DatabaseSync(':memory:');
+  } else {
+    const path = join(cwd, DB_RELPATH);
+    mkdirSync(dirname(path), { recursive: true });
+    db = new DatabaseSync(path);
+  }
+  db.exec(SCHEMA);
+  return db;
+}
+
+/** Rebuild = wipe and repopulate; the graph is derived state, always safe to drop. */
+export function resetDb(db) {
+  db.exec('DELETE FROM edges; DELETE FROM nodes;');
+}
+
+export function upsertNode(db, { id, kind, name, file = null, meta = null }) {
+  if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind '${kind}' — valid: ${NODE_KINDS.join(', ')}`);
+  db.prepare(
+    'INSERT INTO nodes (id, kind, name, file, meta) VALUES (?, ?, ?, ?, ?) ' +
+    'ON CONFLICT(id) DO UPDATE SET kind = excluded.kind, name = excluded.name, file = excluded.file, meta = excluded.meta',
+  ).run(id, kind, name, file, meta == null ? null : JSON.stringify(meta));
+}
+
+export function upsertEdge(db, { src, dst, kind }) {
+  if (!EDGE_KINDS.includes(kind)) throw new Error(`unknown edge kind '${kind}' — valid: ${EDGE_KINDS.join(', ')}`);
+  db.prepare('INSERT OR IGNORE INTO edges (src, dst, kind) VALUES (?, ?, ?)').run(src, dst, kind);
+}
+
+/**
+ * Incremental unit: drop what a file CONTRIBUTED before re-adding it — only
+ * edges originating (src) in the file's scope. Edges pointing AT this file
+ * belong to other files' scopes and must survive a reindex of this one;
+ * ticket edges originate from ticket nodes and are untouched by design.
+ */
+export function deleteFileScope(db, file) {
+  const ids = db.prepare('SELECT id FROM nodes WHERE file = ? OR id = ?').all(file, `file:${file}`).map((r) => r.id);
+  if (ids.length === 0) return;
+  const ph = ids.map(() => '?').join(', ');
+  db.prepare(`DELETE FROM edges WHERE src IN (${ph})`).run(...ids);
+  db.prepare(`DELETE FROM nodes WHERE id IN (${ph})`).run(...ids);
+}
+
+export function counts(db) {
+  return {
+    nodes: db.prepare('SELECT COUNT(*) AS n FROM nodes').get().n,
+    edges: db.prepare('SELECT COUNT(*) AS n FROM edges').get().n,
+  };
+}

--- a/plugin/mcp/graph/indexer.mjs
+++ b/plugin/mcp/graph/indexer.mjs
@@ -1,0 +1,143 @@
+/**
+ * Structural indexer (spec §9; SP8 T2). ts-morph is resolved lazily FROM THE
+ * CONSUMER REPO — forge itself ships no runtime dependencies; a TS project is
+ * where TS tooling lives. Non-TS repos never index: librarian stays grep-first
+ * and scoper import-scan, permanently (spec §9 — a fallback, not a stopgap).
+ *
+ * Heuristics (documented, deliberately simple):
+ *  - component = exported function/class with an uppercase-first name declared
+ *    in a .tsx/.jsx file
+ *  - props-interface = interface/type alias named *Props
+ *  - file kind: *.test.*|*.spec.* -> test, *.stories.* -> story, else file
+ *  - edge kind follows the importer: test -> tests, story -> documents,
+ *    else imports; renders = JSX tags resolved to known components
+ */
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { upsertNode, upsertEdge, deleteFileScope, resetDb } from './db.mjs';
+
+export function fileKind(rel) {
+  if (/\.(test|spec)\.[cm]?[jt]sx?$/.test(rel)) return 'test';
+  if (/\.stories\.[cm]?[jt]sx?$/.test(rel)) return 'story';
+  return 'file';
+}
+
+export function edgeKindFor(importerKind) {
+  return importerKind === 'test' ? 'tests' : importerKind === 'story' ? 'documents' : 'imports';
+}
+
+const posix = (p) => p.split('\\').join('/');
+
+export async function loadTsMorph(cwd) {
+  try {
+    const req = createRequire(join(cwd, 'package.json'));
+    return { ok: true, tsMorph: req('ts-morph') };
+  } catch {
+    return {
+      ok: false,
+      error:
+        'ts-morph is not resolvable from this repo — the graph indexes TypeScript projects only. ' +
+        'TS repo: `npm i -D ts-morph` (or pnpm/yarn) and re-run. ' +
+        'Non-TS repo: leave features.graph off — librarian works grep-first and scoper import-scans; ' +
+        'that fallback is permanent, not a stopgap (spec §9).',
+    };
+  }
+}
+
+export async function makeProject(cwd) {
+  const loaded = await loadTsMorph(cwd);
+  if (!loaded.ok) return loaded;
+  const { Project } = loaded.tsMorph;
+  const tsconfig = join(cwd, 'tsconfig.json');
+  const project = existsSync(tsconfig)
+    ? new Project({ tsConfigFilePath: tsconfig })
+    : new Project({ compilerOptions: { allowJs: false, jsx: 2 /* React */ } });
+  if (!existsSync(tsconfig)) project.addSourceFilesAtPaths([join(cwd, '**/*.{ts,tsx}'), '!**/node_modules/**']);
+  return { ok: true, project, tsMorph: loaded.tsMorph };
+}
+
+function relOf(cwd, sourceFile) {
+  return posix(relative(cwd, sourceFile.getFilePath()));
+}
+
+/** Index one ts-morph SourceFile into the db. Returns node/edge tallies. */
+export function indexSourceFile(db, cwd, sf) {
+  const rel = relOf(cwd, sf);
+  const kind = fileKind(rel);
+  deleteFileScope(db, rel);
+  upsertNode(db, { id: `file:${rel}`, kind, name: rel, file: rel });
+
+  const componentNames = new Set();
+  const importedFrom = new Map(); // local name -> imported file rel
+
+  for (const imp of sf.getImportDeclarations()) {
+    const target = imp.getModuleSpecifierSourceFile();
+    if (!target || target.isInNodeModules()) continue;
+    const targetRel = relOf(cwd, target);
+    upsertEdge(db, { src: `file:${rel}`, dst: `file:${targetRel}`, kind: edgeKindFor(kind) });
+    for (const named of imp.getNamedImports()) importedFrom.set(named.getName(), targetRel);
+    const def = imp.getDefaultImport();
+    if (def) importedFrom.set(def.getText(), targetRel);
+  }
+
+  const isComponentFile = /\.[jt]sx$/.test(rel);
+  for (const [name, decls] of sf.getExportedDeclarations()) {
+    const decl = decls[0];
+    if (!decl) continue;
+    const declKind = decl.getKindName();
+    upsertNode(db, { id: `export:${rel}#${name}`, kind: 'export', name, file: rel, meta: { declKind } });
+    const isCallable = /FunctionDeclaration|ArrowFunction|ClassDeclaration|VariableDeclaration/.test(declKind);
+    if (isComponentFile && isCallable && /^[A-Z]/.test(name)) {
+      upsertNode(db, { id: `component:${rel}#${name}`, kind: 'component', name, file: rel });
+      componentNames.add(name);
+    }
+    if (/InterfaceDeclaration|TypeAliasDeclaration/.test(declKind) && /Props$/.test(name)) {
+      const members = typeof decl.getMembers === 'function'
+        ? decl.getMembers().map((m) => (typeof m.getName === 'function' ? m.getName() : null)).filter(Boolean)
+        : [];
+      upsertNode(db, { id: `props:${rel}#${name}`, kind: 'props-interface', name, file: rel, meta: { members } });
+    }
+  }
+
+  // renders: JSX tags inside this file resolved to local or imported components
+  if (isComponentFile && componentNames.size > 0) {
+    const tags = new Set();
+    // kind-name match, not SyntaxKind numbers — those shift between TS versions
+    for (const el of sf.getDescendants()) {
+      if (!/^Jsx(OpeningElement|SelfClosingElement)$/.test(el.getKindName())) continue;
+      const tag = el.getTagNameNode().getText();
+      if (/^[A-Z]/.test(tag)) tags.add(tag);
+    }
+    for (const src of componentNames) {
+      for (const tag of tags) {
+        if (tag === src) continue;
+        const targetRel = componentNames.has(tag) ? rel : importedFrom.get(tag);
+        if (targetRel) upsertEdge(db, { src: `component:${rel}#${src}`, dst: `component:${targetRel}#${tag}`, kind: 'renders' });
+      }
+    }
+  }
+  return rel;
+}
+
+export async function rebuild(db, cwd) {
+  const made = await makeProject(cwd);
+  if (!made.ok) return made;
+  resetDb(db); // ticket edges are re-derived by graphctl tickets after a rebuild
+  const files = made.project.getSourceFiles().filter((sf) => !sf.isInNodeModules() && !sf.isDeclarationFile());
+  for (const sf of files) indexSourceFile(db, cwd, sf);
+  return { ok: true, files: files.length };
+}
+
+export async function indexFiles(db, cwd, paths) {
+  const made = await makeProject(cwd);
+  if (!made.ok) return made;
+  let n = 0;
+  for (const p of paths) {
+    const sf = made.project.getSourceFile(join(cwd, p)) ?? made.project.addSourceFileAtPathIfExists(join(cwd, p));
+    if (!sf) { deleteFileScope(db, posix(p)); continue; } // deleted file: drop its rows
+    indexSourceFile(db, cwd, sf);
+    n++;
+  }
+  return { ok: true, files: n };
+}

--- a/plugin/mcp/graph/queries.mjs
+++ b/plugin/mcp/graph/queries.mjs
@@ -1,0 +1,88 @@
+/**
+ * Graph queries (spec §9; SP8 T3) — the six MCP tools' logic, pure over the
+ * db handle. Parameterized SQL only. Ranked matches are keyword heuristics,
+ * not embeddings (schema slot reserved; spec backlog).
+ */
+
+const parseMeta = (r) => ({ ...r, meta: r.meta ? JSON.parse(r.meta) : null });
+
+export function findComponent(db, query) {
+  const like = `%${query}%`;
+  return db.prepare(
+    "SELECT id, kind, name, file, meta FROM nodes WHERE kind IN ('component', 'export') AND name LIKE ? ORDER BY kind, name LIMIT 25",
+  ).all(like).map(parseMeta);
+}
+
+/** Direct users of a symbol (renders edges) or token (uses-token edges), plus file-level importers. */
+export function whoUses(db, symbol) {
+  const direct = db.prepare(
+    "SELECT e.src, e.kind, n.file FROM edges e LEFT JOIN nodes n ON n.id = e.src " +
+    "WHERE e.kind IN ('renders', 'uses-token') AND (e.dst LIKE ? OR e.dst = ?) LIMIT 100",
+  ).all(`%#${symbol}`, symbol).map((r) => ({ user: r.src, via: r.kind, file: r.file }));
+  const files = db.prepare('SELECT file FROM nodes WHERE name = ? AND file IS NOT NULL').all(symbol).map((r) => r.file);
+  const importers = files.length === 0 ? [] : db.prepare(
+    `SELECT DISTINCT e.src FROM edges e WHERE e.kind IN ('imports', 'tests', 'documents') AND e.dst IN (${files.map(() => '?').join(', ')})`,
+  ).all(...files.map((f) => `file:${f}`)).map((r) => ({ user: r.src, via: 'imports-file' }));
+  return [...direct, ...importers];
+}
+
+/** Props interfaces ranked by member overlap with the given member list. */
+export function similarProps(db, members) {
+  const want = new Set(members.map((m) => m.toLowerCase()));
+  return db.prepare("SELECT id, name, file, meta FROM nodes WHERE kind = 'props-interface'").all()
+    .map(parseMeta)
+    .map((r) => {
+      const have = (r.meta?.members ?? []).map((m) => m.toLowerCase());
+      const overlap = have.filter((m) => want.has(m)).length;
+      return { ...r, overlap, of: want.size };
+    })
+    .filter((r) => r.overlap > 0)
+    .sort((a, b) => b.overlap - a.overlap)
+    .slice(0, 10);
+}
+
+/** Transitive dependents of files[] over imports/tests/documents edges. */
+export function blastRadius(db, files) {
+  const hit = new Set(files.map((f) => `file:${f}`));
+  let frontier = [...hit];
+  while (frontier.length > 0) {
+    const ph = frontier.map(() => '?').join(', ');
+    const next = db.prepare(
+      `SELECT DISTINCT src FROM edges WHERE kind IN ('imports', 'tests', 'documents') AND dst IN (${ph})`,
+    ).all(...frontier).map((r) => r.src).filter((s) => !hit.has(s));
+    next.forEach((s) => hit.add(s));
+    frontier = next;
+  }
+  const ids = [...hit];
+  const ph = ids.map(() => '?').join(', ');
+  const rows = db.prepare(`SELECT id, kind, name FROM nodes WHERE id IN (${ph})`).all(...ids);
+  return {
+    files: rows.filter((r) => r.kind === 'file').map((r) => r.name).filter((n) => !files.includes(n)),
+    tests: rows.filter((r) => r.kind === 'test').map((r) => r.name),
+    stories: rows.filter((r) => r.kind === 'story').map((r) => r.name),
+  };
+}
+
+export function codeForTicket(db, ticket) {
+  const id = `ticket:${ticket.startsWith('#') ? ticket : `#${ticket}`}`;
+  return db.prepare("SELECT dst FROM edges WHERE kind = 'ticket' AND src = ?").all(id)
+    .map((r) => r.dst.replace(/^file:/, ''));
+}
+
+/** Reuse candidates ranked by keyword hits across export/component/story names and props members. */
+export function reuseCandidates(db, description) {
+  const words = [...new Set(description.toLowerCase().split(/[^a-z0-9]+/).filter((w) => w.length >= 3))];
+  if (words.length === 0) return [];
+  const rows = db.prepare(
+    "SELECT id, kind, name, file, meta FROM nodes WHERE kind IN ('component', 'export', 'props-interface', 'story')",
+  ).all().map(parseMeta);
+  return rows
+    .map((r) => {
+      const hay = `${r.name} ${r.file ?? ''} ${(r.meta?.members ?? []).join(' ')}`.toLowerCase();
+      const score = words.filter((w) => hay.includes(w)).length;
+      return { id: r.id, kind: r.kind, name: r.name, file: r.file, score };
+    })
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+    .slice(0, 10);
+}

--- a/plugin/mcp/graph/server.mjs
+++ b/plugin/mcp/graph/server.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Graph MCP server (spec §9; SP8 T4) — newline-delimited JSON-RPC 2.0 over
+ * stdio, hand-rolled (zero deps; the protocol surface we need is tiny:
+ * initialize, tools/list, tools/call, ping). Hardening: every tool input is
+ * schema-validated, file paths are canonicalized to the repo root, SQL is
+ * parameterized in the layers below. With features.graph off the server stays
+ * up and answers every call with a teaching error — a crash-looping server
+ * would be noisier than an honest refusal.
+ */
+import { createInterface } from 'node:readline';
+import { resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { openDb } from './db.mjs';
+import { findComponent, whoUses, similarProps, blastRadius, codeForTicket, reuseCandidates } from './queries.mjs';
+
+export const PROTOCOL_VERSION = '2024-11-05';
+
+export const TOOLS = [
+  { name: 'find_component', description: 'Find components/exports by name substring — ask before writing anything new.',
+    inputSchema: { type: 'object', properties: { query: { type: 'string', minLength: 1 } }, required: ['query'] } },
+  { name: 'who_uses', description: 'Who renders/imports a symbol or uses a token — impact of touching it.',
+    inputSchema: { type: 'object', properties: { symbol: { type: 'string', minLength: 1 } }, required: ['symbol'] } },
+  { name: 'similar_props', description: 'Props interfaces ranked by member overlap — near-duplicates to reuse instead.',
+    inputSchema: { type: 'object', properties: { members: { type: 'array', items: { type: 'string' }, minItems: 1 } }, required: ['members'] } },
+  { name: 'blast_radius', description: 'Transitive dependents (files, tests, stories) of a set of files — the test set for a change.',
+    inputSchema: { type: 'object', properties: { files: { type: 'array', items: { type: 'string' }, minItems: 1 } }, required: ['files'] } },
+  { name: 'code_for_ticket', description: 'Files linked to a ticket via commit-message issue refs.',
+    inputSchema: { type: 'object', properties: { ticket: { type: 'string', minLength: 1 } }, required: ['ticket'] } },
+  { name: 'reuse_candidates', description: 'Existing exports/components ranked against a feature description — check before creating files.',
+    inputSchema: { type: 'object', properties: { description: { type: 'string', minLength: 3 } }, required: ['description'] } },
+];
+
+/** Minimal validator for the schema subset TOOLS uses. */
+export function validateInput(schema, args) {
+  if (args == null || typeof args !== 'object' || Array.isArray(args)) return 'arguments must be an object';
+  for (const key of schema.required ?? []) if (!(key in args)) return `missing required '${key}'`;
+  for (const [key, val] of Object.entries(args)) {
+    const prop = schema.properties[key];
+    if (!prop) return `unknown argument '${key}'`;
+    if (prop.type === 'string' && (typeof val !== 'string' || val.length < (prop.minLength ?? 0))) {
+      return `'${key}' must be a string of length >= ${prop.minLength ?? 0}`;
+    }
+    if (prop.type === 'array') {
+      if (!Array.isArray(val) || val.length < (prop.minItems ?? 0)) return `'${key}' must be an array with >= ${prop.minItems ?? 0} items`;
+      if (prop.items?.type === 'string' && !val.every((v) => typeof v === 'string')) return `'${key}' items must be strings`;
+    }
+  }
+  return null;
+}
+
+/** Canonicalize a repo-relative path; traversal outside the root is refused. */
+export function canonicalize(root, p) {
+  const abs = resolve(root, p);
+  const base = resolve(root);
+  if (abs !== base && !abs.startsWith(base + sep)) return null;
+  return abs.slice(base.length + 1).split(sep).join('/') || null;
+}
+
+export function makeHandler({ db, root, graphEnabled }) {
+  const rpcError = (id, code, message) => ({ jsonrpc: '2.0', id, error: { code, message } });
+  const result = (id, res) => ({ jsonrpc: '2.0', id, result: res });
+  const toolText = (id, payload, isError = false) =>
+    result(id, { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }], isError });
+
+  return function handle(msg) {
+    if (msg?.jsonrpc !== '2.0' || typeof msg.method !== 'string') return rpcError(msg?.id ?? null, -32600, 'invalid request');
+    const { id, method, params } = msg;
+    if (method.startsWith('notifications/')) return null; // notifications get no response
+    switch (method) {
+      case 'initialize':
+        return result(id, {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: { name: 'forge-graph', version: '0.1.0' },
+        });
+      case 'ping':
+        return result(id, {});
+      case 'tools/list':
+        return result(id, { tools: TOOLS });
+      case 'tools/call': {
+        const tool = TOOLS.find((t) => t.name === params?.name);
+        if (!tool) return rpcError(id, -32602, `unknown tool '${params?.name}'`);
+        if (!graphEnabled) {
+          return toolText(id, { error: 'features.graph is off for this repo — enable it in .claude/forge.json and run `node plugin/scripts/graph/graphctl.mjs rebuild` (TypeScript repos only; grep-first is the permanent fallback otherwise).' }, true);
+        }
+        const args = params.arguments ?? {};
+        const invalid = validateInput(tool.inputSchema, args);
+        if (invalid) return rpcError(id, -32602, `invalid arguments for ${tool.name}: ${invalid}`);
+        try {
+          switch (tool.name) {
+            case 'find_component': return toolText(id, findComponent(db, args.query));
+            case 'who_uses': return toolText(id, whoUses(db, args.symbol));
+            case 'similar_props': return toolText(id, similarProps(db, args.members));
+            case 'blast_radius': {
+              const rels = args.files.map((f) => canonicalize(root, f));
+              if (rels.some((r) => r === null)) return rpcError(id, -32602, 'invalid arguments for blast_radius: paths must stay inside the repo root');
+              return toolText(id, blastRadius(db, rels));
+            }
+            case 'code_for_ticket': return toolText(id, codeForTicket(db, args.ticket));
+            case 'reuse_candidates': return toolText(id, reuseCandidates(db, args.description));
+          }
+        } catch (e) {
+          return toolText(id, { error: `graph query failed: ${e.message}` }, true);
+        }
+        return rpcError(id, -32603, 'unreachable');
+      }
+      default:
+        return rpcError(id, -32601, `method '${method}' not found`);
+    }
+  };
+}
+
+export async function isGraphEnabled(root) {
+  try {
+    const { loadConfig } = await import('../../scripts/lib/config.mjs');
+    const cfg = await loadConfig(root);
+    return cfg.ok && cfg.config?.features?.graph === true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const root = process.cwd();
+  const graphEnabled = await isGraphEnabled(root);
+  const db = graphEnabled ? openDb(root) : null;
+  const handle = makeHandler({ db, root, graphEnabled });
+  const rl = createInterface({ input: process.stdin, terminal: false });
+  rl.on('line', (line) => {
+    if (!line.trim()) return;
+    let msg;
+    try { msg = JSON.parse(line); } catch { process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'parse error' } }) + '\n'); return; }
+    const res = handle(msg);
+    if (res) process.stdout.write(JSON.stringify(res) + '\n');
+  });
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) main();

--- a/plugin/scripts/doctor.mjs
+++ b/plugin/scripts/doctor.mjs
@@ -115,6 +115,23 @@ export async function runDoctor(ctx) {
     else results.push(warn('deploy', `features.deploy is on but missing: ${missing.join(', ')}`, 'run /forge:deploy-init'));
   }
 
+  // graph layer (warn-level, only when features.graph is on)
+  if (cfg.ok && cfg.config.features?.graph === true) {
+    const { loadTsMorph } = await import('../mcp/graph/indexer.mjs');
+    const tsconfigExists = await stat(join(cwd, 'tsconfig.json')).then(() => true, () => false);
+    if (!tsconfigExists) {
+      results.push(warn('graph', 'features.graph is on but no tsconfig.json — the graph indexes TypeScript repos only', 'turn features.graph off; grep-first is the permanent fallback (spec §9)'));
+    } else {
+      const tm = await loadTsMorph(cwd);
+      if (!tm.ok) results.push(warn('graph', 'features.graph is on but ts-morph is not resolvable from this repo', 'npm i -D ts-morph, then node plugin/scripts/graph/graphctl.mjs rebuild'));
+      else {
+        const dbExists = await stat(join(cwd, '.forge', 'graph.db')).then(() => true, () => false);
+        if (dbExists) results.push(ok('graph', 'ts-morph resolvable, graph.db present'));
+        else results.push(warn('graph', 'graph.db not built yet', 'node plugin/scripts/graph/graphctl.mjs rebuild'));
+      }
+    }
+  }
+
   // statusline wired (info-level) — local settings first (that's where init writes it)
   const settingsLocal = await readJson(join(cwd, '.claude', 'settings.local.json')).catch(() => null);
   const settings = await readJson(join(cwd, '.claude', 'settings.json')).catch(() => null);

--- a/plugin/scripts/graph/graphctl.mjs
+++ b/plugin/scripts/graph/graphctl.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * graphctl (spec §9; SP8 T5) — the graph's CLI face:
+ *   rebuild             full reindex (wipes derived state, re-derives ticket edges)
+ *   reindex <files…>    incremental: only the named files' rows change
+ *   tickets             git log issue-ref scan -> ticket edges
+ *   install-hook        writes .git/hooks/post-commit (explicit opt-in — plugins
+ *                       cannot install git hooks themselves; idempotent)
+ */
+import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run } from '../lib/exec.mjs';
+import { openDb, upsertNode, upsertEdge, counts } from '../../mcp/graph/db.mjs';
+import { rebuild, indexFiles } from '../../mcp/graph/indexer.mjs';
+
+const TICKET_REF_RE = /\(#(\d+)\)/g;
+const SUBJECT_PREFIX = '@@forge@@';
+
+/**
+ * Parse `git log --name-only --format=@@forge@@%s` output into ticket -> files.
+ * The prefix disambiguates subjects from filenames — a ref-less subject would
+ * otherwise be indistinguishable from a path.
+ */
+export function parseTicketLog(logText) {
+  const map = new Map();
+  let current = [];
+  for (const line of logText.split(/\r?\n/)) {
+    if (line.startsWith(SUBJECT_PREFIX)) {
+      current = [...line.matchAll(TICKET_REF_RE)].map((m) => m[1]);
+    } else if (line.trim() && current.length > 0) {
+      const file = line.trim().split('\\').join('/');
+      for (const t of current) {
+        if (!map.has(t)) map.set(t, new Set());
+        map.get(t).add(file);
+      }
+    }
+  }
+  return map;
+}
+
+export async function scanTickets(db, cwd, execFn = run) {
+  const res = await execFn('git', ['log', '--name-only', `--format=${SUBJECT_PREFIX}%s`], { cwd });
+  if (!res.ok) return { ok: false, error: res.stderr || 'git log failed' };
+  const map = parseTicketLog(res.stdout);
+  let edges = 0;
+  for (const [ticket, files] of map) {
+    upsertNode(db, { id: `ticket:#${ticket}`, kind: 'ticket', name: `#${ticket}` });
+    for (const f of files) {
+      upsertEdge(db, { src: `ticket:#${ticket}`, dst: `file:${f}`, kind: 'ticket' });
+      edges++;
+    }
+  }
+  return { ok: true, tickets: map.size, edges };
+}
+
+export const HOOK_MARKER = '# forge-graph post-commit';
+const HOOK_BODY = `#!/bin/sh
+${HOOK_MARKER}
+changed=$(git diff-tree --no-commit-id --name-only -r HEAD -- '*.ts' '*.tsx')
+[ -n "$changed" ] && node "$(dirname "$0")/../../plugin/scripts/graph/graphctl.mjs" reindex $changed >/dev/null 2>&1 || true
+`;
+
+export async function installHook(cwd) {
+  const hooksDir = join(cwd, '.git', 'hooks');
+  const hookPath = join(hooksDir, 'post-commit');
+  const gitExists = await access(join(cwd, '.git')).then(() => true, () => false);
+  if (!gitExists) return { ok: false, error: 'not a git repository' };
+  const existing = await readFile(hookPath, 'utf8').catch(() => null);
+  if (existing?.includes(HOOK_MARKER)) return { ok: true, installed: false, note: 'hook already present' };
+  if (existing != null) return { ok: false, error: `a post-commit hook already exists at ${hookPath} — merge the forge-graph reindex line in manually (marker: "${HOOK_MARKER}")` };
+  await mkdir(hooksDir, { recursive: true });
+  await writeFile(hookPath, HOOK_BODY, { encoding: 'utf8', mode: 0o755 });
+  return { ok: true, installed: true, path: hookPath };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const cwd = process.cwd();
+  const fail = (msg) => { console.error(msg); process.exit(1); };
+  if (cmd === 'rebuild') {
+    const db = openDb(cwd);
+    rebuild(db, cwd).then(async (res) => {
+      if (!res.ok) fail(res.error);
+      const t = await scanTickets(db, cwd);
+      if (!t.ok) fail(t.error);
+      console.log(`graph: ${res.files} files indexed, ${t.tickets} tickets linked — ${JSON.stringify(counts(db))}`);
+    });
+  } else if (cmd === 'reindex') {
+    if (rest.length === 0) fail('usage: graphctl reindex <files…>');
+    const db = openDb(cwd);
+    indexFiles(db, cwd, rest).then((res) => {
+      if (!res.ok) fail(res.error);
+      console.log(`graph: ${res.files} files reindexed`);
+    });
+  } else if (cmd === 'tickets') {
+    const db = openDb(cwd);
+    scanTickets(db, cwd).then((res) => {
+      if (!res.ok) fail(res.error);
+      console.log(`graph: ${res.tickets} tickets, ${res.edges} ticket edges`);
+    });
+  } else if (cmd === 'install-hook') {
+    installHook(cwd).then((res) => {
+      if (!res.ok) fail(res.error);
+      console.log(res.installed ? `graph: post-commit hook installed at ${res.path}` : `graph: ${res.note}`);
+    });
+  } else {
+    fail('usage: graphctl <rebuild|reindex <files…>|tickets|install-hook>');
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      ts-morph:
+        specifier: ^28.0.0
+        version: 28.0.0
       vitest:
         specifier: ^3.2.4
         version: 3.2.7
@@ -298,6 +301,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -340,6 +346,14 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -351,6 +365,9 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -403,6 +420,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -410,6 +431,9 @@ packages:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -471,6 +495,9 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -707,6 +734,12 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@ts-morph/common@0.29.0':
+    dependencies:
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.17
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -760,6 +793,12 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
+
   cac@6.7.14: {}
 
   chai@5.3.3:
@@ -771,6 +810,8 @@ snapshots:
       pathval: 2.0.1
 
   check-error@2.1.3: {}
+
+  code-block-writer@13.0.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -830,9 +871,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
+
   ms@2.1.3: {}
 
   nanoid@3.3.16: {}
+
+  path-browserify@1.0.1: {}
 
   pathe@2.0.3: {}
 
@@ -905,6 +952,11 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
+
+  ts-morph@28.0.0:
+    dependencies:
+      '@ts-morph/common': 0.29.0
+      code-block-writer: 13.0.3
 
   vite-node@3.2.4:
     dependencies:

--- a/tests/fixtures/graph-ts/src/Button.stories.tsx
+++ b/tests/fixtures/graph-ts/src/Button.stories.tsx
@@ -1,0 +1,3 @@
+import { Button } from './Button';
+
+export const Primary = () => <Button label="Primary" onClick={() => {}} />;

--- a/tests/fixtures/graph-ts/src/Button.tsx
+++ b/tests/fixtures/graph-ts/src/Button.tsx
@@ -1,0 +1,13 @@
+export interface ButtonProps {
+  label: string;
+  onClick: () => void;
+  variant?: 'primary' | 'ghost';
+}
+
+export function Button({ label, onClick, variant = 'primary' }: ButtonProps) {
+  return (
+    <button className={`btn btn--${variant}`} onClick={onClick}>
+      {label}
+    </button>
+  );
+}

--- a/tests/fixtures/graph-ts/src/Card.test.tsx
+++ b/tests/fixtures/graph-ts/src/Card.test.tsx
@@ -1,0 +1,4 @@
+import { Card } from './Card';
+
+// fixture: exercised by the graph indexer, never run as a test
+export const probe = Card;

--- a/tests/fixtures/graph-ts/src/Card.tsx
+++ b/tests/fixtures/graph-ts/src/Card.tsx
@@ -1,0 +1,18 @@
+import { Button } from './Button';
+import { formatDate } from './utils';
+
+export interface CardProps {
+  title: string;
+  onClick: () => void;
+  date?: Date;
+}
+
+export function Card({ title, onClick, date }: CardProps) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      {date ? <time>{formatDate(date)}</time> : null}
+      <Button label="Open" onClick={onClick} />
+    </section>
+  );
+}

--- a/tests/fixtures/graph-ts/src/utils.ts
+++ b/tests/fixtures/graph-ts/src/utils.ts
@@ -1,0 +1,3 @@
+export function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}

--- a/tests/fixtures/graph-ts/tsconfig.json
+++ b/tests/fixtures/graph-ts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/tests/graph/graph.test.mjs
+++ b/tests/graph/graph.test.mjs
@@ -172,7 +172,8 @@ describe('path hardening (AC-8.6)', () => {
     expect(canonicalize(FIXTURE, './src/../src/Card.tsx')).toBe('src/Card.tsx');
     expect(canonicalize(FIXTURE, '../../secrets.txt')).toBe(null);
     expect(canonicalize(FIXTURE, '/etc/passwd')).toBe(null);
-    expect(canonicalize(FIXTURE, 'C:\\Windows\\system32')).toBe(null);
+    // a drive-letter path is only absolute on Windows; on POSIX it's a (weird) relative name
+    if (process.platform === 'win32') expect(canonicalize(FIXTURE, 'C:\\Windows\\system32')).toBe(null);
   });
 
   it('AC-8.6: blast_radius via the server refuses escaping paths', () => {

--- a/tests/graph/graph.test.mjs
+++ b/tests/graph/graph.test.mjs
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { openDb, resetDb, upsertNode, upsertEdge, deleteFileScope, counts, NODE_KINDS } from '../../plugin/mcp/graph/db.mjs';
+import { rebuild, indexFiles, fileKind, loadTsMorph } from '../../plugin/mcp/graph/indexer.mjs';
+import { findComponent, whoUses, similarProps, blastRadius, codeForTicket, reuseCandidates } from '../../plugin/mcp/graph/queries.mjs';
+import { makeHandler, validateInput, canonicalize, TOOLS } from '../../plugin/mcp/graph/server.mjs';
+import { parseTicketLog, scanTickets, installHook, HOOK_MARKER } from '../../plugin/scripts/graph/graphctl.mjs';
+import { runDoctor } from '../../plugin/scripts/doctor.mjs';
+import { fakeGh, REPO_VIEW, AUTH_OK } from '../helpers/fakegh.mjs';
+
+const FIXTURE = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures', 'graph-ts');
+const noop = () => {};
+
+// index once — ts-morph project creation is the slow part
+let db;
+beforeAll(async () => {
+  db = openDb(FIXTURE, { memory: true });
+  const res = await rebuild(db, FIXTURE);
+  expect(res).toMatchObject({ ok: true, files: 5 });
+}, 60_000);
+
+describe('graph db (AC-8.1)', () => {
+  it('AC-8.1: upserts are idempotent and SQL is parameterized end-to-end', () => {
+    const d = openDb('.', { memory: true });
+    upsertNode(d, { id: 'export:a.ts#x', kind: 'export', name: "x'); DROP TABLE nodes; --", file: 'a.ts' });
+    upsertNode(d, { id: 'export:a.ts#x', kind: 'export', name: "x'); DROP TABLE nodes; --", file: 'a.ts' });
+    upsertEdge(d, { src: 'file:a.ts', dst: 'file:b.ts', kind: 'imports' });
+    upsertEdge(d, { src: 'file:a.ts', dst: 'file:b.ts', kind: 'imports' });
+    expect(counts(d)).toEqual({ nodes: 1, edges: 1 });
+    expect(findComponent(d, "'); DROP")).toHaveLength(1); // still queryable — nothing was executed
+    expect(() => upsertNode(d, { id: 'x', kind: 'nonsense', name: 'x' })).toThrow(/unknown node kind/);
+  });
+
+  it('AC-8.1: rebuild wipes and repopulates (re-run does not duplicate)', async () => {
+    const before = counts(db);
+    const res = await rebuild(db, FIXTURE);
+    expect(res.ok).toBe(true);
+    expect(counts(db)).toEqual(before);
+  });
+
+  it('deleteFileScope keeps ticket edges (git history is not file content)', () => {
+    const d = openDb('.', { memory: true });
+    upsertNode(d, { id: 'file:a.ts', kind: 'file', name: 'a.ts', file: 'a.ts' });
+    upsertNode(d, { id: 'ticket:#7', kind: 'ticket', name: '#7' });
+    upsertEdge(d, { src: 'ticket:#7', dst: 'file:a.ts', kind: 'ticket' });
+    upsertEdge(d, { src: 'file:a.ts', dst: 'file:b.ts', kind: 'imports' });
+    deleteFileScope(d, 'a.ts');
+    expect(counts(d).edges).toBe(1); // imports edge gone, ticket edge kept
+  });
+});
+
+describe('indexer (AC-8.2)', () => {
+  it('AC-8.2: extracts components, exports, props interfaces from the fixture', () => {
+    const comps = findComponent(db, 'utton').filter((r) => r.kind === 'component');
+    expect(comps.map((c) => c.name)).toContain('Button');
+    expect(findComponent(db, 'formatDate')[0]).toMatchObject({ kind: 'export', name: 'formatDate' });
+    const props = similarProps(db, ['label', 'onClick', 'variant']);
+    expect(props[0]).toMatchObject({ name: 'ButtonProps', overlap: 3 });
+  });
+
+  it('AC-8.2: file kinds and typed edges — imports/tests/documents', () => {
+    expect(fileKind('src/Card.test.tsx')).toBe('test');
+    expect(fileKind('src/Button.stories.tsx')).toBe('story');
+    expect(fileKind('src/Card.tsx')).toBe('file');
+    const users = whoUses(db, 'Card');
+    expect(users.some((u) => u.user === 'file:src/Card.test.tsx' && u.via === 'imports-file')).toBe(true);
+  });
+
+  it('AC-8.2: a repo where ts-morph is unresolvable gets the teaching fallback error', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-nots-'));
+    const res = await loadTsMorph(dir);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/grep-first|fallback/i);
+    expect(res.error).toMatch(/permanent/i);
+  });
+});
+
+describe('MCP stdio protocol (AC-8.3)', () => {
+  const handler = () => makeHandler({ db, root: FIXTURE, graphEnabled: true });
+  const call = (name, args) => handler()({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } });
+
+  it('AC-8.3: initialize, tools/list, tools/call round-trip', () => {
+    const h = handler();
+    const init = h({ jsonrpc: '2.0', id: 0, method: 'initialize', params: {} });
+    expect(init.result.protocolVersion).toBeTruthy();
+    expect(init.result.serverInfo.name).toBe('forge-graph');
+    const list = h({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+    expect(list.result.tools.map((t) => t.name).sort()).toEqual(
+      ['blast_radius', 'code_for_ticket', 'find_component', 'reuse_candidates', 'similar_props', 'who_uses'],
+    );
+    const res = call('find_component', { query: 'Button' });
+    expect(res.result.isError).toBe(false);
+    expect(JSON.parse(res.result.content[0].text).length).toBeGreaterThan(0);
+  });
+
+  it('AC-8.3: unknown tool, invalid input, unknown method, notification', () => {
+    const h = handler();
+    expect(call('rm_rf', {}).error.code).toBe(-32602);
+    expect(call('find_component', {}).error.message).toMatch(/missing required 'query'/);
+    expect(call('find_component', { query: 'x', extra: 1 }).error.message).toMatch(/unknown argument/);
+    expect(call('similar_props', { members: [] }).error.message).toMatch(/>= 1 items/);
+    expect(h({ jsonrpc: '2.0', id: 9, method: 'nope' }).error.code).toBe(-32601);
+    expect(h({ jsonrpc: '2.0', method: 'notifications/initialized' })).toBe(null);
+    expect(h({ method: 'tools/list' }).error.code).toBe(-32600);
+  });
+
+  it('features.graph off: every call answers with the teaching error, server never crashes', () => {
+    const h = makeHandler({ db: null, root: FIXTURE, graphEnabled: false });
+    const res = h({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'find_component', arguments: { query: 'x' } } });
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toContain('features.graph is off');
+  });
+});
+
+describe('queries (AC-8.4)', () => {
+  it('AC-8.4: who_uses Button — renders edges + importing files', () => {
+    const users = whoUses(db, 'Button');
+    expect(users.some((u) => u.user === 'component:src/Card.tsx#Card' && u.via === 'renders')).toBe(true);
+    expect(users.some((u) => u.user === 'file:src/Card.tsx')).toBe(true);
+    expect(users.some((u) => u.user === 'file:src/Button.stories.tsx')).toBe(true);
+  });
+
+  it('AC-8.4: blast_radius is transitive and buckets tests/stories', () => {
+    const r = blastRadius(db, ['src/Button.tsx']);
+    expect(r.files).toContain('src/Card.tsx');
+    expect(r.tests).toContain('src/Card.test.tsx'); // via Card, not a direct import
+    expect(r.stories).toContain('src/Button.stories.tsx');
+  });
+
+  it('AC-8.4: similar_props ranks by member overlap; reuse_candidates ranks by keywords', () => {
+    const props = similarProps(db, ['onClick', 'title']);
+    expect(props[0].name).toBe('CardProps');
+    const reuse = reuseCandidates(db, 'a clickable button with a label');
+    expect(reuse[0].name).toMatch(/Button/);
+    expect(reuseCandidates(db, '!!')).toEqual([]);
+  });
+});
+
+describe('ticket edges (AC-8.5)', () => {
+  it('AC-8.5: parseTicketLog maps (#n) commits to their files', () => {
+    const log = [
+      '@@forge@@feat(board): digest flow metrics (#9)', '',
+      'plugin/scripts/board/digest.mjs', 'tests/board.test.mjs', '',
+      '@@forge@@chore: no ref here', '',
+      'README.md', '',
+      '@@forge@@fix(learn): nul byte (#9) and also (#12)', '',
+      'plugin/scripts/learn/distill.mjs', '',
+    ].join('\n');
+    const map = parseTicketLog(log);
+    expect([...map.get('9')]).toEqual(expect.arrayContaining(['plugin/scripts/board/digest.mjs', 'plugin/scripts/learn/distill.mjs']));
+    expect([...map.get('12')]).toEqual(['plugin/scripts/learn/distill.mjs']);
+    expect(map.get('9').has('README.md')).toBe(false); // ref-less commit's files attach to nothing
+  });
+
+  it('AC-8.5: scanTickets writes ticket nodes/edges; code_for_ticket reads them back', async () => {
+    const d = openDb('.', { memory: true });
+    const exec = async () => ({ ok: true, code: 0, stdout: '@@forge@@feat: thing (#42)\n\nsrc/thing.ts\nsrc/other.ts\n', stderr: '' });
+    const res = await scanTickets(d, '.', exec);
+    expect(res).toMatchObject({ ok: true, tickets: 1, edges: 2 });
+    expect(codeForTicket(d, '#42').sort()).toEqual(['src/other.ts', 'src/thing.ts']);
+    expect(codeForTicket(d, '42').sort()).toEqual(['src/other.ts', 'src/thing.ts']);
+    expect(codeForTicket(d, '#7')).toEqual([]);
+  });
+});
+
+describe('path hardening (AC-8.6)', () => {
+  it('AC-8.6: canonicalize refuses traversal outside the repo root', () => {
+    expect(canonicalize(FIXTURE, 'src/Button.tsx')).toBe('src/Button.tsx');
+    expect(canonicalize(FIXTURE, './src/../src/Card.tsx')).toBe('src/Card.tsx');
+    expect(canonicalize(FIXTURE, '../../secrets.txt')).toBe(null);
+    expect(canonicalize(FIXTURE, '/etc/passwd')).toBe(null);
+    expect(canonicalize(FIXTURE, 'C:\\Windows\\system32')).toBe(null);
+  });
+
+  it('AC-8.6: blast_radius via the server refuses escaping paths', () => {
+    const h = makeHandler({ db, root: FIXTURE, graphEnabled: true });
+    const res = h({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'blast_radius', arguments: { files: ['../../../etc'] } } });
+    expect(res.error.message).toMatch(/inside the repo root/);
+  });
+});
+
+describe('incremental + hook (AC-8.7)', () => {
+  it('AC-8.7: reindex touches only the named files rows', async () => {
+    const d = openDb(FIXTURE, { memory: true });
+    await rebuild(d, FIXTURE);
+    upsertNode(d, { id: 'export:src/utils.ts#SENTINEL', kind: 'export', name: 'SENTINEL', file: 'src/utils.ts' });
+    const before = counts(d);
+    const res = await indexFiles(d, FIXTURE, ['src/Button.tsx']);
+    expect(res).toMatchObject({ ok: true, files: 1 });
+    // Button's rows re-created identically; utils' sentinel untouched
+    expect(counts(d)).toEqual(before);
+    expect(findComponent(d, 'SENTINEL')).toHaveLength(1);
+    const gone = await indexFiles(d, FIXTURE, ['src/utils.ts']);
+    expect(gone.ok).toBe(true);
+    expect(findComponent(d, 'SENTINEL')).toHaveLength(0); // real reindex replaced the fake row
+  });
+
+  it('AC-8.7: install-hook writes post-commit once; re-run is a no-op; foreign hooks are never clobbered', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-hook-'));
+    await mkdir(join(dir, '.git'), { recursive: true });
+    const first = await installHook(dir);
+    expect(first).toMatchObject({ ok: true, installed: true });
+    expect(await readFile(join(dir, '.git', 'hooks', 'post-commit'), 'utf8')).toContain(HOOK_MARKER);
+    expect(await installHook(dir)).toMatchObject({ ok: true, installed: false });
+
+    const dir2 = await mkdtemp(join(tmpdir(), 'forge-hook2-'));
+    await mkdir(join(dir2, '.git', 'hooks'), { recursive: true });
+    await writeFile(join(dir2, '.git', 'hooks', 'post-commit'), '#!/bin/sh\necho mine\n', 'utf8');
+    const clash = await installHook(dir2);
+    expect(clash.ok).toBe(false);
+    expect(clash.error).toMatch(/already exists/);
+    expect(await readFile(join(dir2, '.git', 'hooks', 'post-commit'), 'utf8')).toContain('echo mine');
+  });
+});
+
+describe('doctor graph checks (AC-8.8)', () => {
+  async function cwdWithGraphOn({ tsconfig }) {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-docgraph-'));
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    committed.features = { ...(committed.features ?? {}), graph: true };
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed), 'utf8');
+    await writeFile(join(cwd, '.gitignore'), '.forge/\n', 'utf8');
+    if (tsconfig) await writeFile(join(cwd, 'tsconfig.json'), '{}', 'utf8');
+    return cwd;
+  }
+  const ghAllOk = () => fakeGh([['auth status', AUTH_OK], ['repo view', REPO_VIEW], [() => true, { ok: false, stderr: 'x' }]]).gh;
+
+  it('AC-8.8: features.graph on + no tsconfig -> actionable ⚠ naming the permanent fallback', async () => {
+    const res = await runDoctor({ gh: ghAllOk(), cwd: await cwdWithGraphOn({ tsconfig: false }), log: noop });
+    const g = res.results.find((r) => r.name === 'graph');
+    expect(g).toMatchObject({ level: 'warn' });
+    expect(g.msg).toContain('TypeScript repos only');
+  });
+
+  it('AC-8.8: features.graph on + tsconfig but ts-morph unresolvable -> ⚠ with the install hint', async () => {
+    const res = await runDoctor({ gh: ghAllOk(), cwd: await cwdWithGraphOn({ tsconfig: true }), log: noop });
+    const g = res.results.find((r) => r.name === 'graph');
+    expect(g).toMatchObject({ level: 'warn' });
+    expect(g.hint).toContain('ts-morph');
+  });
+});
+
+describe('schema slots', () => {
+  it('node kinds carry the full spec §9 set (embedding column reserved)', () => {
+    for (const k of ['file', 'component', 'export', 'props-interface', 'token', 'story', 'test', 'icon']) {
+      expect(NODE_KINDS).toContain(k);
+    }
+    expect(TOOLS).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
Closes #10. Plan: [docs/plans/2026-07-17-sp8-graph-rag.md](https://github.com/dngioidev/forge/blob/main/docs/plans/2026-07-17-sp8-graph-rag.md)

## What

- **Store** (`plugin/mcp/graph/db.mjs`): `node:sqlite` — zero deps, no native builds on Windows; parameterized SQL only; embedding column reserved (spec backlog). Incremental scope deletes only edges a file *contributes* (src-side) — edges pointing at it belong to other files' scopes; ticket edges survive by design.
- **Indexer**: ts-morph resolved **lazily from the consumer repo** — forge ships no runtime dependency (recorded in the plan; ts-morph is a devDep for fixtures only). Components/exports/props-interfaces + imports/renders/tests/documents edges; non-TS repo ⇒ teaching error naming the permanent grep-first fallback.
- **MCP stdio server**: hand-rolled JSON-RPC 2.0 (initialize/tools list+call/ping — the surface we need is tiny). Every input schema-validated; file paths canonicalized to the repo root; `features.graph` off ⇒ server stays up and answers every call with a teaching error instead of crash-looping (small deviation from the plan's 'exits cleanly' — a dead server reads as broken, an honest refusal doesn't). Registered in plugin.json `mcpServers`.
- **graphctl**: rebuild / reindex / tickets / install-hook. Ticket edges from `git log --format=@@forge@@%s` — the subject prefix keeps ref-less subjects from parsing as filenames. install-hook is opt-in, idempotent, and never clobbers a foreign post-commit hook.
- **doctor**: `features.graph` on + non-TS repo or unresolvable ts-morph ⇒ actionable ⚠.

## Commits → issues

All commits → #10 (plan on main: `b8cbdf9`).

## AC checklist (acgate: 8/8 green)

- [x] AC-8.1 parameterized schema, idempotent upserts, rebuild wipes
- [x] AC-8.2 fixture extraction + non-TS teaching error
- [x] AC-8.3 initialize/tools-list/tools-call + protocol errors
- [x] AC-8.4 who_uses / transitive blast_radius / similar_props / reuse_candidates
- [x] AC-8.5 ticket edges round-trip
- [x] AC-8.6 path canonicalization refuses traversal
- [x] AC-8.7 incremental reindex scope + idempotent install-hook
- [x] AC-8.8 doctor graph warnings

## Verification (honest)

- 215/215 tests (21 new; the fixture indexes with **real ts-morph**, not mocks). Gates live: plandrift clean (16 files), testintent clean, depguard ✓ ts-morph (2721d old), acgate 8/8.
- **Live dogfood**: `graphctl tickets` on this repo's real history → 10 tickets, 195 ticket edges; `code_for_ticket #9` returns exactly SP7's file set; the server answered initialize + a flag-off tools/call over real stdio.
- **NOT verified**: the server under a real Claude Code MCP client (plugin not installed in this session — protocol shapes match the MCP spec but an actual client handshake hasn't run); `plugin.json mcpServers` registration is by-the-docs but untested against a live plugin load; the post-commit hook end-to-end on a consumer repo; index behavior on a large real TS codebase (fixture is 5 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x