### PR TITLE
feat: status line v2 — glyph always, project, context bar, model, cost (#43)

### DIFF
--- a/plugin/scripts/statusline.mjs
+++ b/plugin/scripts/statusline.mjs
@@ -1,14 +1,56 @@
 #!/usr/bin/env node
 /**
- * Claude Code status line (spec §7 — situation-aware since SP3).
- * Prints: `[glyph ]forge #<ticket> <branch>`. The glyph appears only when a
- * human is needed (🔒 security-response, 🔥 incident, 🚩n pending decisions)
- * — quiet while building/idle. A status line must never break a session:
- * any error prints nothing (or drops the glyph) and exits 0.
+ * Claude Code status line v2 (#43): one glanceable strip —
+ *   <glyph> <project> · #<ticket> <branch> · ▓▓▓░░░░░ 42% · <model> · $0.42
+ * Glyph is ALWAYS present (· idle, ▶ work in progress, 🚩n decisions,
+ * 🔥 incident, 🔒 security-response). Segments the payload can't provide are
+ * omitted silently — payload shapes vary across Claude Code versions.
+ * A status line must never break a session: any error prints nothing (or a
+ * partial line) and exits 0.
  */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { run } from './lib/exec.mjs';
 import { parseBranch } from './lib/ticket.mjs';
 import { deriveSituation } from './lib/situation.mjs';
+
+/** Context usage across known payload shapes -> {used, max} or null. */
+export function extractContext(payload) {
+  const cands = [
+    payload?.context_window, payload?.context, payload?.usage,
+    payload?.cost?.context_window, payload?.model?.context_window,
+  ];
+  for (const c of cands) {
+    if (!c || typeof c !== 'object') continue;
+    const used = [c.used_tokens, c.used, c.input_tokens, c.tokens_used].find((v) => typeof v === 'number');
+    const max = [c.max_tokens, c.max, c.context_window_size, c.limit].find((v) => typeof v === 'number');
+    if (typeof used === 'number' && typeof max === 'number' && max > 0) return { used, max };
+  }
+  return null;
+}
+
+export function renderBar({ used, max }, cells = 8) {
+  const ratio = Math.min(1, Math.max(0, used / max));
+  const fill = Math.round(ratio * cells);
+  return `${'▓'.repeat(fill)}${'░'.repeat(cells - fill)} ${Math.round(ratio * 100)}%`;
+}
+
+/** Pure composition — everything optional except the branch. */
+export function composeLine({ situation, pendingCount, project, branch, ticket, context, model, costUsd }) {
+  const glyph =
+    situation === 'security-response' ? '🔒' :
+    situation === 'incident' ? '🔥' :
+    situation === 'awaiting-decision' ? `🚩${pendingCount || ''}` :
+    parseBranch(branch ?? '').kind === 'work' || parseBranch(branch ?? '').kind === 'hotfix' ? '▶' : '·';
+  const segments = [
+    `${glyph} ${project ?? 'forge'}`,
+    branch ? (ticket != null ? `#${ticket} ${branch}` : branch) : null,
+    context ? renderBar(context) : null,
+    model || null,
+    typeof costUsd === 'number' ? `$${costUsd.toFixed(2)}` : null,
+  ];
+  return segments.filter(Boolean).join(' · ');
+}
 
 async function readStdin() {
   let data = '';
@@ -16,29 +58,36 @@ async function readStdin() {
   return data;
 }
 
-try {
-  const raw = await readStdin();
-  let cwd = process.cwd();
-  try {
-    const payload = JSON.parse(raw);
-    cwd = payload?.workspace?.current_dir || payload?.cwd || cwd;
-  } catch { /* no/invalid payload — fall back to cwd */ }
+async function main() {
+  let payload = null;
+  try { payload = JSON.parse(await readStdin()); } catch { /* fall back below */ }
+  const cwd = payload?.workspace?.current_dir || payload?.cwd || process.cwd();
 
   const res = await run('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD']);
-  if (!res.ok) process.exit(0);
+  if (!res.ok) return; // not a repo — print nothing
   const branch = res.stdout.trim();
-  const parsed = parseBranch(branch);
 
-  // Situation glyph: local files only (.forge/) — never a network call.
-  let prefix = '';
+  let situation = null;
+  let pendingCount = 0;
   try {
     const s = await deriveSituation(cwd, { blocked: 0, inProgress: 0 });
-    if (s.key === 'security-response' || s.key === 'incident') prefix = `${s.glyph} `;
-    else if (s.key === 'awaiting-decision') prefix = `🚩${s.pendingCount} `;
-  } catch { /* glyph is optional */ }
+    situation = s.key;
+    pendingCount = s.pendingCount;
+  } catch { /* glyph degrades to branch inference */ }
 
-  process.stdout.write(prefix + (parsed.ticket != null ? `forge #${parsed.ticket} ${branch}` : `forge ${branch}`));
-} catch {
-  // silent by design
+  const projectDir = payload?.workspace?.project_dir || payload?.workspace?.current_dir || cwd;
+  process.stdout.write(composeLine({
+    situation, pendingCount,
+    project: String(projectDir).split(/[\\/]/).filter(Boolean).pop(),
+    branch, ticket: parseBranch(branch).ticket,
+    context: extractContext(payload),
+    model: payload?.model?.display_name || null,
+    costUsd: typeof payload?.cost?.total_cost_usd === 'number' ? payload.cost.total_cost_usd : null,
+  }));
 }
-process.exit(0);
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  try { await main(); } catch { /* silent by design */ }
+  process.exit(0);
+}

