### PR TITLE
feat: local web console — monitor + decide from the browser, zero cloud (#37)

### DIFF
--- a/console/daemon.mjs
+++ b/console/daemon.mjs
@@ -127,7 +127,14 @@ if (isMain) {
     });
   } else if (cmd === 'status') {
     loadCfg().then((cfg) => runStatus(cfg));
+  } else if (cmd === 'serve') {
+    const pi = process.argv.indexOf('--port');
+    loadCfg().then(async (cfg) => {
+      const { startServer, DEFAULT_PORT } = await import('./serve.mjs');
+      const { port } = await startServer(cfg, { port: pi > -1 ? Number(process.argv[pi + 1]) : DEFAULT_PORT, log: console.log });
+      console.log(`forge console → http://127.0.0.1:${port}  (${cfg.repos.length} repo(s), ctrl-c to stop)`);
+    });
   } else {
-    fail('usage: daemon.mjs <register|once|watch|status>');
+    fail('usage: daemon.mjs <register|once|watch|status|serve [--port N]>');
   }
 }

--- a/console/serve.mjs
+++ b/console/serve.mjs
@@ -1,0 +1,79 @@
+/**
+ * Local web console (#37) — the rung between terminal views and SP9b:
+ * monitor every configured repo and answer escalations from a browser,
+ * zero cloud, zero dependencies. State is collected LIVE per request
+ * (fresher than the outbox files); a decision answered here resolves the
+ * same file the daemon inbox writes, so the halted pipeline can't tell
+ * the difference.
+ *
+ * Hardening: binds 127.0.0.1 only; the Host-header allowlist is the
+ * DNS-rebinding guard (a malicious site can make the browser send the
+ * request, but not with a localhost Host header).
+ */
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { collectRepo } from './lib/collect.mjs';
+import { resolveReply } from './daemon.mjs';
+
+const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), 'web');
+export const DEFAULT_PORT = 7433;
+
+export function hostAllowed(host) {
+  return /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i.test(host ?? '');
+}
+
+export async function stateOf(config) {
+  const repos = [];
+  for (const cwd of config.repos) {
+    try {
+      repos.push(await collectRepo(cwd));
+    } catch (e) {
+      repos.push({ repo: cwd, error: e.message });
+    }
+  }
+  return { machineId: config.machineId, generatedAt: new Date().toISOString(), repos };
+}
+
+export function makeApp(config, log = () => {}) {
+  return async function handle(req, res) {
+    const send = (code, body, type = 'application/json') => {
+      res.writeHead(code, { 'Content-Type': type, 'Cache-Control': 'no-store' });
+      res.end(type === 'application/json' ? JSON.stringify(body) : body);
+    };
+    try {
+      if (!hostAllowed(req.headers.host)) return send(403, { error: 'localhost only' });
+      const path = new URL(req.url, 'http://localhost').pathname;
+
+      if (req.method === 'GET' && path === '/') {
+        return send(200, await readFile(join(WEB_ROOT, 'index.html'), 'utf8'), 'text/html; charset=utf-8');
+      }
+      if (req.method === 'GET' && path === '/api/state') {
+        return send(200, await stateOf(config));
+      }
+      if (req.method === 'POST' && path === '/api/decide') {
+        let raw = '';
+        for await (const chunk of req) raw += chunk;
+        let body;
+        try { body = JSON.parse(raw); } catch { return send(400, { error: 'invalid json' }); }
+        if (typeof body?.id !== 'string' || typeof body?.answer !== 'string' || !body.answer.trim()) {
+          return send(400, { error: 'need { id, answer }' });
+        }
+        const r = await resolveReply(config.repos, { id: body.id, answer: body.answer.trim(), by: body.by ?? 'local-console' }, log);
+        return send(r.ok ? 200 : 404, r);
+      }
+      return send(404, { error: 'not found' });
+    } catch (e) {
+      return send(500, { error: e.message });
+    }
+  };
+}
+
+export function startServer(config, { port = DEFAULT_PORT, log = () => {} } = {}) {
+  const server = createServer(makeApp(config, log));
+  return new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(port, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}

--- a/console/web/index.html
+++ b/console/web/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>forge console</title>
+<style>
+  :root { --bg:#0d1117; --card:#161b22; --line:#30363d; --fg:#e6edf3; --dim:#8b949e; --accent:#58a6ff; --ok:#3fb950; --warn:#d29922; --bad:#f85149; }
+  * { box-sizing:border-box; margin:0; }
+  body { background:var(--bg); color:var(--fg); font:14px/1.5 ui-monospace,SFMono-Regular,Consolas,monospace; padding:24px; max-width:960px; margin:0 auto; }
+  header { display:flex; justify-content:space-between; align-items:baseline; margin-bottom:20px; }
+  h1 { font-size:18px; } h1 small { color:var(--dim); font-weight:normal; margin-left:8px; }
+  #stamp { color:var(--dim); font-size:12px; }
+  .repo { background:var(--card); border:1px solid var(--line); border-radius:8px; padding:16px 18px; margin-bottom:16px; }
+  .repo-head { display:flex; gap:10px; align-items:baseline; flex-wrap:wrap; }
+  .glyph { font-size:18px; }
+  .name { font-size:16px; font-weight:bold; }
+  .situation { color:var(--dim); }
+  .situation.incident, .situation.security-response { color:var(--bad); font-weight:bold; }
+  .situation.awaiting-decision { color:var(--warn); font-weight:bold; }
+  .meta { color:var(--dim); margin-top:4px; }
+  .meta b { color:var(--fg); font-weight:normal; }
+  .ledger { margin-top:8px; height:8px; background:var(--line); border-radius:4px; overflow:hidden; display:flex; }
+  .ledger .done { background:var(--ok); } .ledger .active { background:var(--warn); }
+  .decision { border:1px solid var(--warn); border-radius:6px; padding:12px; margin-top:12px; }
+  .decision .reason { margin-bottom:8px; }
+  .decision .age { color:var(--dim); font-size:12px; }
+  .opts { display:flex; flex-direction:column; gap:6px; margin-top:8px; }
+  button { background:#21262d; color:var(--fg); border:1px solid var(--line); border-radius:6px; padding:6px 12px; font:inherit; cursor:pointer; text-align:left; }
+  button:hover { border-color:var(--accent); }
+  .free { display:flex; gap:6px; margin-top:8px; }
+  .free input { flex:1; background:var(--bg); color:var(--fg); border:1px solid var(--line); border-radius:6px; padding:6px 10px; font:inherit; }
+  .journal { margin-top:12px; color:var(--dim); font-size:12px; }
+  .journal div { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .error { color:var(--bad); }
+  #empty { color:var(--dim); text-align:center; padding:40px 0; }
+</style>
+</head>
+<body>
+<header><h1>forge console<small id="machine"></small></h1><span id="stamp"></span></header>
+<div id="repos"></div>
+<div id="empty" hidden>no repos configured — run: node console/daemon.mjs register</div>
+<script>
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+async function decide(id, answer) {
+  if (!answer || !answer.trim()) return;
+  const res = await fetch('/api/decide', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ id, answer }) });
+  const out = await res.json();
+  if (!res.ok) alert(out.error || 'decide failed');
+  refresh();
+}
+
+function repoCard(r) {
+  if (r.error) return `<div class="repo"><div class="repo-head"><span class="name">${esc(r.repo)}</span></div><div class="error">${esc(r.error)}</div></div>`;
+  const l = r.ledger;
+  const ledger = l && l.total ? `<div class="ledger" title="${l.done}/${l.total} done">
+      <span class="done" style="width:${(100*l.done/l.total).toFixed(0)}%"></span>
+      <span class="active" style="width:${(100*l.inProgress/l.total).toFixed(0)}%"></span></div>` : '';
+  const decisions = (r.pendingDecisions ?? []).map((d) => `
+    <div class="decision">
+      <div class="reason">🚩 <b>#${esc(d.issue)}</b> ${esc(d.reason)} <span class="age">${d.ageHours != null ? esc(d.ageHours)+'h old' : ''}</span></div>
+      <div class="opts">${(d.options ?? []).map((o, i) => `<button onclick="decide('${esc(d.id)}', ${JSON.stringify(esc(`option ${i+1} — ${o}`))})">${i+1}. ${esc(o)}</button>`).join('')}</div>
+      <div class="free"><input id="in-${esc(d.id)}" placeholder="or type an answer"><button onclick="decide('${esc(d.id)}', document.getElementById('in-${esc(d.id)}').value)">send</button></div>
+    </div>`).join('');
+  const journal = (r.journalTail ?? []).slice(-5).reverse().map((e) =>
+    `<div>${esc(e.ts ?? '')} · ${esc(e.kind)}${e.gate ? ' ('+esc(e.gate)+')' : ''}${e.ticket ? ' '+esc(e.ticket) : ''}</div>`).join('');
+  return `<div class="repo">
+    <div class="repo-head"><span class="glyph">${esc(r.glyph ?? '·')}</span><span class="name">${esc(r.repo)}</span>
+      <span class="situation ${esc(r.situation)}">${esc(r.situation)}</span></div>
+    <div class="meta">${r.ticket ? `<b>${esc(r.ticket)}</b> · ` : ''}${esc(r.branch ?? 'no branch')}${l && l.total ? ` · tasks ${l.done}/${l.total}` : ''}</div>
+    ${ledger}${decisions}
+    ${journal ? `<div class="journal">${journal}</div>` : ''}
+  </div>`;
+}
+
+async function refresh() {
+  try {
+    const s = await (await fetch('/api/state')).json();
+    document.getElementById('machine').textContent = s.machineId;
+    document.getElementById('stamp').textContent = new Date(s.generatedAt).toLocaleTimeString();
+    document.getElementById('repos').innerHTML = s.repos.map(repoCard).join('');
+    document.getElementById('empty').hidden = s.repos.length > 0;
+  } catch {
+    document.getElementById('stamp').textContent = 'server unreachable';
+  }
+}
+refresh();
+setInterval(refresh, 5000);
+</script>
+</body>
+</html>

--- a/docs/guides/console-daemon.md
+++ b/docs/guides/console-daemon.md
@@ -9,7 +9,14 @@ node console/daemon.mjs register     # creates ~/.forge/daemon.json, adds this r
 node console/daemon.mjs once         # one cycle: collect → publish → inbox
 node console/daemon.mjs watch        # the same, every intervalSec
 node console/daemon.mjs status       # last-publish age per repo
+node console/daemon.mjs serve        # local web console → http://127.0.0.1:7433
 ```
+
+## Local web console (`serve`)
+
+One page for the whole machine: per-repo situation glyph, active ticket/branch, ledger progress, journal tail — and **tap-to-answer escalations**: each pending decision renders its options as buttons (plus a free-text box); answering writes the exact resolved decision file the daemon inbox produces, so the halted pipeline resumes identically. State is collected live per request, so it's always current even if `watch` isn't running.
+
+Localhost-only by construction: binds 127.0.0.1 and rejects foreign `Host` headers (DNS-rebinding guard). No auth because localhost *is* the machine owner — multi-user access is what the Firebase step adds (SP9b).
 
 Machine config `~/.forge/daemon.json`:
 

--- a/tests/console/serve.test.mjs
+++ b/tests/console/serve.test.mjs
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { request } from 'node:http';
+import { startServer, hostAllowed, stateOf } from '../../console/serve.mjs';
+
+const DECISION = {
+  id: 'esc-9-web', issue: 9, reason: 'pick one', status: 'pending',
+  options: ['ship it', 'hold it'], createdAt: '2026-07-17T10:00:00Z',
+};
+
+async function repoDir() {
+  const dir = await mkdtemp(join(tmpdir(), 'forge-web-'));
+  await mkdir(join(dir, '.git'), { recursive: true });
+  await writeFile(join(dir, '.git', 'HEAD'), 'ref: refs/heads/feat/9-learning-loop\n', 'utf8');
+  await mkdir(join(dir, '.forge', 'decisions'), { recursive: true });
+  await writeFile(join(dir, '.forge', 'decisions', `${DECISION.id}.json`), JSON.stringify(DECISION), 'utf8');
+  await writeFile(join(dir, '.forge', 'journal.jsonl'), JSON.stringify({ ts: 't1', kind: 'escalation', ticket: '#9' }) + '\n', 'utf8');
+  return dir;
+}
+
+const servers = [];
+afterAll(() => servers.forEach(({ server }) => server.close()));
+
+async function liveServer() {
+  const repo = await repoDir();
+  const config = { machineId: 'm-web', repos: [repo], transport: { kind: 'file', dir: await mkdtemp(join(tmpdir(), 'forge-webt-')) } };
+  const started = await startServer(config, { port: 0 });
+  servers.push(started);
+  return { repo, config, base: `http://127.0.0.1:${started.port}` };
+}
+
+describe('local web console', () => {
+  it('AC-B5.1: /api/state returns live snapshots for every configured repo', async () => {
+    const { base } = await liveServer();
+    const res = await fetch(`${base}/api/state`);
+    expect(res.ok).toBe(true);
+    const s = await res.json();
+    expect(s.machineId).toBe('m-web');
+    expect(s.repos).toHaveLength(1);
+    expect(s.repos[0]).toMatchObject({ situation: 'awaiting-decision', ticket: '#9', branch: 'feat/9-learning-loop' });
+    expect(s.repos[0].pendingDecisions[0]).toMatchObject({ id: 'esc-9-web', options: ['ship it', 'hold it'] });
+  });
+
+  it('AC-B5.2: /api/decide resolves like the daemon inbox; unknown id 404s; bad body 400s', async () => {
+    const { base, repo } = await liveServer();
+    const res = await fetch(`${base}/api/decide`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'esc-9-web', answer: 'option 1 — ship it' }),
+    });
+    expect(res.status).toBe(200);
+    const file = JSON.parse(await readFile(join(repo, '.forge', 'decisions', 'esc-9-web.json'), 'utf8'));
+    expect(file).toMatchObject({ status: 'resolved', answer: 'option 1 — ship it', resolvedBy: 'local-console' });
+    const journal = await readFile(join(repo, '.forge', 'journal.jsonl'), 'utf8');
+    expect(journal).toContain('"escalation-resolved"');
+
+    // second answer: no longer pending -> 404; garbage -> 400
+    expect((await fetch(`${base}/api/decide`, { method: 'POST', body: JSON.stringify({ id: 'esc-9-web', answer: 'x' }) })).status).toBe(404);
+    expect((await fetch(`${base}/api/decide`, { method: 'POST', body: 'not json' })).status).toBe(400);
+    expect((await fetch(`${base}/api/decide`, { method: 'POST', body: JSON.stringify({ id: 'x', answer: '  ' }) })).status).toBe(400);
+
+    const state = await (await fetch(`${base}/api/state`)).json();
+    expect(state.repos[0].pendingDecisions).toEqual([]);
+    expect(state.repos[0].situation).not.toBe('awaiting-decision');
+  });
+
+  it('AC-B5.3: localhost-only — foreign Host headers rejected, allowlist exact', async () => {
+    const { base } = await liveServer();
+    expect(hostAllowed('localhost:7433')).toBe(true);
+    expect(hostAllowed('127.0.0.1')).toBe(true);
+    expect(hostAllowed('[::1]:9')).toBe(true);
+    expect(hostAllowed('evil.example')).toBe(false);
+    expect(hostAllowed('localhost.evil.example')).toBe(false);
+    expect(hostAllowed(undefined)).toBe(false);
+    // fetch/undici drops custom Host headers — raw http.request carries it
+    const status = await new Promise((resolve, reject) => {
+      const req = request(`${base}/api/state`, { headers: { Host: 'evil.example' } }, (res) => { res.resume(); resolve(res.statusCode); });
+      req.on('error', reject);
+      req.end();
+    });
+    expect(status).toBe(403);
+  });
+
+  it('AC-B5.4: GET / serves the self-contained page; unknown routes 404', async () => {
+    const { base } = await liveServer();
+    const res = await fetch(base + '/');
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const html = await res.text();
+    expect(html).toContain('forge console');
+    expect(html).toContain('/api/decide');
+    expect(html).not.toMatch(/src="http|href="http/); // no external assets
+    expect((await fetch(`${base}/nope`)).status).toBe(404);
+  });
+
+  it('stateOf reports per-repo errors without failing the whole snapshot', async () => {
+    const s = await stateOf({ machineId: 'm', repos: ['Z:/does/not/exist'] });
+    expect(s.repos).toHaveLength(1); // collect tolerates missing dirs (nulls), or reports error — either way the snapshot stands
+  });
+});


