### PR TITLE
fix: createSingleSelectField inline-literal mutation (#55)

### DIFF
--- a/plugin/scripts/lib/board.mjs
+++ b/plugin/scripts/lib/board.mjs
@@ -95,16 +95,21 @@ export async function getProjectFields(gh, projectId) {
   return { ok: true, itemsCount: node.items.totalCount, fields };
 }
 
-const CREATE_FIELD_MUTATION = `mutation($projectId: ID!, $name: String!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
-  createProjectV2Field(input: { projectId: $projectId, dataType: SINGLE_SELECT, name: $name, singleSelectOptions: $options }) {
+/** Same inline-literal law as buildStatusMutation (#35/#55): gh -F stringifies arrays. */
+export function buildCreateFieldMutation(projectId, name, optionDefs) {
+  const opts = optionDefs
+    .map((o) => `{name: ${JSON.stringify(o.name)}, color: ${o.color}, description: ""}`)
+    .join(', ');
+  return `mutation {
+  createProjectV2Field(input: { projectId: ${JSON.stringify(projectId)}, dataType: SINGLE_SELECT, name: ${JSON.stringify(name)}, singleSelectOptions: [${opts}] }) {
     projectV2Field { ... on ProjectV2SingleSelectField { id name options { id name } } }
   }
 }`;
+}
 
 export async function createSingleSelectField(gh, projectId, name, optionDefs) {
-  const options = JSON.stringify(optionDefs.map((o) => ({ name: o.name, color: o.color, description: '' })));
   const res = await gh(
-    ['api', 'graphql', '-f', `query=${CREATE_FIELD_MUTATION}`, '-f', `projectId=${projectId}`, '-f', `name=${name}`, '-F', `options=${options}`],
+    ['api', 'graphql', '-f', `query=${buildCreateFieldMutation(projectId, name, optionDefs)}`],
     { parseJson: true },
   );
   if (!res.ok) return { ok: false, error: res.stderr || `create field ${name} failed` };

--- a/tests/lib/board.test.mjs
+++ b/tests/lib/board.test.mjs
@@ -27,3 +27,20 @@ describe('replaceStatusOptions mutation shape (AC-B4.1, #35)', () => {
     expect(seen.find((a) => a.startsWith('query='))).toContain('color: GREEN');
   });
 });
+
+describe('createSingleSelectField mutation shape (AC-B11.1, #55)', () => {
+  it('AC-B11.1: inline literals, bare enum colors, no -F variables', async () => {
+    const { buildCreateFieldMutation, createSingleSelectField, STANDARD_FIELDS } = await import('../../plugin/scripts/lib/board.mjs');
+    const m = buildCreateFieldMutation('PVT_x', 'Priority', STANDARD_FIELDS.priority);
+    expect(m).toContain('{name: "P0", color: RED, description: ""}');
+    expect(m).toContain('dataType: SINGLE_SELECT, name: "Priority"');
+    expect(m).not.toContain('"RED"');
+    expect(m).not.toContain('$options');
+    let seen = null;
+    const gh = async (args) => { seen = args; return { ok: true, json: { data: { createProjectV2Field: { projectV2Field: { id: 'f1' } } } } }; };
+    const res = await createSingleSelectField(gh, 'PVT_x', 'Priority', STANDARD_FIELDS.priority);
+    expect(res.ok).toBe(true);
+    expect(seen.filter((a) => a === '-F')).toHaveLength(0);
+    expect(seen.filter((a) => a === '-f')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #55. Same family as #35 (gh -F stringifies array variables; enum colors unquotable) — found live bootstrapping board #12's fields; replaceStatusOptions was fixed then, this sibling wasn't. Same buildCreateFieldMutation pattern, unused variable-form const removed, regression pins the shape.

Verification: 269/269 tests, testintent clean, acgate AC-B11.1 green. NOT verified live yet — the live proof is finishing board #12's Priority/Size/Type bootstrap immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x