### PR TITLE
feat: SP11 forge:maintain — dep cadence + CVE SLA triage (#14)

### DIFF
--- a/plugin/scripts/care/maintain.mjs
+++ b/plugin/scripts/care/maintain.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * forge:maintain mechanics (spec §4 item 9; SP11) — the cms #70 lesson as
+ * platform law: dependencies are batched routine work, not a PR queue.
+ *
+ *   maintain.mjs plan [--json]     outdated scan -> batch plan + majors list
+ *   maintain.mjs advisories        dependabot alerts -> SLA-stamped triage lines
+ *
+ * npm-family repos only (package.json); other ecosystems get a teaching error —
+ * the adapter pattern (deploy stacks, graph TS-only) applies when needed.
+ */
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+
+export function parseSemver(v) {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(v ?? '');
+  return m ? { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) } : null;
+}
+
+/** patch | minor | major | null (current, downgrade, or unparseable). */
+export function classifyBump(current, latest) {
+  const c = parseSemver(current);
+  const l = parseSemver(latest);
+  if (!c || !l) return null;
+  if (l.major > c.major) return 'major';
+  if (l.major === c.major && l.minor > c.minor) return 'minor';
+  if (l.major === c.major && l.minor === c.minor && l.patch > c.patch) return 'patch';
+  return null;
+}
+
+export async function scanOutdated(cwd, fetchFn = globalThis.fetch) {
+  let pkg;
+  try {
+    pkg = JSON.parse(await readFile(join(cwd, 'package.json'), 'utf8'));
+  } catch {
+    return { ok: false, error: 'no package.json — forge:maintain covers npm-family repos; other ecosystems arrive as adapters when an owner repo needs one (spec §4 item 9)' };
+  }
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+  const results = [];
+  for (const [name, range] of Object.entries(deps)) {
+    const current = range.replace(/^[~^><=\s]+/, '');
+    try {
+      const res = await fetchFn(`https://registry.npmjs.org/${encodeURIComponent(name)}/latest`);
+      if (!res.ok) { results.push({ name, current, latest: null, bump: null, note: `registry ${res.status}` }); continue; }
+      const latest = (await res.json()).version ?? null;
+      results.push({ name, current, latest, bump: classifyBump(current, latest) });
+    } catch (e) {
+      results.push({ name, current, latest: null, bump: null, note: e.message });
+    }
+  }
+  return { ok: true, results };
+}
+
+/** The law, mechanically: patch+minor -> ONE batch; majors -> ONE coordinated ticket, never the batch. */
+export function planBatch(results, date) {
+  const batch = results.filter((r) => r.bump === 'patch' || r.bump === 'minor');
+  const majors = results.filter((r) => r.bump === 'major');
+  return {
+    batch: {
+      branch: `chore/dep-batch-${date}`,
+      bumps: batch.map((r) => ({ name: r.name, from: r.current, to: r.latest, bump: r.bump })),
+      ritual: 'one branch, all bumps, verify green, one PR through the normal ship gates',
+    },
+    majors: {
+      bumps: majors.map((r) => ({ name: r.name, from: r.current, to: r.latest, changelog: `https://www.npmjs.com/package/${r.name}?activeTab=versions` })),
+      ritual: majors.length ? 'ONE coordinated upgrade ticket via forge:triage — majors are never merged individually (spec §4 item 9)' : null,
+    },
+    current: results.filter((r) => r.bump === null && !r.note).length,
+    unresolvable: results.filter((r) => r.note).map((r) => ({ name: r.name, note: r.note })),
+  };
+}
+
+export function renderPlan(plan) {
+  const lines = [];
+  if (plan.batch.bumps.length) {
+    lines.push(`## Batch (${plan.batch.bumps.length}) → ${plan.batch.branch}`);
+    for (const b of plan.batch.bumps) lines.push(`- ${b.name} ${b.from} → ${b.to} (${b.bump})`);
+    lines.push(plan.batch.ritual, '');
+  }
+  if (plan.majors.bumps.length) {
+    lines.push(`## Majors (${plan.majors.bumps.length}) — one coordinated ticket`);
+    for (const m of plan.majors.bumps) lines.push(`- ${m.name} ${m.from} → ${m.to} — ${m.changelog}`);
+    lines.push(plan.majors.ritual, '');
+  }
+  if (!plan.batch.bumps.length && !plan.majors.bumps.length) lines.push('everything current — nothing to maintain');
+  else lines.push(`${plan.current} package(s) already current`);
+  if (plan.unresolvable.length) lines.push(`unresolvable: ${plan.unresolvable.map((u) => u.name).join(', ')}`);
+  return lines.join('\n');
+}
+
+export const SLA_HOURS = { critical: 24, high: 72, medium: 168, low: null };
+const rank = (sev) => ['critical', 'high', 'medium', 'low'].indexOf(sev) + 1 || 5;
+
+export function triageAlerts(alerts, now = Date.now()) {
+  return alerts
+    .filter((a) => a.state === 'open')
+    .map((a) => {
+      const sev = a.security_advisory?.severity ?? 'low';
+      const hours = SLA_HOURS[sev] ?? null;
+      const deadline = hours ? new Date(Date.parse(a.created_at) + hours * 3_600_000).toISOString() : null;
+      const overdue = deadline ? Date.parse(deadline) < now : false;
+      return {
+        number: a.number,
+        pkg: a.dependency?.package?.name ?? 'unknown',
+        severity: sev,
+        summary: a.security_advisory?.summary ?? '',
+        deadline,
+        overdue,
+        sla: hours ? `${hours}h` : 'next maintain run',
+      };
+    })
+    .sort((x, y) => (y.overdue - x.overdue) || (rank(x.severity) - rank(y.severity)));
+}
+
+export async function fetchAlerts(gh, owner, repo) {
+  const res = await gh(['api', `repos/${owner}/${repo}/dependabot/alerts?state=open&per_page=100`], { parseJson: true });
+  if (!res.ok) {
+    if (/dependabot alerts are disabled|403|404/i.test(res.stderr)) {
+      return { ok: false, disabled: true, error: 'Dependabot alerts are not enabled — turn them on in repo Settings → Code security (spec §4 item 9 needs the feed); scan still possible via `npm audit` manually' };
+    }
+    return { ok: false, error: res.stderr || 'alerts query failed' };
+  }
+  return { ok: true, alerts: res.json };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const cmd = process.argv[2];
+  const cwd = process.cwd();
+  const fail = (msg) => { console.error(msg); process.exit(1); };
+  if (cmd === 'plan') {
+    scanOutdated(cwd).then((res) => {
+      if (!res.ok) fail(res.error);
+      const plan = planBatch(res.results, new Date().toISOString().slice(0, 10));
+      console.log(process.argv.includes('--json') ? JSON.stringify(plan, null, 2) : renderPlan(plan));
+    });
+  } else if (cmd === 'advisories') {
+    const gh = makeGh(run);
+    import('../lib/board.mjs').then(async ({ getRepoInfo }) => {
+      const repo = await getRepoInfo(gh);
+      if (!repo.ok) fail(repo.error);
+      const res = await fetchAlerts(gh, repo.owner, repo.name);
+      if (!res.ok) fail(res.error);
+      const triaged = triageAlerts(res.alerts);
+      if (triaged.length === 0) { console.log('no open advisories'); return; }
+      for (const t of triaged) {
+        console.log(`${t.overdue ? '⏰ OVERDUE' : '·'} [${t.severity}] ${t.pkg} — ${t.summary} (alert #${t.number}, SLA ${t.sla}${t.deadline ? `, due ${t.deadline}` : ''})`);
+      }
+    });
+  } else {
+    fail('usage: maintain.mjs <plan [--json]|advisories>');
+  }
+}

