### PR TITLE
feat(control): C3 console control tab — queue/sessions/audit + verbs (#66)

### DIFF
--- a/console/serve.mjs
+++ b/console/serve.mjs
@@ -16,6 +16,9 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { collectRepo } from './lib/collect.mjs';
 import { resolveReply } from './daemon.mjs';
+import { runControl, readAudit, parseArgs as parseControlArgs, defaultBase as controlDefaultBase } from '../control/control.mjs';
+import * as controlQueue from '../control/lib/queue.mjs';
+import * as controlMachine from '../control/lib/machine.mjs';
 
 const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), 'web');
 export const DEFAULT_PORT = 7433;
@@ -36,7 +39,32 @@ export async function stateOf(config) {
   return { machineId: config.machineId, generatedAt: new Date().toISOString(), repos };
 }
 
+/** Read-only forge-control snapshot for the console control tab (C3). */
+export async function controlStateOf(base) {
+  const [q, s, paused, a] = await Promise.all([
+    controlQueue.list(base),
+    controlMachine.listSessions(base),
+    controlMachine.isPaused(base),
+    readAudit(base, { limit: 50 }),
+  ]);
+  return { base, paused, queue: q.entries, sessions: s.sessions, audit: a.audit };
+}
+
+/** Shape a JSON control request into the args object runControl expects. */
+export function controlArgsFromBody(body) {
+  return {
+    verb: body?.verb ?? null,
+    repo: body?.repo ?? null,
+    ticket: body?.ticket != null ? Number(body.ticket) : null,
+    brief: body?.brief ?? '',
+    id: body?.id ?? null,
+    reason: body?.reason ?? '',
+    by: body?.by ?? 'local-console',
+  };
+}
+
 export function makeApp(config, log = () => {}) {
+  const controlBase = config.controlBase ?? controlDefaultBase();
   return async function handle(req, res) {
     const send = (code, body, type = 'application/json') => {
       res.writeHead(code, { 'Content-Type': type, 'Cache-Control': 'no-store' });
@@ -54,6 +82,20 @@ export function makeApp(config, log = () => {}) {
       }
       if (req.method === 'GET' && path === '/api/state') {
         return send(200, await stateOf(config));
+      }
+      if (req.method === 'GET' && path === '/api/control/state') {
+        return send(200, await controlStateOf(controlBase));
+      }
+      if (req.method === 'POST' && path === '/api/control') {
+        let raw = '';
+        for await (const chunk of req) raw += chunk;
+        let body;
+        try { body = JSON.parse(raw); } catch { return send(400, { error: 'invalid json' }); }
+        const args = controlArgsFromBody(body);
+        const r = await runControl(controlBase, args, log);
+        // an unknown/forbidden verb is a client error (400), not a server fault (500)
+        if (!r.ok && /unknown verb/.test(r.error ?? '')) return send(400, r);
+        return send(r.ok ? 200 : 400, r);
       }
       if (req.method === 'POST' && path === '/api/decide') {
         let raw = '';

--- a/console/web/app.js
+++ b/console/web/app.js
@@ -81,6 +81,36 @@ export function repoCard(r, now = Date.now()) {
   </div>`;
 }
 
+// ---------- forge-control panel (C3) ----------
+
+/** Verbs whose button needs the two-step confirm before it fires. */
+export const CONTROL_DESTRUCTIVE = ['kill-all'];
+/** Verbs offered as one-click buttons in the panel (the safe subset of the allowlist). */
+export const CONTROL_VERBS = ['pause', 'resume', 'kill-all'];
+
+/** Render the control tab from GET /api/control/state. Pure — no DOM, testable. */
+export function controlPanel(state, now = Date.now()) {
+  const s = state ?? {};
+  const rows = (items, fn, empty) => (items && items.length ? items.map(fn).join('') : `<div class="cempty">${empty}</div>`);
+  const queue = rows(s.queue, (e) =>
+    `<div class="crow">#${esc(e.seq)} <b>${esc(e.state)}</b> ${esc(e.repo)}${e.ticket ? ' #' + esc(e.ticket) : ''} <span class="cid">${esc(e.id)}</span></div>`, 'queue empty');
+  const sessions = rows(s.sessions, (x) =>
+    `<div class="crow session ${esc(x.state)}">${esc(x.id)} <b>${esc(x.state)}</b> ${esc(x.repo)}${x.ticket ? ' #' + esc(x.ticket) : ''} pid:${esc(x.pid ?? '—')} · ${esc(relativeTime(x.lastHeartbeat, now))}</div>`, 'no sessions');
+  const audit = rows((s.audit ?? []).slice(0, 12), (a) =>
+    `<div class="crow">${esc(relativeTime(a.ts, now))} · <b>${esc(a.verb)}</b>${a.repo ? ' ' + esc(a.repo) : ''}${a.ticket ? ' #' + esc(a.ticket) : ''} <span class="cby">${esc(a.by ?? '')}</span></div>`, 'no audit yet');
+  const buttons = CONTROL_VERBS.map((v) =>
+    `<button data-verb="${esc(v)}"${CONTROL_DESTRUCTIVE.includes(v) ? ' data-destructive="1"' : ''}>${esc(v)}</button>`).join('');
+  const banner = s.paused ? `<div class="cbanner">⏸ PAUSED — the runner spawns nothing until resumed (human-only clear)</div>` : '';
+  return `<h2>forge-control${s.paused ? ' · paused' : ''}</h2>${banner}
+    <div class="cverbs">${buttons}</div>
+    <div class="cgrid">
+      <div class="ccol"><h3>queue</h3>${queue}</div>
+      <div class="ccol"><h3>sessions</h3>${sessions}</div>
+      <div class="ccol"><h3>audit</h3>${audit}</div>
+    </div>
+    <div class="errline" role="alert"></div>`;
+}
+
 // ---------- DOM wiring (browser only) ----------
 if (typeof document !== 'undefined') {
   const confirm = makeConfirm();
@@ -136,6 +166,46 @@ if (typeof document !== 'undefined') {
     }
   }
 
+  // ----- control panel wiring -----
+  const controlConfirm = makeConfirm();
+
+  async function refreshControl() {
+    try {
+      const cs = await (await fetch('/api/control/state')).json();
+      const el = $('#control');
+      el.innerHTML = controlPanel(cs);
+      el.classList.toggle('paused', !!cs.paused);
+    } catch { /* control base may not exist yet — leave the panel as-is */ }
+  }
+
+  async function runVerb(verb, btn) {
+    const destructive = btn.dataset.destructive === '1';
+    if (destructive && !controlConfirm.arm(verb)) {
+      btn.classList.add('armed');
+      btn.dataset.original = btn.dataset.original ?? btn.textContent;
+      btn.textContent = `confirm ${verb}?`;
+      setTimeout(() => { if (controlConfirm.armedId() !== verb) refreshControl(); }, 6200);
+      return;
+    }
+    const errline = $('#control .errline');
+    try {
+      const res = await fetch('/api/control', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ verb }) });
+      const out = await res.json();
+      if (!res.ok) { if (errline) errline.textContent = `control: ${out.error ?? res.status}`; return; }
+      refreshControl();
+    } catch {
+      if (errline) errline.textContent = 'server unreachable — is the console still running?';
+    }
+  }
+
+  document.addEventListener('click', (ev) => {
+    const btn = ev.target.closest('#control button[data-verb]');
+    if (!btn) return;
+    runVerb(btn.dataset.verb, btn);
+  });
+
   refresh();
+  refreshControl();
   setInterval(refresh, 5000);
+  setInterval(refreshControl, 5000);
 }

