### PR TITLE
fix: statusline context bar reads the real Claude Code payload (#45)

### DIFF
--- a/plugin/scripts/statusline.mjs
+++ b/plugin/scripts/statusline.mjs
@@ -22,9 +22,11 @@ export function extractContext(payload) {
   ];
   for (const c of cands) {
     if (!c || typeof c !== 'object') continue;
-    const used = [c.used_tokens, c.used, c.input_tokens, c.tokens_used].find((v) => typeof v === 'number');
-    const max = [c.max_tokens, c.max, c.context_window_size, c.limit].find((v) => typeof v === 'number');
+    // real Claude Code shape (docs): total_input_tokens + context_window_size (+ used_percentage)
+    const used = [c.total_input_tokens, c.used_tokens, c.used, c.input_tokens, c.tokens_used].find((v) => typeof v === 'number');
+    const max = [c.context_window_size, c.max_tokens, c.max, c.limit].find((v) => typeof v === 'number');
     if (typeof used === 'number' && typeof max === 'number' && max > 0) return { used, max };
+    if (typeof c.used_percentage === 'number') return { used: c.used_percentage, max: 100 };
   }
   return null;
 }

--- a/tests/statusline.test.mjs
+++ b/tests/statusline.test.mjs
@@ -55,7 +55,10 @@ describe('statusline v2 composition (AC-B7.1, AC-B7.5)', () => {
 });
 
 describe('context bar (AC-B7.2)', () => {
-  it('AC-B7.2: extractContext handles the payload shapes; absent -> null', () => {
+  it('AC-B7.2 + AC-B8.1: extractContext handles the payload shapes incl. the documented one; absent -> null', () => {
+    // AC-B8.1: the documented Claude Code payload shape
+    expect(extractContext({ context_window: { total_input_tokens: 489_500, total_output_tokens: 1200, context_window_size: 1_000_000, used_percentage: 49, current_usage: null } })).toEqual({ used: 489_500, max: 1_000_000 });
+    expect(extractContext({ context_window: { used_percentage: 49 } })).toEqual({ used: 49, max: 100 });
     expect(extractContext({ context_window: { used_tokens: 1, max_tokens: 4 } })).toEqual({ used: 1, max: 4 });
     expect(extractContext({ context: { used: 2, max: 8 } })).toEqual({ used: 2, max: 8 });
     expect(extractContext({ usage: { input_tokens: 3, context_window_size: 6 } })).toEqual({ used: 3, max: 6 });


### PR DESCRIPTION
Closes #45. The documented payload shape is `context_window.total_input_tokens` + `context_window_size` (+ `used_percentage`, nullable `current_usage`) — the v2 extractor missed `total_input_tokens`, so the bar never rendered on real builds. Added, with `used_percentage` fallback; regression pins the documented shape verbatim (source: code.claude.com/docs/en/statusline.md via claude-code-guide).

Verification: 266/266 tests + acgate AC-B8.1 green; live pipe of the documented payload renders `▶ forge · #45 fix/45-… · ▓▓▓▓░░░░ 49% · Fable 5 · $1.23`. NOT verified: your exact build's emission — but this is the documented contract, not a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x