--- a/plugin/skills/maintain/SKILL.md
+++ b/plugin/skills/maintain/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: maintain
+description: Dependency cadence + CVE triage — patch/minor batched into one PR, majors bundled into one coordinated ticket, advisories on an SLA. Run on demand or as a scheduled routine.
+---
+
+# forge:maintain
+
+The cms #70 lesson as platform law (spec §4 item 9): dependencies are **batched routine work, not a PR queue**. Twenty Dependabot PRs is a process failure, not diligence.
+
+## Cadence ritual
+
+1. `node "${CLAUDE_PLUGIN_ROOT}/scripts/care/maintain.mjs" plan` — outdated scan, classified patch/minor/major.
+2. **Patch + minor → one batch**: ticket (type `chore`) → branch `chore/<issue#>-dep-batch-<date>` → apply every bump → verify green → **one PR** through the normal ship gates (depguard sees version changes, not new deps; testintent guards the suite). Auto-verified means the suite decides, not optimism — a bump that breaks verify drops out of the batch and gets its own line in the ticket.
+3. **Majors → ONE coordinated upgrade ticket, never merged individually**: the plan output lists each major with its changelog link; triage them into a single ticket that names the order, the breaking changes, and the verify evidence each step needs. A major upgrade is planned work (forge:plan), not a checkbox.
+4. Trail comments on the ticket at every step, delivery-log row on merge — routine work is still ticket-first.
+
+## CVE triage (SLA is the law)
+
+`node "${CLAUDE_PLUGIN_ROOT}/scripts/care/maintain.mjs" advisories` — open Dependabot alerts, SLA-stamped from each alert's own createdAt:
+
+| severity | SLA |
+| --- | --- |
+| critical | 24h — treat as forge:hotfix input; if exploitation is suspected, forge:respond first |
+| high | 72h |
+| medium | 7 days |
+| low | next maintain run |
+
+Every open advisory becomes a ticket via forge:triage with its deadline in the body; ⏰ OVERDUE lines are the first thing the next session handles. Alerts disabled ⇒ the script says how to enable them — that setting is part of doctor's secret-scanning family of owner steps.
+
+## Scheduling
+
+On demand is the floor. For a routine: a consumer repo adds one cron workflow step calling `maintain.mjs plan --json` and opening/refreshing the batch ticket (spec row 11: pull earlier if Dependabot pain returns). forge itself runs on demand.