### PR DESCRIPTION
Closes #37. Plan: [docs/plans/2026-07-17-local-web-console.md](https://github.com/dngioidev/forge/blob/main/docs/plans/2026-07-17-local-web-console.md)

`node console/daemon.mjs serve` → **http://127.0.0.1:7433** — one page for the whole machine.

## What

- **`console/serve.mjs`** — zero-dep node:http, bound to 127.0.0.1 with a Host-header allowlist (DNS-rebinding guard). `GET /api/state` collects live per request (always current, even without `watch` running); `POST /api/decide` delegates to the daemon's `resolveReply` — a browser answer writes the exact resolved decision file the inbox produces, journaled, so the halted pipeline resumes identically.
- **`console/web/index.html`** — fully self-contained (no CDN/external assets): situation glyph per repo, ticket/branch, ledger progress bar, decision cards with one button per option + free-text, journal tail; 5s auto-refresh. All dynamic content HTML-escaped.
- **daemon `serve` subcommand** (`--port`, default 7433) + guide section.

## AC checklist (acgate 4/4 + live)

- [x] AC-B5.1 live state API for all configured repos
- [x] AC-B5.2 decide == daemon-inbox resolution; unknown 404, bad body 400, re-answer 404
- [x] AC-B5.3 localhost bind + foreign-Host 403 (raw-socket tested — fetch drops custom Host headers)
- [x] AC-B5.4 self-contained page, no external assets
- [x] AC-B5.5 **live**: served this machine's real state (gioi-821b · forge · #37 · feat/37-local-web-console)

## Verification (honest)

- 253/253 tests (5 new, real http round-trips on an ephemeral port); gates: plandrift clean (5 files), testintent clean, depguard clean, acgate 4/4.
- **NOT verified**: the page rendered in an actual browser (endpoints + HTML shape tested; I can't open one) — first `serve` run on your side is that check; decision buttons live against a real pending escalation (none open right now — the flow is the same resolveReply path the SP9a tests and the #32 escalation exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x