### PR TITLE
fix: escalate.mjs degrades gracefully on boards without a 'blocked' status (#27)

### DIFF
--- a/plugin/scripts/board/escalate.mjs
+++ b/plugin/scripts/board/escalate.mjs
@@ -36,8 +36,15 @@ export async function runEscalate(ctx, args, log = console.log) {
 
   const id = `esc-${args.issue}-${Date.now().toString(36)}`;
 
-  const moved = await runMove(ctx, { issue: args.issue, status: 'blocked' }, () => {});
-  if (!moved.ok) return moved;
+  // Adopted boards may not map 'blocked' — degrade gracefully (spec §5): the
+  // decision comment is the escalation; the column is only its shadow.
+  let boardNote = 'board → blocked';
+  if (ctx.fields?.status?.options?.blocked) {
+    const moved = await runMove(ctx, { issue: args.issue, status: 'blocked' }, () => {});
+    if (!moved.ok) return moved;
+  } else {
+    boardNote = "board unchanged (no 'blocked' status option mapped — add one in the project UI and re-run /forge:init to enable it)";
+  }
 
   const lines = [
     `🚩 **Decision needed** (\`${id}\`)`,
@@ -61,7 +68,7 @@ export async function runEscalate(ctx, args, log = console.log) {
     commentId: comment.id, status: 'pending', createdAt: new Date().toISOString(),
   });
 
-  log(`escalated #${args.issue} (${id}) — board → blocked, decision comment posted`);
+  log(`escalated #${args.issue} (${id}) — ${boardNote}, decision comment posted`);
   return { ok: true, id };
 }
 

--- a/tests/escalate.test.mjs
+++ b/tests/escalate.test.mjs
@@ -50,6 +50,30 @@ describe('escalate (AC-3.2)', () => {
     expect(pending).toMatchObject({ status: 'pending', issue: 3, recommend: 'redesign the task' });
   });
 
+  it('AC-B1.1: board without a blocked option — decision comment, journal, pending file still land; no move fires (#27)', async () => {
+    const cfg = structuredClone(CFG);
+    cfg.board.fields.status.options = { backlog: 'sb', inProgress: 'sp', done: 'sd' }; // this repo's real shape
+    const dir = await mkdtemp(join(tmpdir(), 'forge-esc-nb-'));
+    await mkdir(join(dir, '.claude'), { recursive: true });
+    await writeFile(join(dir, '.claude', 'forge.json'), JSON.stringify(cfg), 'utf8');
+
+    const f = fakeGh([
+      ['repo view', REPO_VIEW],
+      [(j) => j.includes('/comments?'), { stdout: '[]' }],
+      [(j) => j.includes('/issues/3/comments'), { stdout: JSON.stringify({ id: 501 }) }],
+    ]);
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd: dir });
+    const logs = [];
+    const res = await runEscalate(ctx, parseArgs(['--issue', '3', '--reason', 'infra decision', '--options', 'a|b']), (m) => logs.push(m));
+    expect(res.ok).toBe(true);
+    expect(f.calls.some((c) => c.includes('item-edit'))).toBe(false); // no move attempted
+    expect(logs.join(' ')).toMatch(/no 'blocked' status option/);
+    const journal = await readJournal(dir, { kinds: ['escalation'] });
+    expect(journal.events[0]).toMatchObject({ issue: 3, reason: 'infra decision' });
+    const pending = JSON.parse(await readFile(join(dir, '.forge', 'decisions', `${res.id}.json`), 'utf8'));
+    expect(pending.status).toBe('pending');
+  });
+
   it('open: requires at least two options', async () => {
     const f = fakeGh([['repo view', REPO_VIEW]]);
     const ctx = await makeBoardCtx({ gh: f.gh, cwd: await cwdWithConfig() });
@@ -81,6 +105,26 @@ describe('escalate (AC-3.2)', () => {
     expect(file.status).toBe('resolved');
     const journal = await readJournal(cwd, { kinds: ['escalation-resolved'] });
     expect(journal.events.length).toBe(1);
+  });
+
+  it('AC-B1.2: check resolves identically on a board without a blocked option (#27)', async () => {
+    const cfg = structuredClone(CFG);
+    cfg.board.fields.status.options = { backlog: 'sb', inProgress: 'sp', done: 'sd' };
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-esc-nb2-'));
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(cfg), 'utf8');
+    await mkdir(join(cwd, '.forge', 'decisions'), { recursive: true });
+    await writeFile(join(cwd, '.forge', 'decisions', 'esc-9-nb.json'), JSON.stringify({ id: 'esc-9-nb', issue: 9, reason: 'r', options: ['a', 'b'], status: 'pending' }), 'utf8');
+    const f = fakeGh([
+      ['repo view', REPO_VIEW],
+      [(j) => j.includes('/comments?'), { stdout: JSON.stringify([
+        { id: 501, body: '<!-- forge:decision:esc-9-nb -->\n🚩 Decision needed' },
+        { id: 502, body: 'option 1' },
+      ]) }],
+    ]);
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd });
+    const res = await runCheck(ctx, { issue: 9 }, noop);
+    expect(res.resolved).toEqual([{ id: 'esc-9-nb', issue: 9, answer: 'option 1' }]);
   });
 
   it('check: stays pending when only forge-marked comments follow', async () => {


### PR DESCRIPTION
Closes #27. Found live: the first real escalation (SP9a infra decision on #11) died at the status move because this adopted board maps only backlog/inProgress/done — before posting the decision comment, journal event, or pending file. The halt-and-ask spine was dead on any board without the full status set, violating spec §5 ('skills degrade gracefully to the mapped subset').

Fix: when `blocked` isn't mapped, skip the move, post everything else, and say so in the output (with the how-to-enable hint). Boards with `blocked` are unchanged.

## AC checklist (acgate: 2/2 green)

- [x] AC-B1.1 no-blocked board: comment + journal + pending file land, no move fires, output explains
- [x] AC-B1.2 --check resolution identical on a no-blocked board

## Verification (honest)

- 217/217 tests; testintent clean, depguard clean, acgate 2/2 via --acs (bug fix, no plan doc — plandrift n/a).
- The real re-escalation on #11 will be the live proof, run immediately after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x