### PR TITLE
feat(control): C2 runner — spawn claude -p + supervise (#62)

### DIFF
--- a/control/lib/runner.mjs
+++ b/control/lib/runner.mjs
@@ -1,0 +1,121 @@
+/**
+ * forge-control runner (C2/#62; spec §2). The daemon `work` loop: take the next
+ * runnable queue entry, spawn a headless `claude -p` session, supervise it
+ * (heartbeat / timeout / kill), record the outcome to the control journal + the
+ * driving ticket's trail, and ack the entry. One session at a time per machine
+ * (spec §2). The control plane never merges — the spawned session runs the normal
+ * pipeline and the owner merges the PR.
+ *
+ * Everything external is injectable (spawn / trail / journal / clock) so the loop
+ * is fully testable without the real binary, real gh, or real time.
+ */
+import { appendFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { redact } from '../../plugin/scripts/lib/journal.mjs';
+import * as queue from './queue.mjs';
+import * as machine from './machine.mjs';
+import { spawnSession, classify } from './spawn.mjs';
+
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000; // 30 min — a stuck session is killed, not left orphaned
+const DEFAULT_HEARTBEAT_MS = 15 * 1000;
+
+/** Control-plane session log — separate from the repo journal (whose KINDS are fixed). Redacted. */
+async function defaultJournal(base, rec) {
+  await mkdir(base, { recursive: true });
+  await appendFile(join(base, 'runner.jsonl'), JSON.stringify(redact({ ts: new Date().toISOString(), ...rec })) + '\n', 'utf8');
+}
+
+/** Best-effort ticket trail via gh. repo must be an owner/name slug; a path is skipped (journaled). */
+function defaultTrail(repo, ticket, body) {
+  return new Promise((resolve) => {
+    if (!repo || !/^[\w.-]+\/[\w.-]+$/.test(repo)) return resolve({ ok: false, error: `no slug for trail (repo='${repo}')` });
+    execFile('gh', ['issue', 'comment', String(ticket), '--repo', repo, '--body', body], (err) => resolve({ ok: !err, error: err ? String(err) : null }));
+  });
+}
+
+function outcomeLine(outcome, sessionId, extra = {}) {
+  const cost = extra.cost != null ? ` · $${extra.cost}` : '';
+  if (outcome === 'timeout') return `🛑 forge-control killed session \`${sessionId}\` — exceeded timeout (${extra.timeoutMs}ms). Branch/PR (if any) left for review; nothing died silently.`;
+  if (outcome === 'killed') return `🛑 forge-control killed session \`${sessionId}\`.`;
+  if (outcome === 'success') return `✅ forge-control session \`${sessionId}\` finished (success)${cost}. The PR follows the normal pipeline — owner merges.`;
+  return `⚠️ forge-control session \`${sessionId}\` ended: ${outcome}${cost}.`;
+}
+
+/**
+ * Drive one queue entry through a supervised session.
+ * Returns { ok, skipped? , sessionId?, outcome?, entry? }.
+ *   skipped: 'paused' (C1 kill switch engaged) | 'empty' (nothing runnable).
+ */
+export async function runOnce(base, opts = {}) {
+  const {
+    spawn = (o) => spawnSession(o),
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    heartbeatMs = DEFAULT_HEARTBEAT_MS,
+    trail = defaultTrail,
+    journal = defaultJournal,
+    model,
+    permissionMode,
+    mintId = randomUUID,
+  } = opts;
+
+  if (await machine.isPaused(base)) return { ok: true, skipped: 'paused' };
+  const { entry } = await queue.next(base);
+  if (!entry) return { ok: true, skipped: 'empty' };
+
+  const sessionId = mintId();
+  await machine.registerSession(base, { id: sessionId, ticket: entry.ticket, repo: entry.repo, pid: null });
+  await journal(base, { event: 'session-start', sessionId, ticket: entry.ticket, repo: entry.repo, brief: entry.brief });
+
+  const handle = spawn({ brief: entry.brief, sessionId, repo: entry.repo, model, permissionMode });
+  await machine.updateSession(base, sessionId, { pid: handle.pid ?? null });
+
+  // Supervise: a heartbeat while alive, and a timeout that kills by handle (PID under the hood).
+  // The heartbeat is a self-chaining timeout (not setInterval) so it can be stopped cleanly and
+  // its last in-flight write awaited — otherwise a fire-and-forget beat's read-modify-write can
+  // land AFTER the final markSession and clobber the authoritative state back to 'alive'.
+  let killedReason = null;
+  let stopped = false;
+  let hbInflight = Promise.resolve();
+  const timer = setTimeout(() => { killedReason = 'timeout'; try { handle.kill(); } catch { /* already gone */ } }, timeoutMs);
+  const beat = () => {
+    if (stopped) return;
+    hbInflight = machine.updateSession(base, sessionId, {}).catch(() => {});
+    hbTimer = setTimeout(beat, heartbeatMs);
+  };
+  let hbTimer = setTimeout(beat, heartbeatMs);
+
+  let result;
+  try {
+    result = await handle.done; // resolves on natural close AND after a kill
+  } finally {
+    clearTimeout(timer);
+    stopped = true;
+    clearTimeout(hbTimer);
+    await hbInflight; // let the last heartbeat write settle before the authoritative mark below
+  }
+
+  const outcome = classify({ exitCode: result?.exitCode, envelope: result?.envelope, killedReason });
+  const cost = result?.envelope?.total_cost_usd;
+  await machine.markSession(base, sessionId, killedReason ? 'killed' : 'dead');
+  await journal(base, { event: 'session-end', sessionId, ticket: entry.ticket, repo: entry.repo, outcome, cost, killedReason });
+  if (entry.ticket) await trail(entry.repo, entry.ticket, outcomeLine(outcome, sessionId, { cost, timeoutMs }));
+  await queue.ack(base, entry.id);
+
+  return { ok: true, sessionId, outcome, killedReason, entry };
+}
+
+/**
+ * The daemon loop: run entries one at a time until paused or the queue drains.
+ * `once: true` runs a single entry (used by tests / a one-shot invocation).
+ */
+export async function work(base, opts = {}) {
+  const results = [];
+  for (;;) {
+    const r = await runOnce(base, opts);
+    results.push(r);
+    if (r.skipped || opts.once) break;
+  }
+  return results;
+}

--- a/control/lib/spawn.mjs
+++ b/control/lib/spawn.mjs
@@ -1,0 +1,55 @@
+/**
+ * forge-control spawner (C2/#62; spec §2). Builds the headless `claude -p`
+ * invocation the runner supervises, and parses its result envelope. Flag shape
+ * and envelope fields were verified live against Claude Code 2.1.207 (spec §12
+ * spike): success → exit 0 + {subtype:'success', is_error:false}; failure →
+ * exit 1 but STILL valid JSON on stdout with {is_error:true, terminal_reason}.
+ * So the caller always parses stdout JSON and classifies from it + the exit code.
+ */
+import { spawn as nodeSpawn } from 'node:child_process';
+
+/** The exact verified argv (after the `claude` binary). Resume swaps the id flag. */
+export function buildArgs({ brief, sessionId, repo, model = 'claude-sonnet-5', permissionMode = 'plan', resume = false } = {}) {
+  const args = ['-p', brief ?? '', '--output-format', 'json', '--model', model, '--permission-mode', permissionMode];
+  if (resume) args.push('-r', sessionId);
+  else if (sessionId) args.push('--session-id', sessionId);
+  if (repo) args.push('--add-dir', repo);
+  return args;
+}
+
+/**
+ * Terminal outcome from what actually happened. A supervisor-initiated kill wins
+ * (killedReason = 'timeout' | 'killed'); otherwise the envelope decides. Bad/no
+ * envelope with a non-zero exit is 'error'.
+ */
+export function classify({ exitCode, envelope, killedReason } = {}) {
+  if (killedReason) return killedReason;
+  if (envelope && envelope.is_error) return envelope.terminal_reason || 'api_error';
+  if (exitCode === 0 && envelope && envelope.subtype === 'success') return 'success';
+  return 'error';
+}
+
+/**
+ * Spawn one headless session. Returns a handle immediately:
+ *   { sessionId, pid, kill(), done }  where done resolves to
+ *   { exitCode, envelope, stdout, stderr } once the process closes (incl. after kill).
+ * spawnFn/cmd are injectable so the runner is testable without the real binary.
+ */
+export function spawnSession(opts = {}, { spawnFn = nodeSpawn, cmd = 'claude' } = {}) {
+  const args = buildArgs(opts);
+  const child = spawnFn(cmd, args, { cwd: opts.repo || process.cwd() });
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.on('data', (d) => { stdout += d; });
+  child.stderr?.on('data', (d) => { stderr += d; });
+  const done = new Promise((resolve) => {
+    const finish = (exitCode) => {
+      let envelope = null;
+      try { envelope = JSON.parse(stdout); } catch { /* non-JSON / partial → null, classify() → error */ }
+      resolve({ exitCode, envelope, stdout, stderr });
+    };
+    child.on('close', (code) => finish(code));
+    child.on('error', (err) => { stderr += String(err); finish(-1); });
+  });
+  return { sessionId: opts.sessionId, pid: child.pid ?? null, kill: (sig = 'SIGTERM') => child.kill(sig), done };
+}

--- a/control/runner.mjs
+++ b/control/runner.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * forge-control runner entrypoint (C2/#62). Thin daemon shell around the loop in
+ * lib/runner.mjs. Deliberately NOT a control.mjs verb: the owner's control
+ * vocabulary (enqueue/pause/kill/...) stays an allowlist that can't spawn — the
+ * runner is the thing being controlled, started by the owner, not a command.
+ *
+ *   runner.mjs            drain the queue once through, then exit (one-shot)
+ *   runner.mjs --loop     keep looping (a stub sleep between drains)
+ *   runner.mjs --once     run exactly one entry
+ *
+ * Respects the C1 paused flag: if paused, it spawns nothing and exits.
+ */
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { work } from './lib/runner.mjs';
+
+export const defaultBase = (home = homedir()) => join(home, '.forge', 'control');
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const argv = process.argv.slice(2);
+  const once = argv.includes('--once');
+  work(defaultBase(), { once }).then((results) => {
+    for (const r of results) {
+      if (r.skipped) console.log(`runner: idle (${r.skipped})`);
+      else console.log(`runner: ${r.entry?.id} → ${r.outcome}${r.killedReason ? ` (${r.killedReason})` : ''}`);
+    }
+  }).catch((err) => { console.error(`runner: ${err?.message || err}`); process.exit(1); });
+}

--- a/tests/control/runner.test.mjs
+++ b/tests/control/runner.test.mjs
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as queue from '../../control/lib/queue.mjs';
+import * as machine from '../../control/lib/machine.mjs';
+import { buildArgs, classify } from '../../control/lib/spawn.mjs';
+import { runOnce, work } from '../../control/lib/runner.mjs';
+
+const base = () => mkdtemp(join(tmpdir(), 'forge-run-'));
+
+// A fake spawn: 'success' / 'api_error' resolve immediately; 'hang' resolves only
+// when the supervisor calls kill() — that's how we exercise the timeout path.
+function fakeSpawn(mode, sink = []) {
+  return (opts) => {
+    sink.push(opts);
+    let resolveDone;
+    const done = new Promise((res) => { resolveDone = res; });
+    if (mode === 'success') resolveDone({ exitCode: 0, envelope: { subtype: 'success', is_error: false, session_id: opts.sessionId, result: 'ok', total_cost_usd: 0.017 } });
+    else if (mode === 'api_error') resolveDone({ exitCode: 1, envelope: { subtype: 'success', is_error: true, api_error_status: 404, terminal_reason: 'api_error', session_id: opts.sessionId } });
+    // 'hang' → never resolves until kill()
+    return { sessionId: opts.sessionId, pid: 4242, kill: () => resolveDone({ exitCode: null, envelope: null }), done };
+  };
+}
+
+let idSeq = 0;
+const mintId = () => `sess-${++idSeq}`;
+
+describe('spawn shape + classify (AC-C2.3, AC-C2.4)', () => {
+  it('buildArgs is the verified headless flag string; resume swaps the id flag', () => {
+    expect(buildArgs({ brief: 'do X', sessionId: 'u1', repo: '/r', model: 'm', permissionMode: 'plan' }))
+      .toEqual(['-p', 'do X', '--output-format', 'json', '--model', 'm', '--permission-mode', 'plan', '--session-id', 'u1', '--add-dir', '/r']);
+    expect(buildArgs({ brief: 'again', sessionId: 'u1', resume: true })).toContain('-r');
+    expect(buildArgs({ brief: 'again', sessionId: 'u1', resume: true })).not.toContain('--session-id');
+  });
+
+  it('classify: success / api_error / killed / error from exit + envelope', () => {
+    expect(classify({ exitCode: 0, envelope: { subtype: 'success', is_error: false } })).toBe('success');
+    expect(classify({ exitCode: 1, envelope: { is_error: true, terminal_reason: 'api_error' } })).toBe('api_error');
+    expect(classify({ exitCode: null, envelope: null, killedReason: 'timeout' })).toBe('timeout'); // supervisor kill wins
+    expect(classify({ exitCode: 1, envelope: null })).toBe('error');
+  });
+});
+
+describe('runOnce (AC-C2.1)', () => {
+  it('paused → no spawn (respects the C1 kill switch)', async () => {
+    const b = await base();
+    await queue.enqueue(b, { repo: 'dngioidev/forge', ticket: 62, brief: 'x' });
+    await machine.setPaused(b, { by: 'owner', reason: 'test' });
+    const spawned = [];
+    const r = await runOnce(b, { spawn: fakeSpawn('success', spawned), trail: async () => {}, journal: async () => {}, mintId });
+    expect(r.skipped).toBe('paused');
+    expect(spawned).toHaveLength(0);
+    expect((await queue.list(b)).entries).toHaveLength(1); // entry untouched
+  });
+
+  it('empty queue → skipped empty', async () => {
+    const b = await base();
+    const r = await runOnce(b, { spawn: fakeSpawn('success'), trail: async () => {}, journal: async () => {}, mintId });
+    expect(r.skipped).toBe('empty');
+  });
+
+  it('success: registers a session, acks the entry, session ends dead, outcome trailed', async () => {
+    const b = await base();
+    await queue.enqueue(b, { repo: 'dngioidev/forge', ticket: 62, brief: 'ship it' });
+    const trails = [];
+    const r = await runOnce(b, { spawn: fakeSpawn('success'), trail: async (repo, ticket, body) => trails.push({ repo, ticket, body }), journal: async () => {}, mintId });
+    expect(r.outcome).toBe('success');
+    expect((await queue.list(b)).entries).toHaveLength(0); // acked
+    const sessions = (await machine.listSessions(b)).sessions;
+    expect(sessions[0]).toMatchObject({ state: 'dead', ticket: 62, pid: 4242 });
+    expect(trails[0]).toMatchObject({ repo: 'dngioidev/forge', ticket: 62 });
+    expect(trails[0].body).toContain('success');
+  });
+
+  it('api_error: entry still acked, session dead, outcome classified', async () => {
+    const b = await base();
+    await queue.enqueue(b, { repo: 'dngioidev/forge', ticket: 62, brief: 'boom' });
+    const r = await runOnce(b, { spawn: fakeSpawn('api_error'), trail: async () => {}, journal: async () => {}, mintId });
+    expect(r.outcome).toBe('api_error');
+    expect((await machine.listSessions(b)).sessions[0].state).toBe('dead');
+  });
+});
+
+describe('supervisor timeout (AC-C2.2)', () => {
+  it('a hung session is killed by timeout, marked killed, journaled AND trailed', async () => {
+    const b = await base();
+    await queue.enqueue(b, { repo: 'dngioidev/forge', ticket: 62, brief: 'hang forever' });
+    const journal = [];
+    const trails = [];
+    const r = await runOnce(b, {
+      spawn: fakeSpawn('hang'),
+      timeoutMs: 20,
+      heartbeatMs: 5,
+      trail: async (repo, ticket, body) => trails.push(body),
+      journal: async (_b, rec) => journal.push(rec),
+      mintId,
+    });
+    expect(r.outcome).toBe('timeout');
+    expect(r.killedReason).toBe('timeout');
+    expect((await machine.listSessions(b)).sessions[0].state).toBe('killed');
+    // journaled: nothing dies silently
+    expect(journal.find((e) => e.event === 'session-end' && e.killedReason === 'timeout')).toBeTruthy();
+    // trailed the kill
+    expect(trails.some((t) => /killed/i.test(t) && /timeout/i.test(t))).toBe(true);
+  });
+});
+
+describe('work loop', () => {
+  it('drains all pending entries then stops on empty; paused stops immediately', async () => {
+    const b = await base();
+    await queue.enqueue(b, { repo: 'dngioidev/forge', ticket: 1, brief: 'a' });
+    await queue.enqueue(b, { repo: 'dngioidev/forge', ticket: 2, brief: 'b' });
+    const results = await work(b, { spawn: fakeSpawn('success'), trail: async () => {}, journal: async () => {}, mintId });
+    // two runs + a final 'empty'
+    expect(results.filter((r) => r.outcome === 'success')).toHaveLength(2);
+    expect(results[results.length - 1].skipped).toBe('empty');
+    expect((await queue.list(b)).entries).toHaveLength(0);
+  });
+
+  it('control runner journal defaults land in <base>/runner.jsonl', async () => {
+    const b = await base();
+    await queue.enqueue(b, { repo: 'dngioidev/forge', ticket: 62, brief: 'x' });
+    await runOnce(b, { spawn: fakeSpawn('success'), trail: async () => {}, mintId }); // default journal
+    const log = (await readFile(join(b, 'runner.jsonl'), 'utf8')).trim().split('\n').map((l) => JSON.parse(l));
+    expect(log.map((e) => e.event)).toContain('session-start');
+    expect(log.map((e) => e.event)).toContain('session-end');
+  });
+});


### PR DESCRIPTION
## C2 — forge-control runner (spec §2)

Closes #62 (board #12). Builds on C1 (#60/#61): the daemon `work` loop that turns queue entries into supervised headless sessions. **The control plane still never merges** — the spawned session runs the normal pipeline and the owner merges its PR. `runner.mjs` is deliberately NOT a `control.mjs` verb, so the owner's control vocabulary stays an allowlist that cannot spawn.

### What's here
- **`control/lib/spawn.mjs`** — `buildArgs` (the verified headless flag array), `classify` (outcome from exit code + envelope, supervisor-kill wins), `spawnSession` (real `child_process` spawner returning `{sessionId, pid, kill(), done}`; `done` parses the stdout JSON envelope).
- **`control/lib/runner.mjs`** — `runOnce` (paused-check → `queue.next` → register session → spawn → supervise → classify → journal + trail → ack) and `work` (loop until paused/empty). Spawn / trail / journal / clock all injected.
- **`control/runner.mjs`** — thin daemon entrypoint (`--once` / drain).
- **`tests/control/runner.test.mjs`** — 9 tests across AC-C2.1..C2.4.

### The §12 spike (the one thing the spec flagged unverified) — done, on this machine
Ran real `claude -p` (Claude Code 2.1.207):
- success → exit 0, `{subtype:success, is_error:false}`;
- `--session-id <uuid>` round-trips → runner mints it, tracks/kills/resumes by it;
- resume `-r <sid>` retains context;
- failure (bad model) → exit 1 but **still valid JSON on stdout** (`is_error:true`, `terminal_reason`) → always parse stdout, classify from it + exit code;
- `total_cost_usd`/`usage` per session in the envelope → feeds C8 quota.

### Verification — done
- ✅ 9/9 C2 tests; full suite **288/288**.
- ✅ 4 mechanical gates: plandrift clean, testintent clean, depguard clean, acgate all 4 ACs covered by passing tests.
- ✅ A caught bug: the fire-and-forget heartbeat could read-modify-write *after* the final `markSession`, clobbering state back to `alive`. Fixed with a self-chaining heartbeat whose last write is awaited before the authoritative mark (test `AC-C2.2` proves the kill sticks).
- ✅ **Live dogfood with the REAL spawner** (not the fake): enqueued an entry, drove `runOnce` with real `claude` in `plan` mode → outcome `success`, real PID 31484 captured, session `dead`, queue acked, `runner.jsonl` has session-start+end, cost $0.023.

### Verification — NOT done (honest)
- ❌ **Timeout-kill against a real long-running session** — only the injected fake exercises the kill path (real-binary success path is verified; real-binary kill is not). The kill uses `child.kill('SIGTERM')`; on Windows Node maps this to `TerminateProcess`, untested here against a real hung `claude`.
- ❌ **Real `gh` ticket trail** — `defaultTrail` posts `gh issue comment`, but the dogfood used `ticket:null` so no comment was posted; the trail path is only proven via the injected capture in tests.
- ❌ **Resume path** — `buildArgs({resume:true})` is verified + unit-tested, but the runner does not yet resume interrupted sessions (no C2 AC requires it; it's C-series follow-up).
- ❌ **`--loop` continuous mode** — `work` drains once through; a real long-running daemon loop with sleep/backoff is left for C3/C5 (entrypoint currently one-shot).

### Out of scope
Console control tab (C3), situationgate paused read (C4), real ticket end-to-end (C5), trace/quota (C6/C8).
