### PR TITLE
feat: C1 — forge-control queue + registry + allowlisted CLI (#60)

### DIFF
--- a/control/control.mjs
+++ b/control/control.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * forge-control CLI (C1/#60; spec §11 guardrail). The command surface is an
+ * ALLOWLIST enforced HERE, in code — an unknown verb is refused at parse, not
+ * hidden in a UI. The console control tab (C3) POSTs these same verbs. Every
+ * accepted command is appended to an audit log, redacted. The control plane
+ * never pushes, merges, or edits files — its whole vocabulary is below.
+ *
+ *   control.mjs enqueue --repo <path> [--ticket N] [--brief "..."]
+ *   control.mjs list | status
+ *   control.mjs dequeue --id <id>
+ *   control.mjs pause [--reason "..."] | resume
+ *   control.mjs kill --id <session> | kill-all
+ */
+import { appendFile, mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { redact } from '../plugin/scripts/lib/journal.mjs';
+import * as queue from './lib/queue.mjs';
+import * as machine from './lib/machine.mjs';
+
+export const ALLOWED_VERBS = ['enqueue', 'dequeue', 'list', 'status', 'pause', 'resume', 'kill', 'kill-all'];
+
+export const defaultBase = (home = homedir()) => join(home, '.forge', 'control');
+
+export function parseArgs(argv) {
+  const a = { verb: argv[0] ?? null, repo: null, ticket: null, brief: '', id: null, reason: '', by: 'owner' };
+  for (let i = 1; i < argv.length; i++) {
+    if (argv[i] === '--repo') a.repo = argv[++i];
+    else if (argv[i] === '--ticket') a.ticket = Number(argv[++i]);
+    else if (argv[i] === '--brief') a.brief = argv[++i];
+    else if (argv[i] === '--id') a.id = argv[++i];
+    else if (argv[i] === '--reason') a.reason = argv[++i];
+    else if (argv[i] === '--by') a.by = argv[++i];
+  }
+  return a;
+}
+
+async function audit(base, verb, args) {
+  await mkdir(base, { recursive: true });
+  const rec = redact({ ts: new Date().toISOString(), verb, by: args.by, repo: args.repo, ticket: args.ticket, id: args.id });
+  await appendFile(join(base, 'audit.jsonl'), JSON.stringify(rec) + '\n', 'utf8');
+}
+
+/** Dispatch one verb. Returns {ok, ...}; unknown verbs are refused here. */
+export async function runControl(base, args, log = console.log) {
+  const { verb } = args;
+  if (!ALLOWED_VERBS.includes(verb)) {
+    return { ok: false, error: `unknown verb '${verb ?? ''}' — allowed: ${ALLOWED_VERBS.join(', ')}` };
+  }
+  await audit(base, verb, args);
+
+  switch (verb) {
+    case 'enqueue': {
+      const r = await queue.enqueue(base, { repo: args.repo, ticket: args.ticket, brief: args.brief });
+      if (r.ok) log(`enqueued ${r.entry.id} (${args.repo}${args.ticket ? ` #${args.ticket}` : ''})`);
+      return r;
+    }
+    case 'dequeue': {
+      if (!args.id) return { ok: false, error: 'dequeue needs --id' };
+      const r = await queue.ack(base, args.id);
+      if (r.ok) log(`dequeued ${args.id}`);
+      return r;
+    }
+    case 'list': {
+      const q = await queue.list(base);
+      const s = await machine.listSessions(base);
+      const paused = await machine.isPaused(base);
+      for (const e of q.entries) log(`queue ${e.seq} ${e.id} ${e.state} ${e.repo}${e.ticket ? ` #${e.ticket}` : ''}`);
+      for (const ss of s.sessions) log(`session ${ss.id} ${ss.state} ${ss.repo}${ss.ticket ? ` #${ss.ticket}` : ''}`);
+      log(paused ? 'PAUSED (global kill switch engaged)' : 'running');
+      return { ok: true, queue: q.entries, sessions: s.sessions, paused };
+    }
+    case 'status': {
+      const q = await queue.list(base);
+      const s = await machine.listSessions(base);
+      const paused = await machine.isPaused(base);
+      const pending = q.entries.filter((e) => e.state === 'pending').length;
+      const alive = s.sessions.filter((x) => x.state === 'alive').length;
+      log(`${paused ? '⏸ paused · ' : ''}${pending} queued · ${alive} session(s) alive`);
+      return { ok: true, pending, alive, paused };
+    }
+    case 'pause': {
+      await machine.setPaused(base, { by: args.by, reason: args.reason });
+      log('⏸ PAUSED — the runner spawns nothing until resumed (human-only clear)');
+      return { ok: true };
+    }
+    case 'resume': {
+      await machine.clearPaused(base);
+      log('▶ resumed');
+      return { ok: true };
+    }
+    case 'kill': {
+      if (!args.id) return { ok: false, error: 'kill needs --id <session>' };
+      const r = await machine.markSession(base, args.id, 'killed');
+      if (r.ok) log(`killed session ${args.id} (marked; PID termination lands with the C2 runner)`);
+      return r;
+    }
+    case 'kill-all': {
+      const s = await machine.listSessions(base);
+      for (const ss of s.sessions.filter((x) => x.state === 'alive')) await machine.markSession(base, ss.id, 'killed');
+      await machine.setPaused(base, { by: args.by, reason: 'kill-all' });
+      log('🛑 kill-all — all sessions marked killed + paused engaged');
+      return { ok: true, killed: s.sessions.filter((x) => x.state === 'alive').length };
+    }
+  }
+  return { ok: false, error: 'unreachable' };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  runControl(defaultBase(), parseArgs(process.argv.slice(2))).then((res) => {
+    if (!res.ok) { console.error(`control: ${res.error}`); process.exit(1); }
+  });
+}

--- a/control/lib/machine.mjs
+++ b/control/lib/machine.mjs
@@ -1,0 +1,66 @@
+/**
+ * forge-control machine state (C1/#60; spec §2). Two file-backed registries
+ * under the machine base dir:
+ *   <base>/paused                 present = global kill switch engaged
+ *   <base>/sessions/<id>.json     one per spawned/tracked session
+ * Clearing paused is always a human file delete — never automated (spec §2).
+ */
+import { readFile, writeFile, readdir, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const PAUSED = 'paused';
+const SESSIONS = 'sessions';
+
+export async function isPaused(base) {
+  try { await readFile(join(base, PAUSED), 'utf8'); return true; } catch { return false; }
+}
+
+export async function setPaused(base, { by = 'owner', reason = '' } = {}) {
+  await mkdir(base, { recursive: true });
+  await writeFile(join(base, PAUSED), JSON.stringify({ by, reason, at: new Date().toISOString() }), 'utf8');
+  return { ok: true };
+}
+
+export async function clearPaused(base) {
+  await rm(join(base, PAUSED), { force: true });
+  return { ok: true };
+}
+
+export async function pausedInfo(base) {
+  try { return { ok: true, info: JSON.parse(await readFile(join(base, PAUSED), 'utf8')) }; }
+  catch { return { ok: true, info: null }; }
+}
+
+const sessFile = (base, id) => join(base, SESSIONS, `${id}.json`);
+
+export async function registerSession(base, { id, ticket = null, repo, pid = null } = {}) {
+  if (!id || !repo) return { ok: false, error: 'registerSession needs id and repo' };
+  await mkdir(join(base, SESSIONS), { recursive: true });
+  const now = new Date().toISOString();
+  const rec = { id, ticket, repo, pid, state: 'alive', startedAt: now, lastHeartbeat: now };
+  await writeFile(sessFile(base, id), JSON.stringify(rec), 'utf8');
+  return { ok: true, session: rec };
+}
+
+export async function updateSession(base, id, patch = {}) {
+  let rec;
+  try { rec = JSON.parse(await readFile(sessFile(base, id), 'utf8')); }
+  catch { return { ok: false, error: `no session '${id}'` }; }
+  const next = { ...rec, ...patch, lastHeartbeat: patch.lastHeartbeat ?? new Date().toISOString() };
+  await writeFile(sessFile(base, id), JSON.stringify(next), 'utf8');
+  return { ok: true, session: next };
+}
+
+export function markSession(base, id, state) {
+  return updateSession(base, id, { state });
+}
+
+export async function listSessions(base) {
+  let files;
+  try { files = await readdir(join(base, SESSIONS)); } catch { return { ok: true, sessions: [] }; }
+  const out = [];
+  for (const f of files.filter((f) => f.endsWith('.json'))) {
+    try { out.push(JSON.parse(await readFile(join(base, SESSIONS, f), 'utf8'))); } catch { /* skip */ }
+  }
+  return { ok: true, sessions: out.sort((a, b) => (a.startedAt < b.startedAt ? -1 : 1)) };
+}

--- a/control/lib/queue.mjs
+++ b/control/lib/queue.mjs
@@ -1,0 +1,81 @@
+/**
+ * forge-control work queue (C1/#60; spec §2). File-backed, ordered by an
+ * increasing sequence so FIFO survives restarts and needs no daemon memory.
+ * Layout under the machine base dir:
+ *   <base>/queue/<seq>-<id>.json        pending or held entries
+ *   <base>/queue-done/<seq>-<id>.json   acked (kept as history)
+ * No spawning here — this is the ledger the runner (C2) reads.
+ */
+import { readFile, writeFile, readdir, mkdir, rename } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const Q = 'queue';
+const DONE = 'queue-done';
+const pad = (n) => String(n).padStart(6, '0');
+
+async function entries(base) {
+  const dir = join(base, Q);
+  let files;
+  try { files = await readdir(dir); } catch { return []; }
+  const out = [];
+  for (const f of files.filter((f) => f.endsWith('.json'))) {
+    try { out.push(JSON.parse(await readFile(join(dir, f), 'utf8'))); } catch { /* skip half-write */ }
+  }
+  return out.sort((a, b) => a.seq - b.seq);
+}
+
+async function nextSeq(base) {
+  const es = await entries(base);
+  const done = await (async () => { try { return (await readdir(join(base, DONE))).length; } catch { return 0; } })();
+  const maxLive = es.reduce((m, e) => Math.max(m, e.seq), 0);
+  return Math.max(maxLive, done) + 1;
+}
+
+function fileFor(seq, id) { return `${pad(seq)}-${id}.json`; }
+
+export async function enqueue(base, { id, ticket = null, repo, brief = '', at } = {}) {
+  if (!repo) return { ok: false, error: 'enqueue needs a repo' };
+  const dir = join(base, Q);
+  await mkdir(dir, { recursive: true });
+  const seq = await nextSeq(base);
+  const rec = { id: id ?? `q-${seq}`, seq, ticket, repo, brief, state: 'pending', enqueuedAt: at ?? new Date().toISOString() };
+  await writeFile(join(dir, fileFor(seq, rec.id)), JSON.stringify(rec), 'utf8');
+  return { ok: true, entry: rec };
+}
+
+export async function list(base) {
+  return { ok: true, entries: await entries(base) };
+}
+
+/** The next runnable entry: lowest-seq pending (held entries are skipped). */
+export async function next(base) {
+  const e = (await entries(base)).find((x) => x.state === 'pending');
+  return { ok: true, entry: e ?? null };
+}
+
+async function mutate(base, id, fn) {
+  const es = await entries(base);
+  const e = es.find((x) => x.id === id);
+  if (!e) return { ok: false, error: `no queue entry '${id}'` };
+  fn(e);
+  await writeFile(join(base, Q, fileFor(e.seq, e.id)), JSON.stringify(e), 'utf8');
+  return { ok: true, entry: e };
+}
+
+export function hold(base, id, reason) {
+  return mutate(base, id, (e) => { e.state = 'held'; e.holdReason = reason ?? 'held'; });
+}
+
+export function release(base, id) {
+  return mutate(base, id, (e) => { e.state = 'pending'; delete e.holdReason; });
+}
+
+/** ack = the entry is done; move it to history so the queue only holds live work. */
+export async function ack(base, id) {
+  const es = await entries(base);
+  const e = es.find((x) => x.id === id);
+  if (!e) return { ok: false, error: `no queue entry '${id}'` };
+  await mkdir(join(base, DONE), { recursive: true });
+  await rename(join(base, Q, fileFor(e.seq, e.id)), join(base, DONE, fileFor(e.seq, e.id)));
+  return { ok: true, entry: { ...e, state: 'done' } };
+}

--- a/tests/control/control.test.mjs
+++ b/tests/control/control.test.mjs
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as queue from '../../control/lib/queue.mjs';
+import * as machine from '../../control/lib/machine.mjs';
+import { runControl, parseArgs, ALLOWED_VERBS, defaultBase } from '../../control/control.mjs';
+
+const base = () => mkdtemp(join(tmpdir(), 'forge-ctl-'));
+const noop = () => {};
+
+describe('queue (AC-C1.1)', () => {
+  it('AC-C1.1: enqueue/next/hold/ack round-trip FIFO; held skipped; ack archives', async () => {
+    const b = await base();
+    const a = await queue.enqueue(b, { repo: 'forge', ticket: 60, brief: 'first' });
+    const c = await queue.enqueue(b, { repo: 'cms', brief: 'second' });
+    expect(a.entry.seq).toBe(1);
+    expect(c.entry.seq).toBe(2);
+
+    // next = lowest-seq pending
+    expect((await queue.next(b)).entry.id).toBe(a.entry.id);
+    // hold the first → next skips to the second
+    await queue.hold(b, a.entry.id, 'waiting on decision');
+    expect((await queue.next(b)).entry.id).toBe(c.entry.id);
+    expect((await queue.list(b)).entries.find((e) => e.id === a.entry.id)).toMatchObject({ state: 'held', holdReason: 'waiting on decision' });
+    // release restores order
+    await queue.release(b, a.entry.id);
+    expect((await queue.next(b)).entry.id).toBe(a.entry.id);
+    // ack archives out of the live queue
+    await queue.ack(b, a.entry.id);
+    expect((await queue.list(b)).entries.map((e) => e.id)).toEqual([c.entry.id]);
+    expect(await readdir(join(b, 'queue-done'))).toHaveLength(1);
+    // new enqueue keeps increasing seq past archived
+    expect((await queue.enqueue(b, { repo: 'x' })).entry.seq).toBe(3);
+    expect((await queue.hold(b, 'nope')).ok).toBe(false);
+  });
+
+  it('enqueue requires a repo; empty queue next is null', async () => {
+    const b = await base();
+    expect((await queue.enqueue(b, {})).ok).toBe(false);
+    expect((await queue.next(b)).entry).toBe(null);
+  });
+});
+
+describe('machine paused + sessions (AC-C1.2, AC-C1.3)', () => {
+  it('AC-C1.2: paused flag set/clear with who/when; missing = false', async () => {
+    const b = await base();
+    expect(await machine.isPaused(b)).toBe(false);
+    await machine.setPaused(b, { by: 'dngioidev', reason: 'overnight' });
+    expect(await machine.isPaused(b)).toBe(true);
+    expect((await machine.pausedInfo(b)).info).toMatchObject({ by: 'dngioidev', reason: 'overnight' });
+    await machine.clearPaused(b);
+    expect(await machine.isPaused(b)).toBe(false);
+    expect((await machine.pausedInfo(b)).info).toBe(null);
+  });
+
+  it('AC-C1.3: sessions register/update/list/mark', async () => {
+    const b = await base();
+    await machine.registerSession(b, { id: 's1', ticket: 60, repo: 'forge', pid: 1234 });
+    expect((await machine.listSessions(b)).sessions[0]).toMatchObject({ id: 's1', state: 'alive', pid: 1234 });
+    await machine.updateSession(b, 's1', { state: 'idle' });
+    expect((await machine.listSessions(b)).sessions[0].state).toBe('idle');
+    await machine.markSession(b, 's1', 'killed');
+    expect((await machine.listSessions(b)).sessions[0].state).toBe('killed');
+    expect((await machine.updateSession(b, 'ghost', {})).ok).toBe(false);
+    expect((await machine.registerSession(b, { id: 'x' })).ok).toBe(false); // needs repo
+  });
+});
+
+describe('control CLI allowlist + audit (AC-C1.4)', () => {
+  it('AC-C1.4: unknown verb refused naming the allowed set', async () => {
+    const b = await base();
+    const res = await runControl(b, parseArgs(['deploy', '--repo', 'forge']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unknown verb 'deploy'/);
+    expect(res.error).toContain('enqueue, dequeue, list, status, pause, resume, kill, kill-all');
+    // the dangerous verbs simply do not exist in the vocabulary
+    for (const forbidden of ['push', 'merge', 'edit', 'commit']) expect(ALLOWED_VERBS).not.toContain(forbidden);
+  });
+
+  it('AC-C1.4: every accepted verb writes a redacted audit record', async () => {
+    const b = await base();
+    await runControl(b, parseArgs(['enqueue', '--repo', 'forge', '--ticket', '60', '--brief', 'do the thing']), noop);
+    await runControl(b, parseArgs(['pause', '--reason', 'GITHUB_TOKEN=ghp_secretsecretsecretsecret1234']), noop);
+    const audit = (await readFile(join(b, 'audit.jsonl'), 'utf8')).trim().split('\n').map((l) => JSON.parse(l));
+    expect(audit).toHaveLength(2);
+    expect(audit[0]).toMatchObject({ verb: 'enqueue', repo: 'forge', ticket: 60 });
+    expect(JSON.stringify(audit)).not.toContain('ghp_secretsecret'); // reason not audited, and redaction covers payloads
+  });
+
+  it('AC-C1.4: enqueue → status → dequeue drives the queue; pause/resume/kill-all', async () => {
+    const b = await base();
+    const e = await runControl(b, parseArgs(['enqueue', '--repo', 'forge', '--ticket', '60']), noop);
+    expect(e.ok).toBe(true);
+    expect((await runControl(b, parseArgs(['status']), noop))).toMatchObject({ pending: 1, alive: 0, paused: false });
+
+    await machine.registerSession(b, { id: 's1', repo: 'forge' });
+    const killAll = await runControl(b, parseArgs(['kill-all']), noop);
+    expect(killAll).toMatchObject({ ok: true, killed: 1 });
+    expect(await machine.isPaused(b)).toBe(true); // kill-all engages the switch
+    expect((await machine.listSessions(b)).sessions[0].state).toBe('killed');
+    await runControl(b, parseArgs(['resume']), noop);
+    expect(await machine.isPaused(b)).toBe(false);
+
+    await runControl(b, parseArgs(['dequeue', '--id', e.entry.id]), noop);
+    expect((await queue.list(b)).entries).toHaveLength(0);
+    expect((await runControl(b, parseArgs(['dequeue']), noop)).ok).toBe(false); // needs --id
+  });
+
+  it('defaultBase lives under ~/.forge/control', () => {
+    expect(defaultBase('/home/u')).toBe(join('/home/u', '.forge', 'control'));
+  });
+});


### PR DESCRIPTION
First epic of forge-control (spec approved on #56). Plan: docs/plans/2026-07-18-c1-control-queue.md · tracked on board #12.

## What
- **control/lib/queue.mjs** — file-backed FIFO work queue (enqueue/next/hold/release/ack), restart-safe via sequence numbers; ack archives to queue-done/. No daemon memory needed.
- **control/lib/machine.mjs** — the **paused kill switch** (present-file = engaged; clearing is a human delete, never automated) + sessions registry (register/update/list/mark).
- **control/control.mjs** — the CLI whose verbs are an **allowlist enforced in code** (spec §11): enqueue/dequeue/list/status/pause/resume/kill/kill-all. push/merge/edit/commit are *not in the vocabulary* — an unknown verb is refused at parse naming the allowed set. Every accepted verb writes a redacted audit record. No spawning yet — that's C2.

## AC checklist (acgate 4/4)
- [x] AC-C1.1 queue FIFO + hold-skip + ack-archive
- [x] AC-C1.2 paused set/clear with who/when
- [x] AC-C1.3 sessions register/update/list/mark
- [x] AC-C1.4 unknown-verb refusal + redacted audit

## Verification (honest)
279/279 tests (8 new); plandrift clean (4 files), testintent + depguard clean, acgate 4/4. Live dogfood: real CLI enqueue → status → 'push' refused. **NOT built yet** (by design, later C-epics): spawning claude -p + supervision (C2), console control tab (C3), situationgate reading the paused flag (C4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x