--- a/tests/care/maintain.test.mjs
+++ b/tests/care/maintain.test.mjs
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parseSemver, classifyBump, scanOutdated, planBatch, renderPlan,
+  triageAlerts, fetchAlerts, SLA_HOURS,
+} from '../../plugin/scripts/care/maintain.mjs';
+import { fakeGh } from '../helpers/fakegh.mjs';
+
+const NOW = Date.parse('2026-07-17T12:00:00Z');
+
+describe('outdated classification (AC-11.1)', () => {
+  it('AC-11.1: patch/minor/major from semver distance; current and weird versions -> null', () => {
+    expect(classifyBump('1.2.3', '1.2.4')).toBe('patch');
+    expect(classifyBump('1.2.3', '1.3.0')).toBe('minor');
+    expect(classifyBump('1.2.3', '2.0.0')).toBe('major');
+    expect(classifyBump('1.2.3', '1.2.3')).toBe(null);
+    expect(classifyBump('2.0.0', '1.9.9')).toBe(null); // downgrade is not a bump
+    expect(classifyBump('workspace:*', '1.0.0')).toBe(null);
+    expect(parseSemver('v3.2.4')).toEqual({ major: 3, minor: 2, patch: 4 });
+  });
+
+  it('AC-11.1: scan reads ranges, tolerates registry misses, refuses non-npm repos', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-mnt-'));
+    await writeFile(join(dir, 'package.json'), JSON.stringify({
+      dependencies: { alpha: '^1.0.0' },
+      devDependencies: { beta: '~2.1.0', ghost: '1.0.0' },
+    }), 'utf8');
+    const fetchFn = async (url) => {
+      if (url.includes('ghost')) return { ok: false, status: 404 };
+      if (url.includes('alpha')) return { ok: true, json: async () => ({ version: '1.4.0' }) };
+      return { ok: true, json: async () => ({ version: '2.1.9' }) };
+    };
+    const res = await scanOutdated(dir, fetchFn);
+    expect(res.ok).toBe(true);
+    expect(res.results.find((r) => r.name === 'alpha')).toMatchObject({ current: '1.0.0', latest: '1.4.0', bump: 'minor' });
+    expect(res.results.find((r) => r.name === 'beta').bump).toBe('patch');
+    expect(res.results.find((r) => r.name === 'ghost')).toMatchObject({ bump: null, note: 'registry 404' });
+
+    const empty = await scanOutdated(await mkdtemp(join(tmpdir(), 'forge-mnt2-')));
+    expect(empty.ok).toBe(false);
+    expect(empty.error).toMatch(/npm-family/);
+  });
+});
+
+describe('batch plan (AC-11.2)', () => {
+  const results = [
+    { name: 'a', current: '1.0.0', latest: '1.0.9', bump: 'patch' },
+    { name: 'b', current: '1.0.0', latest: '1.2.0', bump: 'minor' },
+    { name: 'c', current: '1.0.0', latest: '3.0.0', bump: 'major' },
+    { name: 'd', current: '2.0.0', latest: '2.0.0', bump: null },
+    { name: 'e', current: '1.0.0', latest: null, bump: null, note: 'registry 404' },
+  ];
+
+  it('AC-11.2: patch+minor in one batch; majors only in the coordinated list — never both', () => {
+    const plan = planBatch(results, '2026-07-17');
+    expect(plan.batch.branch).toBe('chore/dep-batch-2026-07-17');
+    expect(plan.batch.bumps.map((b) => b.name)).toEqual(['a', 'b']);
+    expect(plan.majors.bumps.map((m) => m.name)).toEqual(['c']);
+    expect(plan.majors.ritual).toMatch(/never merged individually/);
+    expect(plan.current).toBe(1);
+    expect(plan.unresolvable).toEqual([{ name: 'e', note: 'registry 404' }]);
+
+    const out = renderPlan(plan);
+    expect(out).toContain('Batch (2)');
+    expect(out).toContain('Majors (1) — one coordinated ticket');
+    expect(out).not.toMatch(/Batch.*\n.*- c /); // the major never leaks into the batch section
+  });
+
+  it('all-current renders the clean message', () => {
+    expect(renderPlan(planBatch([{ name: 'd', current: '1.0.0', latest: '1.0.0', bump: null }], 'x'))).toContain('everything current');
+  });
+});
+
+describe('CVE triage (AC-11.3)', () => {
+  const alert = (n, severity, createdAt, state = 'open') => ({
+    number: n, state, created_at: createdAt,
+    dependency: { package: { name: `pkg${n}` } },
+    security_advisory: { severity, summary: `advisory ${n}` },
+  });
+
+  it('AC-11.3: SLA deadlines from the alert createdAt; overdue first, then severity', () => {
+    const triaged = triageAlerts([
+      alert(1, 'low', '2026-07-17T00:00:00Z'),
+      alert(2, 'critical', '2026-07-15T00:00:00Z'),   // 24h SLA -> overdue
+      alert(3, 'high', '2026-07-17T00:00:00Z'),        // due 2026-07-20
+      alert(4, 'critical', '2026-07-17T11:00:00Z'),    // due tomorrow, not overdue
+      alert(5, 'high', '2026-07-01T00:00:00Z', 'fixed'), // closed — excluded
+    ], NOW);
+    expect(triaged.map((t) => t.number)).toEqual([2, 4, 3, 1]);
+    expect(triaged[0]).toMatchObject({ overdue: true, deadline: '2026-07-16T00:00:00.000Z', sla: '24h' });
+    expect(triaged.find((t) => t.number === 3).deadline).toBe('2026-07-20T00:00:00.000Z');
+    expect(triaged.find((t) => t.number === 1)).toMatchObject({ deadline: null, sla: 'next maintain run' });
+    expect(SLA_HOURS).toEqual({ critical: 24, high: 72, medium: 168, low: null });
+  });
+
+  it('AC-11.3: disabled alerts respond with the enable hint, not a crash', async () => {
+    const { gh } = fakeGh([[(j) => j.includes('dependabot/alerts'), { ok: false, stderr: 'HTTP 403: Dependabot alerts are disabled for this repository' }]]);
+    const res = await fetchAlerts(gh, 'o', 'r');
+    expect(res.ok).toBe(false);
+    expect(res.disabled).toBe(true);
+    expect(res.error).toMatch(/Settings/);
+  });
+});
+
+describe('skill carries the laws (AC-11.4)', () => {
+  it('AC-11.4: batch+one-PR, majors never individual, SLA table', async () => {
+    const skill = await readFile(new URL('../../plugin/skills/maintain/SKILL.md', import.meta.url), 'utf8');
+    expect(skill).toMatch(/one PR/i);
+    expect(skill).toMatch(/never merged individually/i);
+    expect(skill).toMatch(/\| critical \| 24h/);
+    expect(skill).toMatch(/batched routine work, not a PR queue/i);
+  });
+});