--- a/console/web/index.html
+++ b/console/web/index.html
@@ -50,6 +50,24 @@
   .journal div { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   .error { color:var(--alarm); }
   #empty { color:var(--smoke); text-align:center; padding:40px 0; }
+  /* control panel (C3) — the forge-control queue/sessions/audit + kill switch */
+  #control { margin-top:26px; border-top:1px solid var(--seam); padding-top:16px; }
+  #control h2 { font:600 13px Bahnschrift,'Arial Narrow',sans-serif; letter-spacing:.14em; text-transform:uppercase; color:var(--smoke); margin-bottom:10px; }
+  #control.paused h2 { color:var(--alarm); }
+  .cbanner { border:1px dashed var(--alarm); color:var(--alarm); padding:8px 12px; margin-bottom:12px; font-size:12px; }
+  .cverbs { display:flex; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
+  .cverbs button[data-destructive] { border-color:var(--warm); color:var(--warm); }
+  .cverbs button.armed { border-color:var(--alarm); color:var(--alarm); }
+  .cgrid { display:grid; grid-template-columns:1fr 1fr 1fr; gap:14px; }
+  @media (max-width:720px) { .cgrid { grid-template-columns:1fr; } }
+  .ccol h3 { font:600 11px Bahnschrift,sans-serif; letter-spacing:.12em; text-transform:uppercase; color:var(--smoke); margin-bottom:6px; }
+  .crow { font-size:12px; padding:4px 0; border-bottom:1px solid rgba(58,50,42,.5); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .crow b { color:var(--ash); font-weight:normal; }
+  .crow .cid, .crow .cby { color:var(--smoke); }
+  .crow.session.alive b { color:var(--spark); }
+  .crow.session.killed b { color:var(--alarm); }
+  .cempty { color:var(--smoke); font-size:12px; padding:4px 0; }
+  #control .errline { color:var(--alarm); font-size:12px; min-height:1em; margin-top:8px; }
   @media (prefers-reduced-motion: no-preference) { .repo { transition:border-color .25s, background-color .25s; } }
 </style>
 </head>
@@ -57,6 +75,7 @@
 <header><h1>forge<small id="machine"></small></h1><span id="stamp" role="status" aria-live="polite"></span></header>
 <div id="repos"></div>
 <div id="empty" hidden>no repos configured — run: node console/daemon.mjs register</div>
+<section id="control" aria-label="forge-control"></section>
 <script type="module" src="/app.js"></script>
 </body>
 </html>

--- a/control/control.mjs
+++ b/control/control.mjs
@@ -12,7 +12,7 @@
  *   control.mjs pause [--reason "..."] | resume
  *   control.mjs kill --id <session> | kill-all
  */
-import { appendFile, mkdir } from 'node:fs/promises';
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -41,6 +41,22 @@ async function audit(base, verb, args) {
   await mkdir(base, { recursive: true });
   const rec = redact({ ts: new Date().toISOString(), verb, by: args.by, repo: args.repo, ticket: args.ticket, id: args.id });
   await appendFile(join(base, 'audit.jsonl'), JSON.stringify(rec) + '\n', 'utf8');
+}
+
+/**
+ * The last `limit` audit records, newest-first (C3/#66). Records were already
+ * redacted at write time, so this never re-exposes a secret. A missing or
+ * partially-written file yields as many valid records as parse — never throws.
+ */
+export async function readAudit(base, { limit = 50 } = {}) {
+  let raw;
+  try { raw = await readFile(join(base, 'audit.jsonl'), 'utf8'); } catch { return { ok: true, audit: [] }; }
+  const recs = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try { recs.push(JSON.parse(line)); } catch { /* skip half-written tail line */ }
+  }
+  return { ok: true, audit: recs.slice(-limit).reverse() };
 }
 
 /** Dispatch one verb. Returns {ok, ...}; unknown verbs are refused here. */

--- a/tests/console/control-tab.test.mjs
+++ b/tests/console/control-tab.test.mjs
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { request } from 'node:http';
+import { startServer, controlStateOf, controlArgsFromBody } from '../../console/serve.mjs';
+import { readAudit, runControl, parseArgs } from '../../control/control.mjs';
+import * as queue from '../../control/lib/queue.mjs';
+import * as machine from '../../control/lib/machine.mjs';
+import { controlPanel, CONTROL_DESTRUCTIVE, CONTROL_VERBS } from '../../console/web/app.js';
+
+const noop = () => {};
+const servers = [];
+afterAll(() => servers.forEach(({ server }) => server.close()));
+
+// A control base seeded with one queued entry, one alive session, and one audit record.
+async function seededBase() {
+  const base = await mkdtemp(join(tmpdir(), 'forge-ctltab-'));
+  await queue.enqueue(base, { repo: 'dngioidev/forge', ticket: 66, brief: 'do the thing' });
+  await machine.registerSession(base, { id: 's-alpha', ticket: 66, repo: 'dngioidev/forge', pid: 999 });
+  await runControl(base, parseArgs(['enqueue', '--repo', 'dngioidev/forge', '--ticket', '66']), noop); // writes an audit record
+  return base;
+}
+
+async function liveServer(controlBase) {
+  const config = { machineId: 'm-ctl', repos: [], controlBase };
+  const started = await startServer(config, { port: 0 });
+  servers.push(started);
+  return `http://127.0.0.1:${started.port}`;
+}
+
+describe('control tab endpoints (AC-C3.1, AC-C3.2)', () => {
+  it('AC-C3.1: GET /api/control/state returns queue + sessions + paused + audit; Host guard 403', async () => {
+    const base = await seededBase();
+    const url = await liveServer(base);
+    const s = await (await fetch(`${url}/api/control/state`)).json();
+    expect(s.paused).toBe(false);
+    expect(s.queue.length).toBeGreaterThanOrEqual(1);
+    expect(s.sessions[0]).toMatchObject({ id: 's-alpha', state: 'alive', pid: 999 });
+    expect(s.audit[0]).toMatchObject({ verb: 'enqueue', repo: 'dngioidev/forge', ticket: 66 });
+
+    // foreign Host header → 403 (same rebinding guard as the rest of the console)
+    const status = await new Promise((resolve, reject) => {
+      const req = request(`${url}/api/control/state`, { headers: { Host: 'evil.example' } }, (res) => { res.resume(); resolve(res.statusCode); });
+      req.on('error', reject); req.end();
+    });
+    expect(status).toBe(403);
+  });
+
+  it('AC-C3.2: POST /api/control runs an allowlisted verb; unknown verb 400 naming the set; never 500', async () => {
+    const base = await seededBase();
+    const url = await liveServer(base);
+    // pause engages the kill switch and the next state reflects it
+    const pause = await fetch(`${url}/api/control`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ verb: 'pause', reason: 'from console' }) });
+    expect(pause.status).toBe(200);
+    expect((await (await fetch(`${url}/api/control/state`)).json()).paused).toBe(true);
+    // resume clears it
+    await fetch(`${url}/api/control`, { method: 'POST', body: JSON.stringify({ verb: 'resume' }) });
+    expect((await (await fetch(`${url}/api/control/state`)).json()).paused).toBe(false);
+    // an unknown/forbidden verb is a 400 naming the allowed set — NOT a 500
+    const bad = await fetch(`${url}/api/control`, { method: 'POST', body: JSON.stringify({ verb: 'push' }) });
+    expect(bad.status).toBe(400);
+    const body = await bad.json();
+    expect(body.error).toMatch(/unknown verb 'push'/);
+    expect(body.error).toContain('enqueue, dequeue, list, status, pause, resume, kill, kill-all');
+    // malformed json → 400
+    expect((await fetch(`${url}/api/control`, { method: 'POST', body: 'not json' })).status).toBe(400);
+  });
+
+  it('controlArgsFromBody defaults the actor to local-console and coerces ticket', () => {
+    expect(controlArgsFromBody({ verb: 'enqueue', repo: 'r', ticket: '66' })).toMatchObject({ verb: 'enqueue', repo: 'r', ticket: 66, by: 'local-console' });
+  });
+});
+
+describe('readAudit (AC-C3.3)', () => {
+  it('AC-C3.3: newest-first, tolerates missing + partial files, no thrown error', async () => {
+    // missing file → empty, ok
+    const empty = await mkdtemp(join(tmpdir(), 'forge-aud-'));
+    expect(await readAudit(empty)).toEqual({ ok: true, audit: [] });
+
+    const base = await mkdtemp(join(tmpdir(), 'forge-aud-'));
+    const lines = [
+      JSON.stringify({ ts: 't1', verb: 'enqueue' }),
+      JSON.stringify({ ts: 't2', verb: 'pause' }),
+      '{ this is a half-written tail line', // must be skipped, not throw
+    ].join('\n') + '\n';
+    await writeFile(join(base, 'audit.jsonl'), lines, 'utf8');
+    const r = await readAudit(base, { limit: 10 });
+    expect(r.ok).toBe(true);
+    expect(r.audit.map((a) => a.verb)).toEqual(['pause', 'enqueue']); // newest-first, bad line dropped
+    // limit keeps only the newest N
+    expect((await readAudit(base, { limit: 1 })).audit).toHaveLength(1);
+    await rm(base, { recursive: true, force: true });
+  });
+});
+
+describe('controlPanel render (AC-C3.4)', () => {
+  it('AC-C3.4: renders queue/sessions/audit and marks kill-all destructive for the two-step confirm', () => {
+    const html = controlPanel({
+      paused: false,
+      queue: [{ seq: 1, id: 'q-1', state: 'pending', repo: 'dngioidev/forge', ticket: 66 }],
+      sessions: [{ id: 's-alpha', state: 'alive', repo: 'dngioidev/forge', ticket: 66, pid: 999, lastHeartbeat: new Date().toISOString() }],
+      audit: [{ ts: new Date().toISOString(), verb: 'enqueue', repo: 'dngioidev/forge', ticket: 66, by: 'local-console' }],
+    });
+    expect(html).toContain('queue');
+    expect(html).toContain('sessions');
+    expect(html).toContain('audit');
+    expect(html).toContain('s-alpha');
+    // kill-all is the destructive verb → carries the marker the wiring uses to require confirm
+    expect(CONTROL_DESTRUCTIVE).toContain('kill-all');
+    expect(CONTROL_VERBS).toEqual(expect.arrayContaining(['pause', 'resume', 'kill-all']));
+    expect(html).toMatch(/data-verb="kill-all" data-destructive="1"/);
+    expect(html).toMatch(/data-verb="pause"(?! data-destructive)/); // pause is not destructive
+
+    // paused state shows the banner
+    expect(controlPanel({ paused: true, queue: [], sessions: [], audit: [] })).toContain('PAUSED');
+  });
+});


