### PR TITLE
docs: install guide for cms and any consumer project (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# forge
+
+A portable AI-dev-platform plugin for Claude Code: 18 pipeline skills in 5 lanes, an 11-role agent roster with pluggable backends, GitHub Projects board automation with a ticket-trail law, mechanical ship gates, a learning loop, a graph-RAG index, and a per-machine console daemon. The platform ships itself — every feature here was planned, gated, trailed, and merged through its own pipeline.
+
+## Install
+
+```
+/plugin marketplace add dngioidev/forge
+/plugin install forge@forge
+/forge:init
+```
+
+**[→ Full install guide](docs/guides/install.md)** — prerequisites, adopt-vs-create, per-feature wiring, troubleshooting.
+
+## Find anything
+
+- [docs/README.md](docs/README.md) — the route index: every spec, plan, ADR, and guide, one line each.
+- [Platform design spec](docs/specs/2026-07-15-forge-platform-design.md) — the whole design in one document.
+
+## Laws worth knowing before you disagree with a gate
+
+Ticket-first, always — silent side-work is forbidden. Owner merges every PR. Situations (incident, security-response) change what's *allowed*, not what's suggested. Gates are mechanical scripts — run them, don't argue with them. `"Unknown" is a valid answer.`

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 
 ## Guides
 
+- [Install](guides/install.md) — forge into any project: prerequisites, marketplace install, init adopt-vs-create, doctor, per-feature wiring, superpowers migration.
 - [Console daemon](guides/console-daemon.md) — register/once/watch/status, file-transport layout, metadata-only guardrail, the Firebase follow-up step.
 - [Rollback runbook](guides/rollback-runbook.md) — find the previous digest, redeploy it (one command), verify, record; forward-only-migration exception.
 - [Data-recovery runbook](guides/data-recovery-runbook.md) — restore → verify → postmortem; never debug against the only copy.

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,0 +1,65 @@
+# Installing forge into a project
+
+The full path from any repo — fresh or existing (cms included) — to a working forge setup. Every step is idempotent; re-running is always safe.
+
+## 0. Prerequisites
+
+| need | check | fix |
+| --- | --- | --- |
+| Claude Code | `claude --version` | claude.com/claude-code |
+| Node ≥ 22.13 on PATH | `node --version` | nodejs.org (portable zip works — no admin needed) |
+| gh CLI, authed, `project` scope | `gh auth status` | `gh auth login -s project` (existing auth: `gh auth refresh -s project`) |
+| a git repo on GitHub | `git remote -v` | push it first — the board, tickets, and trail all live there |
+
+## 1. Install the plugin
+
+In a Claude Code session inside the target repo:
+
+```
+/plugin marketplace add dngioidev/forge
+/plugin install forge@forge
+```
+
+(or from the terminal: `claude plugin marketplace add dngioidev/forge` then `claude plugin install forge@forge`.)
+
+This brings the 18 skills, the `/forge:*` commands, the safety + learning hooks, and the graph MCP server. Nothing runs against your repo yet.
+
+## 2. Bootstrap: `/forge:init`
+
+One command, two modes:
+
+- **Adopt** an existing GitHub Project: have its number ready. Fields/options are **mapped as-is** — nothing on a live board is modified (ADR-0001); missing statuses are listed for you to add via the UI whenever you want them.
+- **Create** a fresh project: full bootstrap — the 6-status Status field, Priority/Size/Type fields, all created for you.
+
+Either mode also creates (only if missing): the pinned **delivery-log issue**, `.claude/forge.json` (committed — the repo's board ids + conventions), a `.gitignore` entry for `.forge/`, the **verify CI workflow** template, and (if you say yes) the status line in `.claude/settings.local.json`.
+
+`forge.json` is where you set the verify command (`pnpm verify`, `npm test`, …), docs dirs, team members/roles, and feature flags — all optional beyond the board block.
+
+## 3. Health check: `/forge:doctor`
+
+Run it after init and any time something feels off. ✗ items block work and say how to fix; ⚠ items are **owner settings** worth doing early: branch protection on main, secret scanning + push protection, Dependabot alerts (feeds `forge:maintain`), and repo Settings → *Automatically delete head branches*.
+
+## 4. Optional wiring (per feature, all off by default)
+
+| feature | turn on | what you get |
+| --- | --- | --- |
+| deploy | `/forge:deploy-init` (sets `features.deploy`) | Dockerfile/compose/terraform scaffold, staging/production env-branch workflows, deploy-readiness gate, smoke script |
+| graph | `features.graph: true` + `npm i -D ts-morph` + `node <plugin>/scripts/graph/graphctl.mjs rebuild` | structural index: find_component / who_uses / blast_radius / reuse_candidates MCP tools (TypeScript repos only — grep-first is the permanent fallback otherwise) |
+| CLI backends | roster in `forge.json` + `/forge:backends-sync` | non-Claude backends for investigator/librarian/second-opinion, ignore-files synced |
+| console daemon | `node <plugin-or-checkout>/console/daemon.mjs register` then `watch` | per-machine telemetry + remote decision inbox (file transport today; Firebase later) |
+| design review | `features.designReview: true` | design-reviewer validates UI work against visual specs |
+
+## 5. Working in it
+
+Everything is ticket-first: `/forge:ticket` for quick triage, then the lane skills (ideate → brainstorm → design → plan → execute → ship → release; hotfix/respond/maintain for care). `forge board status` (or the status line) is the one-glance catch-up. The owner merges every PR — agents never do.
+
+## 6. Migrating from superpowers
+
+forge replaces ship / plan+execute / brainstorm one-for-one. Once installed and init'd: `claude plugin uninstall superpowers` from the consumer repo's checkout. Keep both during a transition if you like — the skills don't collide, but two ship rituals is one too many.
+
+## Troubleshooting
+
+- **`gh: command not found` inside scripts** — gh must be on the *user* PATH, not just the shell profile; portable installs to `%LOCALAPPDATA%` work (see [shell notes template](../../plugin/templates/shell-windows.md) on Windows).
+- **`token lacks the 'project' scope`** — `gh auth refresh -s project`.
+- **Board writes fail with dangling ids** — someone edited field options in the UI; re-run `/forge:init` to re-map, then `/forge:doctor`.
+- **Anything else** — `/forge:doctor` first; its hints are the supported fixes.


### PR DESCRIPTION
Closes #33. No single consumer-facing install path existed — the pieces lived in spec §3/§6, commands/init.md, and doctor hints.

- **docs/guides/install.md** — prerequisites table, marketplace install, init adopt-vs-create (what each creates, ADR-0001 behavior on live boards), doctor's owner-settings list, per-feature wiring table (deploy/graph/backends/console/designReview), daily-flow pointer, **superpowers migration**, troubleshooting.
- **README.md** (root, new) — the front door: what forge is, 3-line install, route-index + spec links, the laws in one paragraph.
- Route index updated.

## Verification (honest)

Docs-only: 246/246 tests still green, testintent + depguard clean, plandrift n/a (docs are default-allowed), no ACs (nothing executable — the guide's commands are the same ones init/doctor/deploy-init already test). The cms walk-through itself is the real verification and happens at install time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x