### PR DESCRIPTION
Closes #14 — **the last rollout epic**. Plan: [docs/plans/2026-07-17-sp11-maintain.md](https://github.com/dngioidev/forge/blob/main/docs/plans/2026-07-17-sp11-maintain.md)

## What

- **`maintain.mjs plan`** — registry scan (zero-dep REST, injected fetch), semver-classified; **patch+minor → one batch branch, one PR; majors → one coordinated ticket, never merged individually** (the cms #70 law, enforced in the plan structure). Tolerates unpublished packages; refuses non-npm repos with the adapter-pattern teaching error.
- **`maintain.mjs advisories`** — open Dependabot alerts, SLA-stamped from each alert's own createdAt (critical 24h · high 72h · medium 7d · low next-run), overdue-first ordering; disabled alerts get the enable hint, not a crash.
- **`forge:maintain` skill** — the cadence ritual + SLA table + scheduling note.

## Commits → issues

All commits → #14 (plan on main: `76cd459`).

## AC checklist (acgate 4/4 + live)

- [x] AC-11.1 classification + non-npm teaching error
- [x] AC-11.2 majors can never appear in the batch
- [x] AC-11.3 SLA deadlines from createdAt; disabled-alerts hint
- [x] AC-11.4 skill carries the laws
- [x] AC-11.5 **live**: real plan on this repo found vitest 3.2.4→4.1.10 (major → coordinated-ticket lane), ts-morph current

## Verification (honest)

- 246/246 tests (7 new); gates live: plandrift clean (3 files), testintent clean, depguard clean, acgate 4/4 (AC-11.5 is the live run above, not a unit test).
- **NOT verified**: advisories against a repo with alerts enabled (this repo has them off — owner setting; the parser is fixture-tested against the documented alert shape); the batch ritual end-to-end (no batchable updates exist right now — the one outdated dep is a major, correctly excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x