### PR TITLE
fix: release bumps version files — plugin updates work from v0.2.0 on (#51)

### DIFF
--- a/plugin/scripts/release/release.mjs
+++ b/plugin/scripts/release/release.mjs
@@ -62,20 +62,35 @@ export async function runRelease(ctx, args, log = console.log) {
   const section = renderChangelogSection(version, date, groups, repoUrl);
   const body = renderReleaseBody({ version, summary: summarize(groups, version), groups, repoUrl, infraChanged, migrations, imageDigest });
 
-  if (args.dryRun) {
-    log(`\n— dry run — would release v${version} (${bump} bump from ${tag ?? 'no prior tag'})`);
-    log(section);
-    return { ok: true, dryRun: true, version, bump, body };
+  // version files the ecosystem actually reads (#51): package.json, and the
+  // plugin manifest — the field the Claude Code plugin updater compares.
+  const versionFiles = ['package.json', join('plugin', '.claude-plugin', 'plugin.json')];
+  const bumpTargets = [];
+  for (const rel of versionFiles) {
+    try {
+      const raw = await readFile(join(cwd, rel), 'utf8');
+      if (JSON.parse(raw).version !== undefined) bumpTargets.push({ rel, raw });
+    } catch { /* absent in consumer repos — skip */ }
   }
 
-  // 3. changelog commit
+  if (args.dryRun) {
+    log(`\n— dry run — would release v${version} (${bump} bump from ${tag ?? 'no prior tag'})`);
+    log(`— would bump version in: ${bumpTargets.map((t) => t.rel).join(', ') || '(no version files)'}`);
+    log(section);
+    return { ok: true, dryRun: true, version, bump, body, bumpFiles: bumpTargets.map((t) => t.rel) };
+  }
+
+  // 3. version bumps + changelog commit
+  for (const t of bumpTargets) {
+    await writeFile(join(cwd, t.rel), t.raw.replace(/"version":\s*"[^"]+"/, `"version": "${version}"`), 'utf8');
+  }
   const clPath = join(cwd, 'CHANGELOG.md');
   let cl = '';
   try { cl = await readFile(clPath, 'utf8'); } catch { cl = '# Changelog\n\n'; }
   const marker = '# Changelog\n\n';
   const updated = cl.startsWith(marker) ? marker + section + '\n' + cl.slice(marker.length) : section + '\n' + cl;
   await writeFile(clPath, updated, 'utf8');
-  const add = await git('add', 'CHANGELOG.md');
+  const add = await git('add', 'CHANGELOG.md', ...bumpTargets.map((t) => t.rel));
   const commit = add.ok && (await git('commit', '-m', `chore(release): v${version}`));
   if (!commit.ok) return { ok: false, error: 'changelog commit failed' };
 

--- a/tests/release.test.mjs
+++ b/tests/release.test.mjs
@@ -101,3 +101,34 @@ describe('readiness (AC-4c.3)', () => {
     expect(crit.items.find((i) => i.name === 'findings').msg).toContain('critical');
   });
 });
+
+describe('release bumps version files (AC-B10.1, #51)', () => {
+  it('AC-B10.1: dry run computes the bump and lists both version files; regex targets only the version key', async () => {
+    const { runRelease } = await import('../plugin/scripts/release/release.mjs');
+    const { mkdir, writeFile, readFile } = await import('node:fs/promises');
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-rel-'));
+    await mkdir(join(cwd, 'plugin', '.claude-plugin'), { recursive: true });
+    await writeFile(join(cwd, 'package.json'), '{\n  "name": "forge",\n  "version": "0.1.0",\n  "private": true\n}', 'utf8');
+    await writeFile(join(cwd, 'plugin', '.claude-plugin', 'plugin.json'), '{\n  "name": "forge",\n  "version": "0.1.0",\n  "description": "version 0.1.0 of things"\n}', 'utf8');
+    const execFn = async (cmd, args) => {
+      const j = args.join(' ');
+      if (j.includes('--abbrev-ref')) return { ok: true, code: 0, stdout: 'main\n', stderr: '' };
+      if (j.includes('--porcelain')) return { ok: true, code: 0, stdout: '', stderr: '' };
+      if (j.includes('rev-list')) return { ok: true, code: 0, stdout: '0\n', stderr: '' };
+      if (j.startsWith('describe')) return { ok: true, code: 0, stdout: 'v0.1.0\n', stderr: '' };
+      if (j.startsWith('log')) return { ok: true, code: 0, stdout: 'feat(release): bump version files (#51)\n', stderr: '' };
+      if (j.startsWith('diff')) return { ok: true, code: 0, stdout: '', stderr: '' };
+      return { ok: true, code: 0, stdout: '', stderr: '' };
+    };
+    const gh = async () => ({ ok: false, stderr: 'no repo' });
+    const res = await runRelease({ cwd, gh, execFn }, { dryRun: true }, () => {});
+    expect(res).toMatchObject({ ok: true, dryRun: true, version: '0.2.0', bump: 'minor' });
+    expect(res.bumpFiles.sort()).toEqual(['package.json', join('plugin', '.claude-plugin', 'plugin.json')].sort());
+    // the replace regex must hit ONLY the version key, not other strings containing versions
+    const manifest = await readFile(join(cwd, 'plugin', '.claude-plugin', 'plugin.json'), 'utf8');
+    expect(manifest).toContain('"version": "0.1.0"'); // dry run wrote nothing
+    const bumped = manifest.replace(/"version":\s*"[^"]+"/, '"version": "0.2.0"');
+    expect(bumped).toContain('"version": "0.2.0"');
+    expect(bumped).toContain('version 0.1.0 of things'); // description untouched
+  });
+});


### PR DESCRIPTION
Closes #51. Found live: `/plugin update` said 'already at latest (0.1.0)' because release.mjs changelogs and tags but never writes the version into package.json or plugin/.claude-plugin/plugin.json — the manifest field the Claude Code updater compares. Fix: both files (when present with a version key — consumer repos without them skip) bump in the release commit; dry-run reports what would bump.

## Verification (honest)
268/268 tests; acgate AC-B10.1 (dry-run e2e with fake git: v0.1.0 tag + feat commit → 0.2.0 minor, both files listed; regex proven to touch only the version key); testintent clean. NOT verified: a real (non-dry) release run — that IS the next step: after merge I'll cut v0.2.0 live, which dogfoods the whole path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x