### PR TITLE
fix: replaceStatusOptions never worked live — inline-literal mutation (#35)

### DIFF
--- a/plugin/scripts/lib/board.mjs
+++ b/plugin/scripts/lib/board.mjs
@@ -111,20 +111,29 @@ export async function createSingleSelectField(gh, projectId, name, optionDefs) {
   return { ok: true, field: res.json.data.createProjectV2Field.projectV2Field };
 }
 
-const UPDATE_STATUS_MUTATION = `mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
-  updateProjectV2Field(input: { fieldId: $fieldId, singleSelectOptions: $options }) {
+/**
+ * Options must be INLINE literals: gh -F delivers a JSON array as a string
+ * (API rejects it), and option colors are GraphQL enums that JSON can't
+ * express unquoted. Verified live in the #32 migration + SP1 spike (#35).
+ */
+export function buildStatusMutation(fieldId, optionDefs) {
+  const opts = optionDefs
+    .map((o) => `{name: ${JSON.stringify(o.name)}, color: ${o.color}, description: ""}`)
+    .join(', ');
+  return `mutation {
+  updateProjectV2Field(input: { fieldId: ${JSON.stringify(fieldId)}, singleSelectOptions: [${opts}] }) {
     projectV2Field { ... on ProjectV2SingleSelectField { id name options { id name } } }
   }
 }`;
+}
 
 /**
  * ADR-0001: replaces ALL options and mints new ids — call only on projects
  * with zero items (fresh bootstrap). Callers must check itemsCount first.
  */
 export async function replaceStatusOptions(gh, fieldId, optionDefs) {
-  const options = JSON.stringify(optionDefs.map((o) => ({ name: o.name, color: o.color, description: '' })));
   const res = await gh(
-    ['api', 'graphql', '-f', `query=${UPDATE_STATUS_MUTATION}`, '-f', `fieldId=${fieldId}`, '-F', `options=${options}`],
+    ['api', 'graphql', '-f', `query=${buildStatusMutation(fieldId, optionDefs)}`],
     { parseJson: true },
   );
   if (!res.ok) return { ok: false, error: res.stderr || 'status options update failed' };

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -13,7 +13,9 @@ const BOARD8 = {
   projectId: 'PVT_kwHOCkJQ784BdZrh',
   fields: [
     { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7emI', name: 'Status', options: [
-      { id: '04db063a', name: 'Backlog' }, { id: '29224f44', name: 'In progress' }, { id: '7d8a60b9', name: 'Done' }] },
+      // six-status set since the #32 migration (ids re-minted by replaceStatusOptions)
+      { id: '8a1e2226', name: 'Backlog' }, { id: 'e90d0eb6', name: 'Ready' }, { id: '2a209b69', name: 'In progress' },
+      { id: 'a9159ac9', name: 'In review' }, { id: '5b1d391c', name: 'Blocked / Needs decision' }, { id: '7c5d9faa', name: 'Done' }] },
     { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7esI', name: 'Priority', options: [
       { id: '66c7f4b7', name: 'P0' }, { id: '23a624d0', name: 'P1' }, { id: 'd9b45a49', name: 'P2' }] },
     { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7esU', name: 'Size', options: [

--- a/tests/lib/board.test.mjs
+++ b/tests/lib/board.test.mjs
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { buildStatusMutation, replaceStatusOptions, STANDARD_STATUS } from '../../plugin/scripts/lib/board.mjs';
+
+describe('replaceStatusOptions mutation shape (AC-B4.1, #35)', () => {
+  it('AC-B4.1: options are inline literals — enum colors bare, names JSON-escaped, no variables', () => {
+    const m = buildStatusMutation('PVTSSF_x', STANDARD_STATUS);
+    expect(m).toContain('{name: "Backlog", color: GRAY, description: ""}');
+    expect(m).toContain('{name: "Blocked / Needs decision", color: RED, description: ""}');
+    expect(m).toContain('fieldId: "PVTSSF_x"');
+    expect(m).not.toContain('"GRAY"'); // an enum in quotes is the original bug
+    expect(m).not.toContain('$options'); // no variables — gh -F stringifies arrays
+    expect(m).toContain('singleSelectOptions: [');
+    // names with quotes stay valid GraphQL
+    expect(buildStatusMutation('f', [{ name: 'a "b"', color: 'GRAY' }])).toContain('{name: "a \\"b\\"", color: GRAY');
+  });
+
+  it('AC-B4.1: replaceStatusOptions sends exactly one -f query arg, no -F', async () => {
+    let seen = null;
+    const gh = async (args) => {
+      seen = args;
+      return { ok: true, json: { data: { updateProjectV2Field: { projectV2Field: { options: [{ id: 'n1', name: 'Backlog' }] } } } } };
+    };
+    const res = await replaceStatusOptions(gh, 'PVTSSF_x', STANDARD_STATUS);
+    expect(res.ok).toBe(true);
+    expect(seen.filter((a) => a === '-F')).toHaveLength(0);
+    expect(seen.filter((a) => a === '-f')).toHaveLength(1);
+    expect(seen.find((a) => a.startsWith('query='))).toContain('color: GREEN');
+  });
+});


### PR DESCRIPTION
Closes #35. Found during the #32 board migration: `gh api graphql -F options=<json>` delivers the array as a string (API rejects it), and option colors are GraphQL enums JSON can't express — so the variable-based mutation only ever passed against fakegh. Every fresh-project `forge init` bootstrap would have hit this.

Fix: `buildStatusMutation` inlines the options as GraphQL literals (names JSON-escaped, colors bare enums) — the exact form verified live in the #32 migration (which minted the six-status set now on board #8) and the SP1 spike. Caller signature unchanged.

## AC checklist (acgate 1/1)
- [x] AC-B4.1 mutation shape regression-pinned (bare enums, no variables, one -f arg); escaped names stay valid

## Verification (honest)
- 248/248 tests; testintent + depguard clean; acgate via --acs (bug ticket, no plan doc).
- The generated mutation text is byte-equivalent to the one that ran successfully against the live API an hour ago in the #32 migration; the lib path itself was not re-run live (it would destructively re-mint the board's option ids — ADR-0001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x