### PR DESCRIPTION
## C3 — console control tab (spec §2)

Closes #66 (board #12). Builds on C1 (#60) + C2 (#62): the local web console (#37) gets a **control** tab so you can watch the forge-control queue/sessions/audit and drive the kill switch from a browser. **No new attack surface** — same 127.0.0.1 bind + Host-header rebinding guard, and every verb goes through `runControl` so the allowlist is enforced in the *same code path* as the CLI. push/merge/edit remain impossible because they aren't in the vocabulary.

### What's here
- **`control/control.mjs`** — `readAudit(base, {limit})`: last N audit records newest-first, tolerant of a missing/partial file, already-redacted.
- **`console/serve.mjs`** — `GET /api/control/state` (`{queue, sessions, paused, audit}` from `config.controlBase ?? defaultBase()`, reusing the C1 libs) and `POST /api/control` (verb through `runControl`; unknown/forbidden → **400 naming the allowed set, never 500**). Host guard applies to both.
- **`console/web/index.html` + `app.js`** — a Control panel: queue / sessions / audit columns with the heat identity, and verb buttons (pause / resume / kill-all) that POST `/api/control`. kill-all reuses the existing two-step confirm.
- **`tests/console/control-tab.test.mjs`** — 5 tests across AC-C3.1..C3.4.

