### PR TITLE
feat: SP9a console daemon — transports, sanitizer, decision inbox (#11)

### DIFF
--- a/console/daemon.mjs
+++ b/console/daemon.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * forge console daemon (spec §11; SP9a T4) — one per machine, outbound-only.
+ *   register   create/extend ~/.forge/daemon.json (idempotent machineId)
+ *   once       collect -> sanitize -> publish; consume inbox -> resolve decisions
+ *   watch      `once` on an interval
+ *   status     last-publish age per repo (file transport)
+ *
+ * 9a is read-only + decision replies. Command verbs are SP9b and will be an
+ * allowlist enforced HERE, not in any UI (spec §11 guardrails).
+ */
+import { readFile, appendFile, mkdir } from 'node:fs/promises';
+import { homedir, hostname } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { randomBytes } from 'node:crypto';
+import { collectRepo } from './lib/collect.mjs';
+import { sanitizeTelemetry, sanitizeEscalation } from './lib/sanitize.mjs';
+import { makeTransport } from './lib/transport.mjs';
+import { pendingDecisions } from '../plugin/scripts/lib/situation.mjs';
+import { append as journalAppend } from '../plugin/scripts/lib/journal.mjs';
+import { writeJson, readJson } from '../plugin/scripts/lib/jsonfile.mjs';
+
+export const configPath = (home = homedir()) => join(home, '.forge', 'daemon.json');
+
+export async function register(cwd, home = homedir()) {
+  const path = configPath(home);
+  const existing = await readJson(path).catch(() => null);
+  const config = existing ?? {
+    machineId: `${hostname().toLowerCase()}-${randomBytes(2).toString('hex')}`,
+    repos: [],
+    transport: { kind: 'file', dir: join(home, '.forge', 'console') },
+    intervalSec: 60,
+  };
+  if (!config.repos.includes(cwd)) config.repos.push(cwd);
+  await mkdir(join(home, '.forge'), { recursive: true });
+  await writeJson(path, config);
+  return { ok: true, config, created: existing === null };
+}
+
+/** Resolve one inbox reply into the owning repo's decision file (--check-compatible shape). */
+export async function resolveReply(repos, reply, log = () => {}) {
+  for (const cwd of repos) {
+    const pending = await pendingDecisions(cwd);
+    const d = pending.find((p) => p.id === reply.id);
+    if (!d) continue;
+    await writeJson(join(cwd, '.forge', 'decisions', `${d.id}.json`), {
+      ...d, status: 'resolved', answer: reply.answer, resolvedBy: reply.by ?? 'console', resolvedAt: new Date().toISOString(),
+    });
+    await journalAppend(cwd, 'escalation-resolved', { issue: d.issue, id: d.id, answer: reply.answer, via: 'console' });
+    log(`decision ${d.id} (#${d.issue}) resolved via console: ${reply.answer}`);
+    return { ok: true, repo: cwd, issue: d.issue };
+  }
+  return { ok: false, error: `no pending decision '${reply.id}' in any watched repo` };
+}
+
+export async function runOnce(config, { transport = null, now = Date.now(), log = console.log } = {}) {
+  const t = transport ?? makeTransport(config);
+  const published = [];
+  const refused = [];
+
+  for (const cwd of config.repos) {
+    const snapshot = { ...(await collectRepo(cwd, now)), machineId: config.machineId };
+    const clean = sanitizeTelemetry(snapshot);
+    if (!clean.ok) { refused.push({ repo: cwd, error: clean.error }); continue; }
+    await t.publishTelemetry(clean.doc);
+    published.push(clean.doc.repo);
+
+    for (const d of snapshot.pendingDecisions) {
+      const esc = sanitizeEscalation(d, config.machineId, clean.doc.repo);
+      if (esc.ok) await t.publishEscalation(esc.doc);
+    }
+  }
+
+  const replies = await t.listDecisionReplies();
+  const resolved = [];
+  for (const reply of replies) {
+    const res = await resolveReply(config.repos, reply, log);
+    if (res.ok) {
+      await t.ackDecisionReply(reply.id);
+      resolved.push(reply.id);
+    }
+  }
+
+  log(`daemon: published ${published.length}/${config.repos.length} repo(s)${refused.length ? `, refused ${refused.length} (sanitizer)` : ''}${resolved.length ? `, resolved ${resolved.length} decision(s)` : ''}`);
+  return { ok: true, published, refused, resolved };
+}
+
+export async function runStatus(config, log = console.log) {
+  if (config.transport.kind !== 'file') {
+    log('status reads the file transport outbox; firestore status arrives with the console app');
+    return { ok: true, repos: [] };
+  }
+  const path = join(config.transport.dir, config.machineId, 'telemetry.jsonl');
+  const raw = await readFile(path, 'utf8').catch(() => '');
+  const last = new Map();
+  for (const line of raw.split(/\r?\n/).filter(Boolean)) {
+    try { const d = JSON.parse(line); last.set(d.repo, d.collectedAt); } catch { /* skip */ }
+  }
+  const repos = [...last].map(([repo, at]) => ({ repo, lastPublish: at, ageMin: Math.max(0, Math.round((Date.now() - Date.parse(at)) / 60_000)) }));
+  for (const r of repos) log(`${r.repo.padEnd(24)} last publish ${r.ageMin} min ago`);
+  if (repos.length === 0) log('no telemetry published yet — run: node console/daemon.mjs once');
+  return { ok: true, repos };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const cmd = process.argv[2];
+  const fail = (msg) => { console.error(msg); process.exit(1); };
+  const loadCfg = async () => {
+    const cfg = await readJson(configPath()).catch(() => null);
+    if (!cfg) fail('no machine config — run: node console/daemon.mjs register');
+    return cfg;
+  };
+  if (cmd === 'register') {
+    register(process.cwd()).then((r) => console.log(`${r.created ? 'registered' : 'updated'} machine '${r.config.machineId}' — ${r.config.repos.length} repo(s), transport ${r.config.transport.kind}`));
+  } else if (cmd === 'once') {
+    loadCfg().then((cfg) => runOnce(cfg));
+  } else if (cmd === 'watch') {
+    loadCfg().then(async (cfg) => {
+      console.log(`daemon watching ${cfg.repos.length} repo(s) every ${cfg.intervalSec}s — ctrl-c to stop`);
+      // sequential interval: a slow cycle delays the next instead of overlapping it
+      for (;;) {
+        await runOnce(cfg).catch((e) => console.error(`cycle failed: ${e.message}`));
+        await new Promise((r) => setTimeout(r, cfg.intervalSec * 1000));
+      }
+    });
+  } else if (cmd === 'status') {
+    loadCfg().then((cfg) => runStatus(cfg));
+  } else {
+    fail('usage: daemon.mjs <register|once|watch|status>');
+  }
+}

--- a/console/lib/collect.mjs
+++ b/console/lib/collect.mjs
@@ -1,0 +1,66 @@
+/**
+ * Telemetry collectors (spec §11 monitor; SP9a T1). Everything here reads
+ * state the pipeline already writes — .forge/journal.jsonl, .forge/decisions/,
+ * .forge/progress.md, .git/HEAD. No network, no gh: the daemon must be able
+ * to snapshot a repo even when offline. Output goes through sanitize.mjs
+ * before any transport sees it.
+ */
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { deriveSituation, pendingDecisions } from '../../plugin/scripts/lib/situation.mjs';
+import { read as readJournal } from '../../plugin/scripts/lib/journal.mjs';
+import { parseLedger, LEDGER_RELPATH } from '../../plugin/scripts/lib/ledger.mjs';
+import { parseBranch } from '../../plugin/scripts/lib/ticket.mjs';
+
+export async function currentBranch(cwd) {
+  try {
+    const head = await readFile(join(cwd, '.git', 'HEAD'), 'utf8');
+    const m = /^ref: refs\/heads\/(.+)$/m.exec(head.trim());
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function ledgerCounts(cwd) {
+  try {
+    const text = await readFile(join(cwd, LEDGER_RELPATH), 'utf8');
+    const tasks = parseLedger(text);
+    const by = (s) => tasks.filter((t) => t.status === s).length;
+    return { total: tasks.length, done: by('done'), inProgress: by('in-progress'), pending: by('pending') };
+  } catch {
+    return null;
+  }
+}
+
+const AGE_MS_HOUR = 3_600_000;
+
+/** One repo's snapshot. `now` injected — the daemon stamps once per cycle. */
+export async function collectRepo(cwd, now = Date.now()) {
+  const branch = await currentBranch(cwd);
+  const parsed = parseBranch(branch ?? '');
+  const situation = await deriveSituation(cwd);
+  const pending = await pendingDecisions(cwd);
+  const journal = await readJournal(cwd);
+
+  return {
+    repo: cwd.split(/[\\/]/).filter(Boolean).pop() ?? 'unknown',
+    situation: situation.key,
+    glyph: situation.glyph,
+    branch,
+    ticket: parsed.ticket ? `#${parsed.ticket}` : null,
+    branchKind: parsed.kind,
+    ledger: await ledgerCounts(cwd),
+    pendingDecisions: pending.map((d) => ({
+      id: d.id,
+      issue: d.issue,
+      reason: d.reason,
+      options: d.options,
+      ageHours: d.createdAt ? Math.round(((now - Date.parse(d.createdAt)) / AGE_MS_HOUR) * 10) / 10 : null,
+    })),
+    journalTail: journal.events.slice(-10).map((e) => ({
+      ts: e.ts, kind: e.kind, ticket: e.ticket ?? null, gate: e.gate ?? null, rule: e.rule ?? null,
+    })),
+    collectedAt: new Date(now).toISOString(),
+  };
+}

--- a/console/lib/sanitize.mjs
+++ b/console/lib/sanitize.mjs
@@ -1,0 +1,75 @@
+/**
+ * Metadata-only sanitizer (spec §11 guardrail; SP9a T2). ALLOWLIST, not
+ * denylist: a field that isn't declared here does not leave the machine, no
+ * matter who added it upstream. Code, diffs, and prompts have no declared
+ * field — they cannot pass. Strings are capped; a doc that still fails the
+ * schema refuses to publish (fail-closed: no telemetry beats leaky telemetry).
+ */
+
+const CAP = { short: 80, reason: 200, option: 120 };
+
+const cap = (v, n) => (typeof v === 'string' ? v.slice(0, n) : null);
+const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+
+/** field -> extractor; anything not listed is dropped. */
+const TELEMETRY_SCHEMA = {
+  repo: (v) => cap(v, CAP.short),
+  situation: (v) => cap(v, CAP.short),
+  glyph: (v) => cap(v, 8),
+  branch: (v) => cap(v, CAP.short),
+  ticket: (v) => cap(v, 16),
+  branchKind: (v) => cap(v, 16),
+  collectedAt: (v) => cap(v, 32),
+  machineId: (v) => cap(v, CAP.short),
+  ledger: (v) => (v && typeof v === 'object'
+    ? { total: num(v.total), done: num(v.done), inProgress: num(v.inProgress), pending: num(v.pending) }
+    : null),
+  pendingDecisions: (v) => (Array.isArray(v) ? v.slice(0, 20).map((d) => ({
+    id: cap(d?.id, CAP.short),
+    issue: num(d?.issue),
+    reason: cap(d?.reason, CAP.reason),
+    options: Array.isArray(d?.options) ? d.options.slice(0, 6).map((o) => cap(o, CAP.option)) : [],
+    ageHours: num(d?.ageHours),
+  })) : []),
+  journalTail: (v) => (Array.isArray(v) ? v.slice(-10).map((e) => ({
+    ts: cap(e?.ts, 32),
+    kind: cap(e?.kind, 32),
+    ticket: cap(e?.ticket, 16),
+    gate: cap(e?.gate, 32),
+    rule: cap(e?.rule, 32),
+  })) : []),
+};
+
+const REQUIRED = ['repo', 'situation', 'collectedAt', 'machineId'];
+
+export function sanitizeTelemetry(doc) {
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) {
+    return { ok: false, error: 'telemetry must be an object' };
+  }
+  const out = {};
+  for (const [field, extract] of Object.entries(TELEMETRY_SCHEMA)) {
+    if (field in doc) out[field] = extract(doc[field]);
+  }
+  const missing = REQUIRED.filter((f) => out[f] == null);
+  if (missing.length > 0) {
+    return { ok: false, error: `telemetry refused to publish — missing required metadata: ${missing.join(', ')}` };
+  }
+  return { ok: true, doc: out };
+}
+
+/** Escalation notifications carry even less: the decision, not its content. */
+export function sanitizeEscalation(d, machineId, repo) {
+  const out = {
+    machineId: cap(machineId, CAP.short),
+    repo: cap(repo, CAP.short),
+    id: cap(d?.id, CAP.short),
+    issue: num(d?.issue),
+    reason: cap(d?.reason, CAP.reason),
+    options: Array.isArray(d?.options) ? d.options.slice(0, 6).map((o) => cap(o, CAP.option)) : [],
+    createdAt: cap(d?.createdAt, 32),
+  };
+  if (!out.id || !out.reason || out.options.length < 2) {
+    return { ok: false, error: 'escalation refused to publish — needs id, reason, and >=2 option labels' };
+  }
+  return { ok: true, doc: out };
+}

--- a/console/lib/transport.mjs
+++ b/console/lib/transport.mjs
@@ -1,0 +1,22 @@
+/**
+ * Transport contract (SP9a T3). A transport moves sanitized metadata out and
+ * decision replies in — nothing else. All methods are async:
+ *
+ *   publishTelemetry(doc)          one sanitized snapshot per repo per cycle
+ *   publishEscalation(doc)         idempotent per doc.id
+ *   listDecisionReplies()          -> [{id, answer, by, repliedAt}]
+ *   ackDecisionReply(id)           consume exactly once
+ *
+ * The daemon composes these; it never knows which backend it's talking to.
+ */
+import { makeFileTransport } from '../transports/file.mjs';
+import { makeFirestoreTransport } from '../transports/firestore.mjs';
+
+export function makeTransport(config) {
+  switch (config?.transport?.kind) {
+    case 'file': return makeFileTransport(config);
+    case 'firestore': return makeFirestoreTransport(config);
+    default:
+      throw new Error(`unknown transport '${config?.transport?.kind}' — valid: file, firestore (daemon.json transport.kind)`);
+  }
+}

--- a/console/transports/file.mjs
+++ b/console/transports/file.mjs
@@ -1,0 +1,55 @@
+/**
+ * File transport (SP9a T3) — the live-today backend: a shared directory
+ * (local disk, synced folder, network share) stands in for the cloud.
+ * Layout, machine-scoped:
+ *   <dir>/<machineId>/telemetry.jsonl      append-only snapshots
+ *   <dir>/<machineId>/escalations.jsonl    append-only, idempotent per id
+ *   <dir>/<machineId>/decisions/<id>.json  inbox: replies dropped by a human/app
+ *   <dir>/<machineId>/decisions/<id>.json.done  ack marker (consumed exactly once)
+ */
+import { appendFile, readFile, readdir, rename, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export function makeFileTransport(config) {
+  const machineId = config.machineId;
+  const base = join(config.transport.dir, machineId);
+  const decisionsDir = join(base, 'decisions');
+  const ensure = () => mkdir(decisionsDir, { recursive: true });
+
+  return {
+    kind: 'file',
+
+    async publishTelemetry(doc) {
+      await ensure();
+      await appendFile(join(base, 'telemetry.jsonl'), JSON.stringify(doc) + '\n', 'utf8');
+      return { ok: true };
+    },
+
+    async publishEscalation(doc) {
+      await ensure();
+      const path = join(base, 'escalations.jsonl');
+      const existing = await readFile(path, 'utf8').catch(() => '');
+      if (existing.includes(`"id":${JSON.stringify(doc.id)}`)) return { ok: true, duplicate: true };
+      await appendFile(path, JSON.stringify(doc) + '\n', 'utf8');
+      return { ok: true };
+    },
+
+    async listDecisionReplies() {
+      await ensure();
+      const replies = [];
+      for (const f of (await readdir(decisionsDir)).filter((f) => f.endsWith('.json'))) {
+        try {
+          const d = JSON.parse(await readFile(join(decisionsDir, f), 'utf8'));
+          if (d.id && typeof d.answer === 'string') replies.push({ id: d.id, answer: d.answer, by: d.by ?? null, repliedAt: d.repliedAt ?? null });
+        } catch { /* half-written reply — next cycle */ }
+      }
+      return replies;
+    },
+
+    async ackDecisionReply(id) {
+      const src = join(decisionsDir, `${id}.json`);
+      await rename(src, `${src}.done`).catch(() => {});
+      return { ok: true };
+    },
+  };
+}

--- a/console/transports/firestore.mjs
+++ b/console/transports/firestore.mjs
@@ -1,0 +1,74 @@
+/**
+ * Firestore transport (SP9a T3) — REST, no SDK (zero-dependency principle).
+ * STRUCTURAL until the owner provisions Firebase: the request shapes are
+ * tested with an injected fetch; nothing here has run against a live project.
+ * Auth: a short-lived OAuth token minted from a service-account key is the
+ * follow-up step recorded in the guide — `authToken` is injected for now so
+ * the adapter contract stays honest about what exists.
+ *
+ * Document layout (mirrors the file transport):
+ *   machines/<machineId>/telemetry/<repo>        latest snapshot (PATCH)
+ *   machines/<machineId>/escalations/<id>        one per decision (PATCH, idempotent)
+ *   machines/<machineId>/replies/<id>            inbox written by the app
+ */
+
+const FIELD = (v) => {
+  if (v === null || v === undefined) return { nullValue: null };
+  if (typeof v === 'string') return { stringValue: v };
+  if (typeof v === 'number') return Number.isInteger(v) ? { integerValue: String(v) } : { doubleValue: v };
+  if (typeof v === 'boolean') return { booleanValue: v };
+  if (Array.isArray(v)) return { arrayValue: { values: v.map(FIELD) } };
+  return { mapValue: { fields: toFields(v) } };
+};
+const toFields = (obj) => Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, FIELD(v)]));
+
+export const fromFields = (fields = {}) => {
+  const un = (f) => {
+    if ('stringValue' in f) return f.stringValue;
+    if ('integerValue' in f) return Number(f.integerValue);
+    if ('doubleValue' in f) return f.doubleValue;
+    if ('booleanValue' in f) return f.booleanValue;
+    if ('nullValue' in f) return null;
+    if ('arrayValue' in f) return (f.arrayValue.values ?? []).map(un);
+    if ('mapValue' in f) return fromFields(f.mapValue.fields);
+    return null;
+  };
+  return Object.fromEntries(Object.entries(fields).map(([k, f]) => [k, un(f)]));
+};
+
+export function makeFirestoreTransport(config, fetchFn = globalThis.fetch) {
+  const { projectId, authToken } = config.transport;
+  if (!projectId) throw new Error('firestore transport needs transport.projectId (daemon.json)');
+  const machineId = config.machineId;
+  const root = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents`;
+  const headers = () => ({
+    'Content-Type': 'application/json',
+    ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+  });
+  const docUrl = (col, id) => `${root}/machines/${machineId}/${col}/${encodeURIComponent(id)}`;
+
+  const patch = async (url, doc) => {
+    const res = await fetchFn(url, { method: 'PATCH', headers: headers(), body: JSON.stringify({ fields: toFields(doc) }) });
+    return res.ok ? { ok: true } : { ok: false, error: `firestore ${res.status}` };
+  };
+
+  return {
+    kind: 'firestore',
+    publishTelemetry: (doc) => patch(docUrl('telemetry', doc.repo ?? 'unknown'), doc),
+    publishEscalation: (doc) => patch(docUrl('escalations', doc.id), doc),
+
+    async listDecisionReplies() {
+      const res = await fetchFn(`${root}/machines/${machineId}/replies`, { headers: headers() });
+      if (!res.ok) return [];
+      const body = await res.json();
+      return (body.documents ?? [])
+        .map((d) => ({ name: d.name, ...fromFields(d.fields) }))
+        .filter((d) => d.id && typeof d.answer === 'string' && !d.acked)
+        .map((d) => ({ id: d.id, answer: d.answer, by: d.by ?? null, repliedAt: d.repliedAt ?? null }));
+    },
+
+    async ackDecisionReply(id) {
+      return patch(`${docUrl('replies', id)}?updateMask.fieldPaths=acked`, { acked: true });
+    },
+  };
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,4 +26,4 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 
 ## Guides
 
-_(none yet — install/init/backends/console runbooks land with their sub-projects)_
+- [Console daemon](guides/console-daemon.md) — register/once/watch/status, file-transport layout, metadata-only guardrail, the Firebase follow-up step.

--- a/docs/guides/console-daemon.md
+++ b/docs/guides/console-daemon.md
@@ -1,0 +1,42 @@
+# Console daemon — run it, what it sends, what comes back
+
+The daemon (spec §11) is one process per machine, **outbound-only**: it snapshots every registered repo's pipeline state, publishes metadata to a transport, and resolves escalation decisions from replies. SP9a ships the transport-abstracted core; Firebase and the device app are the follow-up owner step.
+
+## Quick start (file transport — live today)
+
+```
+node console/daemon.mjs register     # creates ~/.forge/daemon.json, adds this repo
+node console/daemon.mjs once         # one cycle: collect → publish → inbox
+node console/daemon.mjs watch        # the same, every intervalSec
+node console/daemon.mjs status       # last-publish age per repo
+```
+
+Machine config `~/.forge/daemon.json`:
+
+```jsonc
+{
+  "machineId": "<hostname>-<4hex>",       // stable; register never regenerates it
+  "repos": ["C:/mywp/forge"],             // register appends the cwd it runs in
+  "transport": { "kind": "file", "dir": "~/.forge/console" },
+  "intervalSec": 60
+}
+```
+
+## File transport layout
+
+```
+<dir>/<machineId>/telemetry.jsonl        append-only snapshots (one per repo per cycle)
+<dir>/<machineId>/escalations.jsonl      pending decisions, idempotent per id
+<dir>/<machineId>/decisions/<id>.json    INBOX — drop {"id": "...", "answer": "...", "by": "..."}
+<dir>/<machineId>/decisions/<id>.json.done   consumed marker
+```
+
+Dropping a reply file resolves the matching `.forge/decisions/<id>.json` in whichever repo owns it — the exact shape `escalate.mjs --check` produces, so the halted pipeline resumes identically either way. The resolution is journaled (`escalation-resolved`, `via: console`).
+
+## What leaves the machine (guardrail, not convention)
+
+Telemetry is **allowlist-sanitized** (`console/lib/sanitize.mjs`): repo name, situation, branch/ticket refs, ledger counts, decision ids/reasons/option labels with ages, journal tail as `{ts, kind, ticket, gate, rule}`. Strings are capped. Code, diffs, and prompts have no field in the schema — they cannot pass, and a doc that fails the schema is refused rather than trimmed-and-sent.
+
+## When Firebase arrives (owner step)
+
+Provision a Firebase project (Auth + Firestore + FCM, free tier), then switch `transport` to `{"kind": "firestore", "projectId": "...", "authToken": "<minted from a service-account key>"}`. The adapter (`console/transports/firestore.mjs`) mirrors the file layout as documents under `machines/<machineId>/…`; it is structurally tested, not yet run against a live project. Token minting from a service-account key + FCM push + the device app land with the graduated `forge-console` repo (SP9b).

--- a/tests/console/daemon.test.mjs
+++ b/tests/console/daemon.test.mjs
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectRepo, ledgerCounts } from '../../console/lib/collect.mjs';
+import { sanitizeTelemetry, sanitizeEscalation } from '../../console/lib/sanitize.mjs';
+import { makeTransport } from '../../console/lib/transport.mjs';
+import { makeFileTransport } from '../../console/transports/file.mjs';
+import { makeFirestoreTransport, fromFields } from '../../console/transports/firestore.mjs';
+import { register, runOnce, runStatus, resolveReply, configPath } from '../../console/daemon.mjs';
+
+const noop = () => {};
+const NOW = Date.parse('2026-07-17T12:00:00Z');
+
+async function repoDir({ branch = 'feat/11-console-daemon', decisions = [], journal = [], ledger = null } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'forge-con-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  await writeFile(join(dir, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`, 'utf8');
+  await mkdir(join(dir, '.forge', 'decisions'), { recursive: true });
+  for (const d of decisions) await writeFile(join(dir, '.forge', 'decisions', `${d.id}.json`), JSON.stringify(d), 'utf8');
+  if (journal.length) await writeFile(join(dir, '.forge', 'journal.jsonl'), journal.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf8');
+  if (ledger) await writeFile(join(dir, '.forge', 'progress.md'), ledger, 'utf8');
+  return dir;
+}
+
+const DECISION = {
+  id: 'esc-11-live', issue: 11, reason: 'infra decision', status: 'pending',
+  options: ['provision now', 'abstract first'], createdAt: '2026-07-17T10:00:00Z',
+};
+
+describe('collectors (AC-9.1)', () => {
+  it('AC-9.1: snapshot carries situation, ticket, branch, ledger counts, decision ages, journal tail', async () => {
+    const dir = await repoDir({
+      decisions: [DECISION],
+      journal: [{ ts: '2026-07-17T09:00:00Z', kind: 'gate-fail', gate: 'plandrift', ticket: '#11' }],
+      ledger: '# SP9a — #11\n\n- [x] T1 — collectors\n- [~] T2 — sanitizer\n- [ ] T3 — transports\n',
+    });
+    const snap = await collectRepo(dir, NOW);
+    expect(snap).toMatchObject({
+      situation: 'awaiting-decision',
+      branch: 'feat/11-console-daemon',
+      ticket: '#11',
+      branchKind: 'work',
+      ledger: { total: 3, done: 1, inProgress: 1, pending: 1 },
+    });
+    expect(snap.pendingDecisions[0]).toMatchObject({ id: 'esc-11-live', issue: 11, ageHours: 2 });
+    expect(snap.journalTail[0]).toEqual({ ts: '2026-07-17T09:00:00Z', kind: 'gate-fail', ticket: '#11', gate: 'plandrift', rule: null });
+    expect(await ledgerCounts(await repoDir())).toBe(null);
+  });
+});
+
+describe('sanitizer (AC-9.2)', () => {
+  const base = { repo: 'forge', situation: 'building', collectedAt: '2026-07-17T12:00:00Z', machineId: 'm-1' };
+
+  it('AC-9.2: unknown fields dropped, strings capped, code/diff/prompt never pass', () => {
+    const res = sanitizeTelemetry({
+      ...base,
+      diff: 'patch content', prompt: 'secret prompt', code: 'const x = 1', stdout: 'log dump',
+      branch: 'b'.repeat(500),
+      journalTail: [{ ts: 't', kind: 'cmd-fail', err_line: 'raw stderr!', cmd: 'the command', ticket: '#1' }],
+    });
+    expect(res.ok).toBe(true);
+    const s = JSON.stringify(res.doc);
+    expect(s).not.toContain('patch content');
+    expect(s).not.toContain('secret prompt');
+    expect(s).not.toContain('raw stderr');
+    expect(s).not.toContain('the command');
+    expect(res.doc.branch.length).toBe(80);
+    expect(res.doc.journalTail[0]).toEqual({ ts: 't', kind: 'cmd-fail', ticket: '#1', gate: null, rule: null });
+  });
+
+  it('AC-9.2: a doc missing required metadata refuses to publish', () => {
+    const res = sanitizeTelemetry({ repo: 'forge', situation: 'idle' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/refused to publish/);
+    expect(sanitizeTelemetry(null).ok).toBe(false);
+  });
+
+  it('escalation docs need id, reason, and option labels', () => {
+    expect(sanitizeEscalation(DECISION, 'm-1', 'forge').ok).toBe(true);
+    expect(sanitizeEscalation({ id: 'x', reason: 'r', options: ['only-one'] }, 'm-1', 'forge').ok).toBe(false);
+  });
+});
+
+describe('file transport (AC-9.3)', () => {
+  it('AC-9.3: machine-scoped outbox; escalations idempotent; inbox consumed exactly once', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-ft-'));
+    const t = makeFileTransport({ machineId: 'm-1', transport: { kind: 'file', dir } });
+
+    await t.publishTelemetry({ repo: 'forge', machineId: 'm-1', collectedAt: 'now' });
+    expect(await readFile(join(dir, 'm-1', 'telemetry.jsonl'), 'utf8')).toContain('"repo":"forge"');
+
+    await t.publishEscalation({ id: 'esc-1', reason: 'r' });
+    const dup = await t.publishEscalation({ id: 'esc-1', reason: 'r' });
+    expect(dup.duplicate).toBe(true);
+    expect((await readFile(join(dir, 'm-1', 'escalations.jsonl'), 'utf8')).match(/esc-1/g)).toHaveLength(1);
+
+    await writeFile(join(dir, 'm-1', 'decisions', 'esc-1.json'), JSON.stringify({ id: 'esc-1', answer: 'option 2', by: 'owner' }), 'utf8');
+    const replies = await t.listDecisionReplies();
+    expect(replies).toEqual([{ id: 'esc-1', answer: 'option 2', by: 'owner', repliedAt: null }]);
+    await t.ackDecisionReply('esc-1');
+    expect(await t.listDecisionReplies()).toEqual([]);
+    expect(await readdir(join(dir, 'm-1', 'decisions'))).toEqual(['esc-1.json.done']);
+  });
+
+  it('unknown transport kind throws a teaching error', () => {
+    expect(() => makeTransport({ transport: { kind: 'carrier-pigeon' } })).toThrow(/valid: file, firestore/);
+  });
+});
+
+describe('daemon once + write-back (AC-9.4)', () => {
+  it('AC-9.4: inbox reply resolves the repo decision file in --check-compatible shape', async () => {
+    const repo = await repoDir({ decisions: [DECISION], journal: [{ ts: 't', kind: 'escalation', ticket: '#11' }] });
+    const out = await mkdtemp(join(tmpdir(), 'forge-out-'));
+    const config = { machineId: 'm-1', repos: [repo], transport: { kind: 'file', dir: out }, intervalSec: 60 };
+
+    const first = await runOnce(config, { now: NOW, log: noop });
+    expect(first.published).toHaveLength(1);
+    expect((await readFile(join(out, 'm-1', 'escalations.jsonl'), 'utf8'))).toContain('esc-11-live');
+
+    await writeFile(join(out, 'm-1', 'decisions', 'esc-11-live.json'), JSON.stringify({ id: 'esc-11-live', answer: 'option 2 — abstract first', by: 'dngioidev' }), 'utf8');
+    const second = await runOnce(config, { now: NOW, log: noop });
+    expect(second.resolved).toEqual(['esc-11-live']);
+
+    const file = JSON.parse(await readFile(join(repo, '.forge', 'decisions', 'esc-11-live.json'), 'utf8'));
+    expect(file).toMatchObject({ status: 'resolved', answer: 'option 2 — abstract first', resolvedBy: 'dngioidev' });
+    expect(file.resolvedAt).toBeTruthy();
+
+    // pendingDecisions now empty => escalate --check has nothing pending
+    const snap = await collectRepo(repo, NOW);
+    expect(snap.pendingDecisions).toEqual([]);
+    expect(snap.situation).not.toBe('awaiting-decision');
+
+    const journal = (await readFile(join(repo, '.forge', 'journal.jsonl'), 'utf8'));
+    expect(journal).toContain('"escalation-resolved"');
+    expect(journal).toContain('"via":"console"');
+  });
+
+  it('a reply for an unknown decision resolves nothing and is not acked', async () => {
+    const repo = await repoDir();
+    const res = await resolveReply([repo], { id: 'esc-ghost', answer: 'x' }, noop);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('firestore adapter, structural (AC-9.5)', () => {
+  const calls = [];
+  const fetchFn = async (url, init = {}) => {
+    calls.push({ url, method: init.method ?? 'GET', body: init.body ? JSON.parse(init.body) : null, headers: init.headers });
+    if (!init.method) {
+      return { ok: true, json: async () => ({ documents: [
+        { name: 'doc1', fields: { id: { stringValue: 'esc-1' }, answer: { stringValue: 'option 1' }, acked: { booleanValue: false } } },
+        { name: 'doc2', fields: { id: { stringValue: 'esc-2' }, answer: { stringValue: 'x' }, acked: { booleanValue: true } } },
+      ] }) };
+    }
+    return { ok: true };
+  };
+  const t = makeFirestoreTransport({ machineId: 'm-1', transport: { kind: 'firestore', projectId: 'proj', authToken: 'tok' } }, fetchFn);
+
+  it('AC-9.5: PATCH urls, bearer auth, field mapping round-trip', async () => {
+    await t.publishTelemetry({ repo: 'forge', ledger: { total: 3 }, tags: ['a'] });
+    const call = calls.at(-1);
+    expect(call.url).toContain('/projects/proj/databases/(default)/documents/machines/m-1/telemetry/forge');
+    expect(call.method).toBe('PATCH');
+    expect(call.headers.Authorization).toBe('Bearer tok');
+    expect(call.body.fields.repo).toEqual({ stringValue: 'forge' });
+    expect(call.body.fields.ledger.mapValue.fields.total).toEqual({ integerValue: '3' });
+    expect(fromFields(call.body.fields)).toMatchObject({ repo: 'forge', ledger: { total: 3 }, tags: ['a'] });
+
+    await t.publishEscalation({ id: 'esc-9', reason: 'r' });
+    expect(calls.at(-1).url).toContain('/escalations/esc-9');
+  });
+
+  it('AC-9.5: inbox lists only unacked replies; ack PATCHes the mask', async () => {
+    const replies = await t.listDecisionReplies();
+    expect(replies).toEqual([{ id: 'esc-1', answer: 'option 1', by: null, repliedAt: null }]);
+    await t.ackDecisionReply('esc-1');
+    expect(calls.at(-1).url).toContain('replies/esc-1?updateMask.fieldPaths=acked');
+    expect(calls.at(-1).body.fields.acked).toEqual({ booleanValue: true });
+  });
+
+  it('missing projectId throws a teaching error', () => {
+    expect(() => makeFirestoreTransport({ machineId: 'm', transport: { kind: 'firestore' } })).toThrow(/projectId/);
+  });
+});
+
+describe('register + status (AC-9.6, AC-9.7)', () => {
+  it('AC-9.6: register creates a stable machineId; re-run keeps it and appends repos', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'forge-home-'));
+    const r1 = await register('/repo/one', home);
+    expect(r1.created).toBe(true);
+    expect(r1.config.machineId).toMatch(/^[a-z0-9-]+-[0-9a-f]{4}$/);
+    const r2 = await register('/repo/two', home);
+    expect(r2.created).toBe(false);
+    expect(r2.config.machineId).toBe(r1.config.machineId);
+    expect(r2.config.repos).toEqual(['/repo/one', '/repo/two']);
+    const r3 = await register('/repo/one', home);
+    expect(r3.config.repos).toHaveLength(2); // no duplicates
+    expect(configPath(home)).toContain('.forge');
+  });
+
+  it('AC-9.7: every publish carries machineId + collectedAt; status reports last-publish age', async () => {
+    const repo = await repoDir();
+    const out = await mkdtemp(join(tmpdir(), 'forge-out2-'));
+    const config = { machineId: 'm-hb', repos: [repo], transport: { kind: 'file', dir: out }, intervalSec: 60 };
+    await runOnce(config, { now: NOW, log: noop });
+    const line = JSON.parse((await readFile(join(out, 'm-hb', 'telemetry.jsonl'), 'utf8')).trim());
+    expect(line.machineId).toBe('m-hb');
+    expect(line.collectedAt).toBe('2026-07-17T12:00:00.000Z');
+
+    const logs = [];
+    const res = await runStatus(config, (m) => logs.push(m));
+    expect(res.repos).toHaveLength(1);
+    expect(logs[0]).toMatch(/last publish \d+ min ago/);
+  });
+});


### PR DESCRIPTION
Closes #11. Plan: [docs/plans/2026-07-17-sp9a-console-daemon.md](https://github.com/dngioidev/forge/blob/main/docs/plans/2026-07-17-sp9a-console-daemon.md) · scoped per the owner decision recorded on #11 (option 2: transport-abstracted first).

## What

- **`console/`** (top-level — graduates to `forge-console` as a directory lift): collectors over state the pipeline already writes (situation, ticket/branch, ledger counts, pending decisions with age, journal tail), **allowlist sanitizer** as the metadata-only guardrail (unknown fields cannot pass; fail-closed — a non-conforming doc refuses to publish rather than trimming), transport contract with **file** (live today: machine-scoped outbox JSONL + decision inbox consumed exactly once) and **firestore** (REST, zero-dep, structural) adapters.
- **Daemon**: `register` (stable machineId, idempotent), `once` / `watch` (collect → sanitize → publish → inbox), `status` (last-publish age). Inbox replies resolve `.forge/decisions/<id>.json` in the exact shape `escalate.mjs --check` produces — the halted pipeline resumes identically from either path — and the resolution is journaled (`via: console`).
- Guide: `docs/guides/console-daemon.md` (run it, layout, what Firebase adds later).

## Commits → issues

All commits → #11 (plan on main: `37abf77`).

## AC checklist (acgate: 7/7 green)

- [x] AC-9.1 repo snapshot from fixtures
- [x] AC-9.2 allowlist sanitizer: code/diff/prompt can't pass; refusal on missing metadata
- [x] AC-9.3 file transport round-trip, idempotent escalations, consume-once inbox
- [x] AC-9.4 inbox reply → --check-compatible resolved decision + journal
- [x] AC-9.5 firestore REST shapes via injected fetch
- [x] AC-9.6 stable machineId on re-register
- [x] AC-9.7 heartbeat fields + status ages

## Verification (honest)

- 230/230 tests (13 new); gates live: plandrift clean (9 files), testintent clean, depguard clean, acgate 7/7.
- **Live dogfood on this machine**: `register` created `gioi-821b`; a pending decision published to the outbox exactly once across two cycles; a reply dropped in the inbox resolved the repo's decision file (verified shape + journal entry); `status` reports publish age. The first cycle also consumed a reply left from an earlier failed attempt — machine-off queueing behaving as designed.
- **NOT verified**: firestore adapter against a live Firebase project (owner hasn't provisioned — structural only, injected fetch); OAuth token minting from a service-account key (explicitly deferred, documented in the guide); `watch` long-run behavior beyond a single interval; multi-repo on this machine (config supports it, only forge is registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x