### PR TITLE
feat: SP10 hotfix + respond — incident mechanics + situation gating (#13)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,3 +28,5 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 ## Guides
 
 - [Console daemon](guides/console-daemon.md) — register/once/watch/status, file-transport layout, metadata-only guardrail, the Firebase follow-up step.
+- [Rollback runbook](guides/rollback-runbook.md) — find the previous digest, redeploy it (one command), verify, record; forward-only-migration exception.
+- [Data-recovery runbook](guides/data-recovery-runbook.md) — restore → verify → postmortem; never debug against the only copy.

--- a/docs/guides/data-recovery-runbook.md
+++ b/docs/guides/data-recovery-runbook.md
@@ -1,0 +1,28 @@
+# Data-recovery runbook — restore → verify → postmortem
+
+**When:** the incident is data corruption or loss — bad migration, destructive bug, fat-fingered production query. **Order is law: restore → verify → postmortem.** Never debug against the only copy.
+
+## 0. Stop the bleeding
+
+- Freeze writes if the corruption is ongoing (maintenance mode / scale writers to zero). A growing blast radius beats any downtime cost.
+- Note the **corruption window**: last-known-good timestamp → detection timestamp. Everything after last-known-good is suspect.
+
+## 1. Restore
+
+- Backups are **Terraform-owned per environment** (spec §10 data lifecycle) — the backup schedule and retention live in `infra/envs/<env>`; the restore target is a **new instance**, never in-place over the evidence.
+- Restore the latest snapshot from *before* the corruption window.
+- Point a **staging copy** of the app at the restored instance first — never production straight onto an unverified restore.
+
+## 2. Verify
+
+- Smoke against the staging copy: `node scripts/forge-smoke.mjs <staging-url>`.
+- Domain checks: row counts vs the last-known-good metric, spot-check the records the incident report named, run the migration-status table against the app version.
+- Only then swing production to the restored instance (this is a deploy-approval action — `team.policy.approvals.deploy`).
+- **Data loss in the window is a disclosure decision**, not a technical detail: anything users wrote between snapshot and freeze is gone — escalate the disclosure note (forge:respond §3 applies even when the cause isn't security).
+
+## 3. Postmortem (mandatory — the incident cannot close without it)
+
+- Root cause, the window, what was lost, what the verify checks were, and **the guard that makes this class impossible** (migration test, constraint, backup-restore drill cadence).
+- `node plugin/scripts/care/incident.mjs close --ticket <n> --postmortem "#<postmortem-ticket>"` — the journal pair is what `/distill` learns from.
+
+**Standing discipline** (declared in spec §10 before the first schema change): migrations forward-only with a tested rollback story; CI runs them against a disposable instance; staging runs them before production. If this runbook is running because one of those was skipped, that goes in the postmortem too.

--- a/docs/guides/rollback-runbook.md
+++ b/docs/guides/rollback-runbook.md
@@ -1,0 +1,37 @@
+# Rollback runbook — redeploy the previous image digest
+
+**When:** production is broken and the last deploy is the suspect. Rollback first, diagnose second — a rolled-back production buys the fix time (forge:hotfix step 2).
+
+**Principle:** production runs **digests, not branches** (spec §10, build-once). Rolling back = pointing the service at the digest that was running before. No build, no merge, no code.
+
+## 1. Find the previous digest
+
+Every promotion is recorded; check in this order:
+
+1. The **delivery log** issue / release notes — each release body names the promoted digest.
+2. The registry: the previous release's semver tag (`v<prev>`), or the staging SHA tag that release retagged.
+3. The running service's own history (e.g. `gcloud run revisions list` / `docker service ps` — the platform keeps prior revisions).
+
+## 2. Redeploy it — one command
+
+The production deploy workflow deploys a named digest; give it the previous one:
+
+```
+gh workflow run deploy-production.yml -f digest=<registry>/<app>@sha256:<previous>
+```
+
+(or the platform-native one-liner, e.g. `gcloud run services update-traffic <app> --to-revisions <prev-revision>=100` — whatever the repo's `deploy` block names as the promote command.)
+
+**This is a production action — `team.policy.approvals.deploy` applies.** The decision comment approving the rollback *is* the authorization; don't wait for a "cleaner" moment.
+
+## 3. Verify
+
+- Smoke: `node scripts/forge-smoke.mjs <production-url>` — exit 0 required.
+- The incident symptom is gone (check the alert/report that opened the incident).
+
+## 4. Record
+
+- Trail note on the incident ticket: previous digest, rolled-back-at, verified-by.
+- The **incident stays open** — rollback is containment, not the fix. The fix ships via forge:hotfix; the postmortem closes the incident.
+
+**Forward-only exception:** if the bad deploy ran **irreversible migrations** (spec §10 data lifecycle), plain rollback can crash the old code against the new schema — switch to the [data-recovery runbook](data-recovery-runbook.md) decision tree first.

--- a/plugin/scripts/backends/runrole.mjs
+++ b/plugin/scripts/backends/runrole.mjs
@@ -6,6 +6,7 @@ import { ADAPTERS } from './agy.mjs';
 import { scanPrompt } from './presend.mjs';
 import { extractReport, citeOrDrop } from './report.mjs';
 import { append as journalAppend } from '../lib/journal.mjs';
+import { deriveSituation } from '../lib/situation.mjs';
 
 const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -24,6 +25,14 @@ export async function runRole({ role, taskBrief, cwd, roster = {}, branchName = 
   }
   if (resolved.runtime === 'claude') {
     return { ok: true, claude: true, model: resolved.model, warnings: resolved.warnings };
+  }
+
+  // security-response freezes CLI backends: no repo content reaches third-party
+  // models during a suspected leak (spec §7/§4 item 18) — Claude-side fallback.
+  const situation = await deriveSituation(cwd);
+  if (situation.key === 'security-response') {
+    await journalAppend(cwd, 'backend-fallback', { role, reason: 'security-response', detail: `CLI backend ${resolved.runtime} frozen during security-response` });
+    return { ok: true, claude: true, model: null, fellBack: true, why: 'security-response: CLI backends frozen' };
   }
 
   const adapter = adapters[resolved.runtime];

--- a/plugin/scripts/care/incident.mjs
+++ b/plugin/scripts/care/incident.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Incident + security-response mechanics (spec §4 items 8/18, §7, §8; SP10 T1).
+ * The journal is the source of truth — these commands write the events
+ * `deriveSituation` consumes; nothing sets a situation by hand.
+ *
+ *   incident.mjs open --ticket <n> --summary "…"        -> situation: incident
+ *   incident.mjs close --ticket <n> --postmortem "<ref>" -> cleared
+ *   incident.mjs respond-open --reason "…"               -> security-response
+ *   incident.mjs respond-close --postmortem "<ref>"      -> cleared
+ *
+ * close/respond-close REQUIRE a postmortem ref — the mandatory-postmortem law
+ * is enforced where the state clears, not requested in prose.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { append as journalAppend } from '../lib/journal.mjs';
+import { deriveSituation } from '../lib/situation.mjs';
+
+export function parseArgs(argv) {
+  const a = { cmd: argv[0] ?? null, ticket: null, summary: null, postmortem: null, reason: null };
+  for (let i = 1; i < argv.length; i++) {
+    if (argv[i] === '--ticket') a.ticket = Number(argv[++i]);
+    else if (argv[i] === '--summary') a.summary = argv[++i];
+    else if (argv[i] === '--postmortem') a.postmortem = argv[++i];
+    else if (argv[i] === '--reason') a.reason = argv[++i];
+  }
+  return a;
+}
+
+export async function runIncident(cwd, args, log = console.log) {
+  switch (args.cmd) {
+    case 'open': {
+      if (!Number.isInteger(args.ticket) || !args.summary) return { ok: false, error: 'open needs --ticket <n> and --summary "…"' };
+      await journalAppend(cwd, 'incident', { phase: 'open', ticket: `#${args.ticket}`, summary: args.summary });
+      break;
+    }
+    case 'close': {
+      if (!Number.isInteger(args.ticket) || !args.postmortem) {
+        return { ok: false, error: 'close needs --ticket <n> and --postmortem "<ticket/link>" — an incident without a postmortem never happened as far as learning is concerned (spec §4 item 8)' };
+      }
+      await journalAppend(cwd, 'incident', { phase: 'closed', ticket: `#${args.ticket}`, postmortem: args.postmortem });
+      break;
+    }
+    case 'respond-open': {
+      if (!args.reason) return { ok: false, error: 'respond-open needs --reason "…"' };
+      await journalAppend(cwd, 'respond-open', { reason: args.reason });
+      break;
+    }
+    case 'respond-close': {
+      if (!args.postmortem) {
+        return { ok: false, error: 'respond-close needs --postmortem "<ticket/link>" — containment is done only when the postmortem is filed (spec §4 item 18)' };
+      }
+      await journalAppend(cwd, 'respond-close', { postmortem: args.postmortem });
+      break;
+    }
+    default:
+      return { ok: false, error: 'usage: incident.mjs <open|close|respond-open|respond-close> …' };
+  }
+  const s = await deriveSituation(cwd);
+  log(`${args.cmd}: situation is now ${s.glyph} ${s.key}`);
+  return { ok: true, situation: s.key };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  runIncident(process.cwd(), parseArgs(process.argv.slice(2))).then((res) => {
+    if (!res.ok) { console.error(res.error); process.exit(1); }
+  });
+}

--- a/plugin/scripts/gates/situationgate.mjs
+++ b/plugin/scripts/gates/situationgate.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Situation gate (spec §7 — situations change what's ALLOWED; SP10 T2).
+ *   --action ship    [--branch <name>]   incident: hotfix/* only · security-response: refused
+ *   --action release                     incident or security-response: refused
+ *   --action backend                     security-response: refused (CLI backends frozen)
+ *   --action skill   --skill <name>      security-response: respond/investigate only
+ * Exit 0 = proceed, 1 = refused (teaching message names the unlocking command).
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { deriveSituation } from '../lib/situation.mjs';
+import { parseBranch } from '../lib/ticket.mjs';
+
+const RESPOND_SKILLS = ['respond', 'investigate'];
+const UNLOCK = {
+  incident: 'close it first: node plugin/scripts/care/incident.mjs close --ticket <n> --postmortem "<ref>"',
+  'security-response': 'containment first; clear with: node plugin/scripts/care/incident.mjs respond-close --postmortem "<ref>"',
+};
+
+export function parseArgs(argv) {
+  const a = { action: null, branch: '', skill: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--action') a.action = argv[++i];
+    else if (argv[i] === '--branch') a.branch = argv[++i];
+    else if (argv[i] === '--skill') a.skill = argv[++i];
+  }
+  return a;
+}
+
+/** Pure rule table: (situationKey, action, {branch, skill}) -> {allowed, why}. */
+export function evaluate(situationKey, action, { branch = '', skill = null } = {}) {
+  if (situationKey === 'security-response') {
+    if (action === 'skill' && RESPOND_SKILLS.includes(skill)) return { allowed: true, why: `${skill} runs during security-response` };
+    return {
+      allowed: false,
+      why: `security-response: deploys frozen, CLI backends disabled, only ${RESPOND_SKILLS.join('/')} run (spec §7). ${UNLOCK['security-response']}`,
+    };
+  }
+  if (situationKey === 'incident') {
+    if (action === 'ship') {
+      const kind = parseBranch(branch).kind;
+      if (kind === 'hotfix') return { allowed: true, why: 'hotfix branch — the incident lane' };
+      return { allowed: false, why: `incident: ship/release pause for non-hotfix branches (spec §7); '${branch || '?'}' is not hotfix/*. ${UNLOCK.incident}` };
+    }
+    if (action === 'release') return { allowed: false, why: `incident: releases pause until the incident closes. ${UNLOCK.incident}` };
+  }
+  return { allowed: true, why: `situation '${situationKey}' does not restrict '${action}'` };
+}
+
+export async function runGate(cwd, args, log = console.log) {
+  if (!['ship', 'release', 'backend', 'skill'].includes(args.action)) {
+    return { ok: false, allowed: false, error: '--action must be ship|release|backend|skill' };
+  }
+  const s = await deriveSituation(cwd);
+  const verdict = evaluate(s.key, args.action, args);
+  log(`situation-gate [${s.glyph} ${s.key}] ${args.action}${args.branch ? ` (${args.branch})` : ''}${args.skill ? ` (${args.skill})` : ''}: ${verdict.allowed ? 'proceed' : 'REFUSED'} — ${verdict.why}`);
+  return { ok: true, allowed: verdict.allowed, situation: s.key, why: verdict.why };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  runGate(process.cwd(), parseArgs(process.argv.slice(2))).then((res) => {
+    if (!res.ok) { console.error(res.error); process.exit(1); }
+    process.exit(res.allowed ? 0 : 1);
+  });
+}

--- a/plugin/scripts/release/readiness.mjs
+++ b/plugin/scripts/release/readiness.mjs
@@ -1,4 +1,5 @@
 import { read as readJournal } from '../lib/journal.mjs';
+import { deriveSituation } from '../lib/situation.mjs';
 
 /**
  * Computed release-readiness checklist (spec §13) — forge:release refuses
@@ -12,6 +13,14 @@ export async function computeReadiness({ cwd, execFn, config, verifyCmd }) {
   const failItem = (name, msg) => items.push({ name, level: 'fail', msg });
 
   const git = (...args) => execFn('git', args);
+
+  // a release never cuts during an emergency (spec §7; SP10 T3)
+  const situation = await deriveSituation(cwd);
+  if (situation.key === 'incident' || situation.key === 'security-response') {
+    failItem('situation', `situation is ${situation.key} — close it first (node plugin/scripts/care/incident.mjs)`);
+  } else {
+    pass('situation', situation.key);
+  }
 
   const branch = await git('rev-parse', '--abbrev-ref', 'HEAD');
   if (!branch.ok || branch.stdout.trim() !== 'main') failItem('branch', `releases cut from main only (on '${branch.stdout.trim()}')`);

--- a/plugin/skills/hotfix/SKILL.md
+++ b/plugin/skills/hotfix/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: hotfix
+description: Expedited production-incident path — compressed ritual, uncompressed deploy chain, mandatory postmortem. Use when production is broken and the fix can't wait for the normal plan cycle.
+---
+
+# forge:hotfix
+
+The law (spec §4 item 8): **only the process ritual is compressed — the deploy path is not.** A hotfix skips the plan doc, not staging smoke.
+
+## Steps
+
+1. **Open the incident first**: `node "${CLAUDE_PLUGIN_ROOT}/scripts/care/incident.mjs" open --ticket <n> --summary "<what production symptom>"` — the ticket (create via forge:triage if none exists, type bug, p0). The situation flips to 🔥 incident; ship/release now refuse non-hotfix branches mechanically (situation gate).
+2. **Rollback-first decision**: can redeploying the previous image digest stop the bleeding now? If yes, run the [rollback runbook](../../../docs/guides/rollback-runbook.md) *before* writing any code — a rolled-back production buys the fix time. Data corruption → [data-recovery runbook](../../../docs/guides/data-recovery-runbook.md).
+3. **Scope note replaces the plan**: one paragraph on the ticket (trail `--phase plan`) — symptom, suspected cause, intended change, blast radius. That's the whole planning ritual.
+4. Branch `hotfix/<issue#>-<slug>` — the only branch kind the situation gate ships during an incident.
+5. **What stays**: verify green locally · security pass on the diff · regression test with the fix (investigate first if the cause is unknown — forge:investigate) · honest verification in the PR.
+6. **What the deploy keeps**: the full environment chain — merge → staging deploy → smoke → promote. It's minutes, not hours; a hotfix that skips staging is how one incident becomes two.
+7. **Close = postmortem**: create the postmortem ticket (mandatory — close refuses without it), then `incident.mjs close --ticket <n> --postmortem "#<postmortem>"`. The incident event pair is what `/distill` learns production lessons from.
+
+Trail comments at every step (started/plan/pr/ci-green/merged) — an incident is the last place for silent work.

--- a/plugin/skills/respond/SKILL.md
+++ b/plugin/skills/respond/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: respond
+description: Security incident response — containment before code. Use on suspected credential leak, injected code, malicious dependency, or any security breach signal.
+---
+
+# forge:respond
+
+The law (spec §4 item 18): **containment before code.** Respond contains and hands off — it never ships the fix itself.
+
+## 1. Contain (before anything else)
+
+1. `node "${CLAUDE_PLUGIN_ROOT}/scripts/care/incident.mjs" respond-open --reason "<signal>"` — the situation flips to 🔒 security-response, which **mechanically**: freezes ship/release for every branch, disables CLI backends (`runRole` falls back to Claude — no repo content reaches third-party models during a suspected leak), and leaves only respond + investigate runnable (situation gate).
+2. **Rotate/revoke** every credential the breach could have touched — tokens, deploy keys, service accounts. Rotation is containment; investigation waits.
+3. Deploys are frozen by the gate; if something is mid-deploy, let it finish or roll back — never push new code during containment.
+
+## 2. Forensics
+
+- The journal is evidence: `escalation`/`blocked-edit`/`backend-fallback` events, and **backend-call prompt hashes** show what left the machine and when.
+- `git log` + the graph's ticket edges scope what a compromised credential could reach.
+- **Scrub-and-rotate over history rewrites** (spec §4): a leaked secret is dead the moment it's rotated; rewriting published history is denylisted and destroys the evidence trail.
+
+## 3. Disclose & hand off
+
+- Users affected ⇒ a disclosure note is part of containment, not an afterthought.
+- The vulnerability fix ships via **forge:hotfix** *after* containment — respond opens that ticket and hands off; the hotfix runs under incident rules.
+
+## 4. Close
+
+Postmortem filed (mandatory), then `incident.mjs respond-close --postmortem "#<n>"` — the situation clears and normal work resumes. `respond-close` refuses without the postmortem ref.

--- a/plugin/skills/ship/SKILL.md
+++ b/plugin/skills/ship/SKILL.md
@@ -9,20 +9,21 @@ Branch → PR with gates, then the post-merge ritual. Since SP5 the core gates a
 
 ## Pre-PR checklist (in order — a failed gate stops the ritual)
 
-1. **Conventions lint** (spec §2): branch matches `<type>/<issue#>-<slug>`; every commit `type(scope): subject (#issue)` ≤72 chars; intended PR title is conventional-format with the issue ref. **Spike branches never ship** — a `spike/…` branch asking for a PR is refused outright (spec §4 item 12: findings merge as ADRs, code is re-implemented via plan/execute).
-2. **Rebase on main**; run the configured verify command — must pass locally.
-3. **Commits→issues map**: every commit has a ticket; otherwise apply the unplanned-work rule (trail `note` or triage).
-4. **Mechanical gates** (spec §13):
+1. **Situation gate** (spec §7): `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/situationgate.mjs" --action ship --branch <branch>` — during an incident only `hotfix/*` ships; during security-response nothing ships. A refusal names the unlocking command; don't argue with it.
+2. **Conventions lint** (spec §2): branch matches `<type>/<issue#>-<slug>`; every commit `type(scope): subject (#issue)` ≤72 chars; intended PR title is conventional-format with the issue ref. **Spike branches never ship** — a `spike/…` branch asking for a PR is refused outright (spec §4 item 12: findings merge as ADRs, code is re-implemented via plan/execute).
+3. **Rebase on main**; run the configured verify command — must pass locally.
+4. **Commits→issues map**: every commit has a ticket; otherwise apply the unplanned-work rule (trail `note` or triage).
+5. **Mechanical gates** (spec §13):
    - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/plandrift.mjs" --plan <plan>` — off-plan files ⇒ escalate or a reviewer-visible `.forge/scope.json` extension
    - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/testintent.mjs"` — weakened existing assertions ⇒ explicit reviewer sign-off in the PR body, or revert
    - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/depguard.mjs"` — new-dependency violations ⇒ remove or escalate
    - **AC gate**: `vitest run --reporter=json --outputFile=.forge/results.json` then `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/acgate.mjs" --plan <plan> --ticket <n> --results .forge/results.json` — every AC id in a passing test, machine evidence only
-5. **Security pass** (`security` role card on the full branch diff): findings journaled; criticals escalate.
-6. **Review pass** (`reviewer` role card; `design-reviewer` for UI when `features.designReview`).
-7. **Honest verification statement** for the PR body: what ran, what passed, what was NOT verified. Never overstate.
-8. Open the PR: `Closes #<n>` + commits→issues map + AC checklist + honest verification.
-9. Trail: `--phase pr`; on checks: `--phase ci-green` or `--phase gate-fail` (cause + fix, repeat).
-10. **CI-green check**: never ask for merge with failing checks.
+6. **Security pass** (`security` role card on the full branch diff): findings journaled; criticals escalate.
+7. **Review pass** (`reviewer` role card; `design-reviewer` for UI when `features.designReview`).
+8. **Honest verification statement** for the PR body: what ran, what passed, what was NOT verified. Never overstate.
+9. Open the PR: `Closes #<n>` + commits→issues map + AC checklist + honest verification.
+10. Trail: `--phase pr`; on checks: `--phase ci-green` or `--phase gate-fail` (cause + fix, repeat).
+11. **CI-green check**: never ask for merge with failing checks.
 
 ## Escalation triggers during ship (spec §7 — halt, don't improvise)
 

--- a/tests/care/incident.test.mjs
+++ b/tests/care/incident.test.mjs
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runIncident, parseArgs } from '../../plugin/scripts/care/incident.mjs';
+import { evaluate, runGate } from '../../plugin/scripts/gates/situationgate.mjs';
+import { deriveSituation } from '../../plugin/scripts/lib/situation.mjs';
+import { computeReadiness } from '../../plugin/scripts/release/readiness.mjs';
+import { runRole } from '../../plugin/scripts/backends/runrole.mjs';
+
+const noop = () => {};
+const tmp = () => mkdtemp(join(tmpdir(), 'forge-inc-'));
+
+describe('incident open/close (AC-10.1)', () => {
+  it('AC-10.1: open flips the situation to incident; close with postmortem clears it', async () => {
+    const cwd = await tmp();
+    const open = await runIncident(cwd, parseArgs(['open', '--ticket', '42', '--summary', 'prod healthcheck failing']), noop);
+    expect(open).toMatchObject({ ok: true, situation: 'incident' });
+    expect((await deriveSituation(cwd)).key).toBe('incident');
+
+    const noPm = await runIncident(cwd, parseArgs(['close', '--ticket', '42']), noop);
+    expect(noPm.ok).toBe(false);
+    expect(noPm.error).toMatch(/postmortem/);
+    expect((await deriveSituation(cwd)).key).toBe('incident'); // refusal wrote nothing
+
+    const close = await runIncident(cwd, parseArgs(['close', '--ticket', '42', '--postmortem', '#43']), noop);
+    expect(close.ok).toBe(true);
+    expect((await deriveSituation(cwd)).key).toBe('idle');
+
+    const journal = await readFile(join(cwd, '.forge', 'journal.jsonl'), 'utf8');
+    expect(journal).toContain('"summary":"prod healthcheck failing"');
+    expect(journal).toContain('"postmortem":"#43"');
+  });
+});
+
+describe('respond-open/close (AC-10.2)', () => {
+  it('AC-10.2: respond-open outranks an open incident; respond-close needs a postmortem', async () => {
+    const cwd = await tmp();
+    await runIncident(cwd, parseArgs(['open', '--ticket', '1', '--summary', 's']), noop);
+    const ro = await runIncident(cwd, parseArgs(['respond-open', '--reason', 'leaked token suspected']), noop);
+    expect(ro.situation).toBe('security-response'); // outranks incident
+
+    expect((await runIncident(cwd, parseArgs(['respond-close']), noop)).ok).toBe(false);
+    await runIncident(cwd, parseArgs(['respond-close', '--postmortem', '#9']), noop);
+    expect((await deriveSituation(cwd)).key).toBe('incident'); // incident still open underneath
+  });
+});
+
+describe('situation gate (AC-10.3)', () => {
+  it('AC-10.3: incident — hotfix ships, others refused with the unlocking command; release refused', () => {
+    expect(evaluate('incident', 'ship', { branch: 'hotfix/42-fix-crash' }).allowed).toBe(true);
+    const refused = evaluate('incident', 'ship', { branch: 'feat/13-hotfix-respond' });
+    expect(refused.allowed).toBe(false);
+    expect(refused.why).toMatch(/incident\.mjs close/);
+    expect(evaluate('incident', 'release', {}).allowed).toBe(false);
+    expect(evaluate('incident', 'backend', {}).allowed).toBe(true);
+  });
+
+  it('AC-10.3: security-response — only respond/investigate skills pass', () => {
+    expect(evaluate('security-response', 'skill', { skill: 'respond' }).allowed).toBe(true);
+    expect(evaluate('security-response', 'skill', { skill: 'investigate' }).allowed).toBe(true);
+    expect(evaluate('security-response', 'skill', { skill: 'execute' }).allowed).toBe(false);
+    expect(evaluate('security-response', 'ship', { branch: 'hotfix/1-x' }).allowed).toBe(false);
+    expect(evaluate('security-response', 'backend', {}).allowed).toBe(false);
+    expect(evaluate('security-response', 'release', {}).why).toMatch(/respond-close/);
+  });
+
+  it('normal situations restrict nothing; runGate reads the journal live', async () => {
+    expect(evaluate('building', 'ship', { branch: 'feat/1-x' }).allowed).toBe(true);
+    const cwd = await tmp();
+    await runIncident(cwd, parseArgs(['open', '--ticket', '1', '--summary', 's']), noop);
+    const res = await runGate(cwd, { action: 'ship', branch: 'feat/1-x', skill: null }, noop);
+    expect(res).toMatchObject({ ok: true, allowed: false, situation: 'incident' });
+  });
+});
+
+describe('CLI backend freeze (AC-10.4)', () => {
+  const roster = { investigator: { backend: 'agy:gemini-flash' } };
+
+  it('AC-10.4: a CLI-pinned role falls back to Claude during security-response, journaled', async () => {
+    const cwd = await tmp();
+    await runIncident(cwd, parseArgs(['respond-open', '--reason', 'r']), noop);
+    const res = await runRole({ role: 'investigator', taskBrief: 'look', cwd, roster, execFn: async () => ({ ok: true, code: 0, stdout: '', stderr: '' }) });
+    expect(res).toMatchObject({ ok: true, claude: true, fellBack: true });
+    expect(res.why).toMatch(/security-response/);
+    const journal = await readFile(join(cwd, '.forge', 'journal.jsonl'), 'utf8');
+    expect(journal).toContain('"reason":"security-response"');
+  });
+
+  it('AC-10.4: Claude-pinned roles are untouched during security-response', async () => {
+    const cwd = await tmp();
+    await runIncident(cwd, parseArgs(['respond-open', '--reason', 'r']), noop);
+    const res = await runRole({ role: 'security', taskBrief: 'scan', cwd, roster: {}, execFn: async () => ({ ok: true }) });
+    expect(res).toMatchObject({ ok: true, claude: true });
+    expect(res.fellBack).toBeUndefined();
+  });
+});
+
+describe('release readiness during emergencies (AC-10.5)', () => {
+  const gitOk = async (cmd, args) => {
+    if (args?.includes('--abbrev-ref')) return { ok: true, stdout: 'main\n', stderr: '' };
+    if (args?.includes('--porcelain')) return { ok: true, stdout: '', stderr: '' };
+    if (args?.includes('--count')) return { ok: true, stdout: '0\n', stderr: '' };
+    return { ok: true, stdout: '', stderr: '' };
+  };
+
+  it('AC-10.5: readiness fails with a situation item during incident, passes after close', async () => {
+    const cwd = await tmp();
+    await runIncident(cwd, parseArgs(['open', '--ticket', '1', '--summary', 's']), noop);
+    const during = await computeReadiness({ cwd, execFn: gitOk, config: {}, verifyCmd: null });
+    const item = during.items.find((i) => i.name === 'situation');
+    expect(during.ok).toBe(false);
+    expect(item).toMatchObject({ level: 'fail' });
+    expect(item.msg).toMatch(/incident/);
+
+    await runIncident(cwd, parseArgs(['close', '--ticket', '1', '--postmortem', '#2']), noop);
+    const after = await computeReadiness({ cwd, execFn: gitOk, config: {}, verifyCmd: null });
+    expect(after.items.find((i) => i.name === 'situation')).toMatchObject({ level: 'pass' });
+  });
+});
+
+describe('skills + runbooks carry the laws (AC-10.6)', () => {
+  const read = (rel) => readFile(new URL(rel, import.meta.url), 'utf8');
+
+  it('AC-10.6: hotfix/respond skills and both runbooks state the laws', async () => {
+    const hotfix = await read('../../plugin/skills/hotfix/SKILL.md');
+    expect(hotfix).toMatch(/only the process ritual is compressed — the deploy path is not/i);
+    expect(hotfix).toMatch(/postmortem/i);
+    expect(hotfix).toMatch(/staging/i);
+
+    const respond = await read('../../plugin/skills/respond/SKILL.md');
+    expect(respond).toMatch(/containment before code/i);
+    expect(respond).toMatch(/scrub-and-rotate over history rewrites/i);
+    expect(respond).toMatch(/hands off/i);
+
+    const rollback = await read('../../docs/guides/rollback-runbook.md');
+    expect(rollback).toMatch(/digests, not branches/i);
+    expect(rollback).toMatch(/rollback is containment, not the fix/i);
+
+    const recovery = await read('../../docs/guides/data-recovery-runbook.md');
+    expect(recovery).toMatch(/restore → verify → postmortem/i);
+    expect(recovery).toMatch(/never debug against the only copy/i);
+
+    const ship = await read('../../plugin/skills/ship/SKILL.md');
+    expect(ship).toMatch(/situationgate\.mjs/);
+  });
+});


### PR DESCRIPTION
Closes #13. Plan: [docs/plans/2026-07-17-sp10-hotfix-respond.md](https://github.com/dngioidev/forge/blob/main/docs/plans/2026-07-17-sp10-hotfix-respond.md)

## What

- **`incident.mjs`** — open/close + respond-open/close write the journal events `deriveSituation` already consumes (nothing sets a situation by hand). The mandatory-postmortem law is enforced where state clears: close/respond-close **refuse** without a postmortem ref.
- **`situationgate.mjs`** — situations change what's *allowed*, mechanically: incident ⇒ only `hotfix/*` ships and releases pause; security-response ⇒ nothing ships, CLI backends frozen, only respond/investigate skills run. Refusals name the unlocking command. `forge:ship` now runs it as step 1.
- **Wiring**: `runRole` sends CLI-pinned roles to the Claude fallback during security-response (journaled — no repo content reaches third-party models during a suspected leak); release readiness gains a `situation` item that fails during emergencies.
- **Skills**: hotfix (compressed ritual, *uncompressed deploy chain* — staging smoke stays; rollback-first decision point) · respond (containment before code; rotate/revoke first; scrub-and-rotate over history rewrites; hands the fix to hotfix).
- **Runbooks**: rollback (previous digest, one command, 'rollback is containment, not the fix') · data-recovery (restore → verify → postmortem; never debug against the only copy).

## Commits → issues

All commits → #13 (plan on main: `1f05f8a`).

## AC checklist (acgate: 6/6 green)

- [x] AC-10.1 incident open/close drives the situation; close requires postmortem
- [x] AC-10.2 security-response outranks incident; respond-close requires postmortem
- [x] AC-10.3 gate rules per situation with teaching messages
- [x] AC-10.4 CLI freeze during security-response, journaled; Claude roles untouched
- [x] AC-10.5 readiness fails during emergencies, passes after close
- [x] AC-10.6 skills + runbooks carry the laws (verbatim-checked)

## Verification (honest)

- 239/239 tests (9 new); gates live on the branch: plandrift clean (11 files), testintent clean, depguard clean, acgate 6/6.
- **Live dogfood on this repo**: opened a real incident → statusline showed 🔥, the gate refused *this very branch* (non-hotfix) with the unlocking command, passed `hotfix/13-fix`, close-with-postmortem cleared it and ship re-opened. The event pair is in the journal for /distill.
- **NOT verified**: a real production rollback/data-restore (no deployed environment exists — runbooks are checklists, their commands mirror the SP4b workflows but have not run); auto-opening incidents from observability alerts (out of scope, needs provisioned cloud).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x