### Verification — done
- ✅ 5/5 C3 tests; full suite **298/298**.
- ✅ 4 gates: plandrift clean (5 touched, all declared), testintent clean, depguard clean, acgate all 4 ACs covered.
- ✅ **Live dogfood over real HTTP** (real server, real control base): GET state returned the seeded queue+session+audit; `pause` → 200 and state flipped `paused:true` with the pause audited; forbidden `merge` → **400** with the allowlist message; `resume` → `paused:false`.

### Verification — NOT done (honest)
- ❌ **Browser render of the panel** — the pure `controlPanel()` HTML is unit-tested and the endpoints are dogfooded, but I did not open it in a real browser (owner post-merge check, same as #37/#39). The heat-identity CSS for the new panel is eyeballed in markup only.
- ❌ **kill / kill-all against real sessions from the button** — the verb POST path is dogfooded (pause/resume) and kill-all's allowlist + confirm are tested, but clicking kill-all to terminate a *live* C2 session end-to-end wasn't exercised (that's C5's job).
- ❌ **enqueue/dequeue from the UI** — the panel ships the kill-switch verbs (pause/resume/kill-all); enqueue/dequeue are reachable via the API but have no buttons yet (deliberate scope: the queue is normally fed by the pipeline, not hand-typed).

### Out of scope
Situationgate paused read (C4), end-to-end ticket dogfood (C5), trace/conformance (C6), alerts (C7), quota (C8).