--- a/tests/statusline.test.mjs
+++ b/tests/statusline.test.mjs
@@ -4,17 +4,18 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { run } from '../plugin/scripts/lib/exec.mjs';
+import { composeLine, extractContext, renderBar } from '../plugin/scripts/statusline.mjs';
 
 const script = join(dirname(fileURLToPath(import.meta.url)), '..', 'plugin', 'scripts', 'statusline.mjs');
 
-async function runStatusline(payload) {
+async function runStatusline(payloadOrRaw) {
   const { spawn } = await import('node:child_process');
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [script], { windowsHide: true });
     let stdout = '';
     child.stdout.on('data', (d) => { stdout += d; });
     child.on('close', (code) => resolve({ code, stdout }));
-    child.stdin.write(JSON.stringify(payload));
+    child.stdin.write(typeof payloadOrRaw === 'string' ? payloadOrRaw : JSON.stringify(payloadOrRaw));
     child.stdin.end();
   });
 }
@@ -29,38 +30,73 @@ async function gitRepoOnBranch(branch) {
   return dir;
 }
 
-describe('statusline (AC-1.5)', () => {
-  it('prints forge #<ticket> <branch> on a work branch', async () => {
-    const dir = await gitRepoOnBranch('feat/12-widget');
-    const res = await runStatusline({ workspace: { current_dir: dir } });
-    expect(res.code).toBe(0);
-    expect(res.stdout).toBe('forge #12 feat/12-widget');
+describe('statusline v2 composition (AC-B7.1, AC-B7.5)', () => {
+  it('AC-B7.1: full strip when the payload provides everything', () => {
+    const line = composeLine({
+      situation: 'idle', pendingCount: 0, project: 'cms', branch: 'feat/12-widget', ticket: 12,
+      context: { used: 450_000, max: 1_000_000 }, model: 'Fable 5', costUsd: 0.42,
+    });
+    expect(line).toBe('▶ cms · #12 feat/12-widget · ▓▓▓▓░░░░ 45% · Fable 5 · $0.42');
   });
 
-  it('prints forge <branch> when the branch has no ticket', async () => {
+  it('AC-B7.1: absent segments omit silently', () => {
+    expect(composeLine({ situation: 'idle', project: 'forge', branch: 'main' })).toBe('· forge · main');
+  });
+
+  it('AC-B7.5: glyph priority — 🔒 > 🔥 > 🚩n > ▶ (work/hotfix branch) > ·', () => {
+    const base = { project: 'x', branch: 'feat/1-a', ticket: 1 };
+    expect(composeLine({ ...base, situation: 'security-response' })).toMatch(/^🔒 /);
+    expect(composeLine({ ...base, situation: 'incident' })).toMatch(/^🔥 /);
+    expect(composeLine({ ...base, situation: 'awaiting-decision', pendingCount: 2 })).toMatch(/^🚩2 /);
+    expect(composeLine({ ...base, situation: 'idle' })).toMatch(/^▶ /);
+    expect(composeLine({ project: 'x', branch: 'hotfix/2-b', ticket: 2, situation: 'idle' })).toMatch(/^▶ /);
+    expect(composeLine({ project: 'x', branch: 'main', situation: 'idle' })).toMatch(/^· /);
+  });
+});
+
+describe('context bar (AC-B7.2)', () => {
+  it('AC-B7.2: extractContext handles the payload shapes; absent -> null', () => {
+    expect(extractContext({ context_window: { used_tokens: 1, max_tokens: 4 } })).toEqual({ used: 1, max: 4 });
+    expect(extractContext({ context: { used: 2, max: 8 } })).toEqual({ used: 2, max: 8 });
+    expect(extractContext({ usage: { input_tokens: 3, context_window_size: 6 } })).toEqual({ used: 3, max: 6 });
+    expect(extractContext({ cost: { context_window: { tokens_used: 1, limit: 2 } } })).toEqual({ used: 1, max: 2 });
+    expect(extractContext({ model: { display_name: 'x' } })).toBe(null);
+    expect(extractContext(null)).toBe(null);
+    expect(extractContext({ context: { used: 1, max: 0 } })).toBe(null); // divide-by-zero guarded
+  });
+
+  it('AC-B7.2: bar fill and percent; clamped at 100%', () => {
+    expect(renderBar({ used: 0, max: 100 })).toBe('░░░░░░░░ 0%');
+    expect(renderBar({ used: 50, max: 100 })).toBe('▓▓▓▓░░░░ 50%');
+    expect(renderBar({ used: 100, max: 100 })).toBe('▓▓▓▓▓▓▓▓ 100%');
+    expect(renderBar({ used: 250, max: 100 })).toBe('▓▓▓▓▓▓▓▓ 100%');
+  });
+});
+
+describe('statusline e2e (AC-B7.3, AC-B7.4)', () => {
+  it('AC-B7.3: project comes from the workspace dir basename; ticket + branch from git', async () => {
+    const dir = await gitRepoOnBranch('feat/12-widget');
+    const res = await runStatusline({ workspace: { current_dir: dir }, model: { display_name: 'Fable 5' }, context_window: { used_tokens: 500, max_tokens: 1000 } });
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe(`▶ ${dir.split(/[\\/]/).pop()} · #12 feat/12-widget · ▓▓▓▓░░░░ 50% · Fable 5`);
+  });
+
+  it('AC-B7.3: branch without a ticket still renders', async () => {
     const dir = await gitRepoOnBranch('main');
     const res = await runStatusline({ workspace: { current_dir: dir } });
     expect(res.code).toBe(0);
-    expect(res.stdout).toBe('forge main');
+    expect(res.stdout).toBe(`· ${dir.split(/[\\/]/).pop()} · main`);
   });
 
-  it('never breaks the session: non-git dir -> empty output, exit 0', async () => {
+  it('AC-B7.4: never breaks the session — non-git dir empty output, exit 0', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'forge-sl-'));
     const res = await runStatusline({ workspace: { current_dir: dir } });
     expect(res.code).toBe(0);
     expect(res.stdout).toBe('');
   });
 
-  it('never breaks the session: garbage stdin -> exit 0', async () => {
-    const { spawn } = await import('node:child_process');
-    const res = await new Promise((resolve) => {
-      const child = spawn(process.execPath, [script], { windowsHide: true });
-      let stdout = '';
-      child.stdout.on('data', (d) => { stdout += d; });
-      child.on('close', (code) => resolve({ code, stdout }));
-      child.stdin.write('not json at all');
-      child.stdin.end();
-    });
+  it('AC-B7.4: never breaks the session — garbage stdin exit 0', async () => {
+    const res = await runStatusline('not json at all');
     expect(res.code).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #43.

`▶ forge · #43 feat/43-statusline-v2 · ▓▓▓▓▓▓░░ 78% · Fable 5 · $1.23` (live output)

- **Glyph always present** with priority 🔒 > 🔥 > 🚩n > ▶ (work/hotfix branch) > · idle.
- **Project name** from the payload workspace dir — 'forge' is no longer hardcoded, so the same wiring works in cms.
- **Context progress bar** (8 cells + percent): payload shapes vary across Claude Code versions, so extraction tries context_window/context/usage/cost.context_window/model.context_window and **omits the bar when absent** — never guesses.
- **Model display name + session cost** when provided; every segment omits silently.
- isMain guard added — importing the module (tests) can no longer hang on stdin.

## AC checklist (acgate 5/5)
- [x] AC-B7.1 full strip + silent omission · [x] AC-B7.2 bar shapes/clamping · [x] AC-B7.3 payload-driven project · [x] AC-B7.4 silent-on-error preserved · [x] AC-B7.5 glyph priority

## Test adaptation note
tests/statusline.test.mjs was rewritten for the new format (old exact-string assertions replaced by stronger e2e + pure-helper coverage). testintent reported clean; flagging the rewrite here anyway for reviewer visibility — no assertion lost its subject, all four original behaviors (ticket line, no-ticket line, non-git silence, garbage-stdin silence) still asserted.

## Verification (honest)
- 266/266 tests (9 in the rewritten file); depguard clean, acgate 5/5.
- Live dogfood above. **NOT verified**: which context field name YOUR Claude Code build actually sends — if the bar doesn't appear in the real status line after merge, paste the payload (`/statusline` debug or hook log) and I'll add the shape; omission is the designed fallback, not a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x