### PR TITLE
feat: statusline effort + rate-limit segments (#47)

### DIFF
--- a/plugin/scripts/statusline.mjs
+++ b/plugin/scripts/statusline.mjs
@@ -38,7 +38,16 @@ export function renderBar({ used, max }, cells = 8) {
 }
 
 /** Pure composition — everything optional except the branch. */
-export function composeLine({ situation, pendingCount, project, branch, ticket, context, model, costUsd }) {
+/** rate_limits -> '5h 24% / 7d 41%' (either window optional). */
+export function renderLimits(rl) {
+  const parts = [
+    typeof rl?.five_hour?.used_percentage === 'number' ? `5h ${Math.round(rl.five_hour.used_percentage)}%` : null,
+    typeof rl?.seven_day?.used_percentage === 'number' ? `7d ${Math.round(rl.seven_day.used_percentage)}%` : null,
+  ].filter(Boolean);
+  return parts.length ? parts.join(' / ') : null;
+}
+
+export function composeLine({ situation, pendingCount, project, branch, ticket, context, model, costUsd, effort, rateLimits }) {
   const glyph =
     situation === 'security-response' ? '🔒' :
     situation === 'incident' ? '🔥' :
@@ -49,6 +58,8 @@ export function composeLine({ situation, pendingCount, project, branch, ticket, 
     branch ? (ticket != null ? `#${ticket} ${branch}` : branch) : null,
     context ? renderBar(context) : null,
     model || null,
+    effort ? `effort:${effort}` : null,
+    renderLimits(rateLimits),
     typeof costUsd === 'number' ? `$${costUsd.toFixed(2)}` : null,
   ];
   return segments.filter(Boolean).join(' · ');
@@ -84,6 +95,8 @@ async function main() {
     branch, ticket: parseBranch(branch).ticket,
     context: extractContext(payload),
     model: payload?.model?.display_name || null,
+    effort: payload?.effort?.level || null,
+    rateLimits: payload?.rate_limits || null,
     costUsd: typeof payload?.cost?.total_cost_usd === 'number' ? payload.cost.total_cost_usd : null,
   }));
 }

--- a/tests/statusline.test.mjs
+++ b/tests/statusline.test.mjs
@@ -39,6 +39,16 @@ describe('statusline v2 composition (AC-B7.1, AC-B7.5)', () => {
     expect(line).toBe('▶ cms · #12 feat/12-widget · ▓▓▓▓░░░░ 45% · Fable 5 · $0.42');
   });
 
+  it('AC-B9.1: effort + rate-limit segments render when present, omit when absent', () => {
+    const line = composeLine({
+      situation: 'idle', project: 'forge', branch: 'main', effort: 'high',
+      rateLimits: { five_hour: { used_percentage: 23.5 }, seven_day: { used_percentage: 41.2 } },
+    });
+    expect(line).toBe('· forge · main · effort:high · 5h 24% / 7d 41%');
+    expect(composeLine({ situation: 'idle', project: 'f', branch: 'main', rateLimits: { seven_day: { used_percentage: 10 } } })).toContain('· 7d 10%');
+    expect(composeLine({ situation: 'idle', project: 'f', branch: 'main', rateLimits: {} })).toBe('· f · main');
+  });
+
   it('AC-B7.1: absent segments omit silently', () => {
     expect(composeLine({ situation: 'idle', project: 'forge', branch: 'main' })).toBe('· forge · main');
   });


### PR DESCRIPTION
Closes #47. Appends `effort:<level>` and `5h n% / 7d n%` from the documented payload (rate_limits present only for Pro/Max after the first response — omits silently otherwise, like every segment).

Verification: 267/267 tests, testintent clean, acgate AC-B9.1 green; live pipe renders `▶ forge · #47 feat/47-statusline-limits · ▓▓▓▓░░░░ 51% · Fable 5 · effort:high · 5h 24% / 7d 41% · $1.50`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x