### PR TITLE
feat(control): C4 situationgate reads the machine paused flag (#68)

### DIFF
--- a/plugin/scripts/gates/situationgate.mjs
+++ b/plugin/scripts/gates/situationgate.mjs
@@ -16,6 +16,7 @@ const RESPOND_SKILLS = ['respond', 'investigate'];
 const UNLOCK = {
   incident: 'close it first: node plugin/scripts/care/incident.mjs close --ticket <n> --postmortem "<ref>"',
   'security-response': 'containment first; clear with: node plugin/scripts/care/incident.mjs respond-close --postmortem "<ref>"',
+  paused: 'resume the machine: node control/control.mjs resume (or delete ~/.forge/control/paused — human-only clear)',
 };
 
 export function parseArgs(argv) {
@@ -28,8 +29,14 @@ export function parseArgs(argv) {
   return a;
 }
 
-/** Pure rule table: (situationKey, action, {branch, skill}) -> {allowed, why}. */
-export function evaluate(situationKey, action, { branch = '', skill = null } = {}) {
+/** Pure rule table: (situationKey, action, {branch, skill, paused}) -> {allowed, why}. */
+export function evaluate(situationKey, action, { branch = '', skill = null, paused = false } = {}) {
+  // The machine kill switch holds ship/release regardless of the care-situation (#68):
+  // even a hotfix during an incident does not ship while the owner has paused the machine.
+  // It does NOT freeze containment (backend/skill) — paused stops *shipping*, not response.
+  if (paused && (action === 'ship' || action === 'release')) {
+    return { allowed: false, why: `paused: the machine is held — ${action} waits until resumed (spec §2). ${UNLOCK.paused}` };
+  }
   if (situationKey === 'security-response') {
     if (action === 'skill' && RESPOND_SKILLS.includes(skill)) return { allowed: true, why: `${skill} runs during security-response` };
     return {
@@ -48,14 +55,15 @@ export function evaluate(situationKey, action, { branch = '', skill = null } = {
   return { allowed: true, why: `situation '${situationKey}' does not restrict '${action}'` };
 }
 
-export async function runGate(cwd, args, log = console.log) {
+export async function runGate(cwd, args, log = console.log, { controlBase } = {}) {
   if (!['ship', 'release', 'backend', 'skill'].includes(args.action)) {
     return { ok: false, allowed: false, error: '--action must be ship|release|backend|skill' };
   }
-  const s = await deriveSituation(cwd);
-  const verdict = evaluate(s.key, args.action, args);
-  log(`situation-gate [${s.glyph} ${s.key}] ${args.action}${args.branch ? ` (${args.branch})` : ''}${args.skill ? ` (${args.skill})` : ''}: ${verdict.allowed ? 'proceed' : 'REFUSED'} — ${verdict.why}`);
-  return { ok: true, allowed: verdict.allowed, situation: s.key, why: verdict.why };
+  const s = await deriveSituation(cwd, { blocked: 0, inProgress: 0 }, { controlBase });
+  const verdict = evaluate(s.key, args.action, { ...args, paused: s.paused });
+  const tag = s.paused && s.key !== 'paused' ? `${s.glyph} ${s.key}+paused` : `${s.glyph} ${s.key}`;
+  log(`situation-gate [${tag}] ${args.action}${args.branch ? ` (${args.branch})` : ''}${args.skill ? ` (${args.skill})` : ''}: ${verdict.allowed ? 'proceed' : 'REFUSED'} — ${verdict.why}`);
+  return { ok: true, allowed: verdict.allowed, situation: s.key, paused: s.paused, why: verdict.why };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/plugin/scripts/lib/situation.mjs
+++ b/plugin/scripts/lib/situation.mjs
@@ -1,20 +1,34 @@
 import { readdir, readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { read as readJournal } from './journal.mjs';
 
 /**
- * Situation derivation (spec §7): computed from journal + decisions + board,
- * never set by hand. Priority: security-response > incident >
- * awaiting-decision > building > idle. (degraded/paused/migrating/
+ * Situation derivation (spec §7): computed from journal + decisions + board +
+ * the machine kill switch, never set by hand. Priority: security-response >
+ * incident > paused > awaiting-decision > building > idle. (degraded/migrating/
  * maintenance derive from signals that arrive with later sub-projects.)
  */
 export const SITUATIONS = {
   'security-response': { glyph: '🔒', label: 'security-response' },
   incident: { glyph: '🔥', label: 'incident' },
+  paused: { glyph: '⏸', label: 'paused' },
   'awaiting-decision': { glyph: '🚩', label: 'awaiting-decision' },
   building: { glyph: '▶', label: 'building' },
   idle: { glyph: '·', label: 'idle' },
 };
+
+/** Default forge-control base — the same path C1's control plane writes to. */
+export const controlBase = (home = homedir()) => join(home, '.forge', 'control');
+
+/**
+ * The C1 machine kill switch: `<base>/paused` present = engaged (#68). Read
+ * directly, NOT via control/lib — the distributable plugin must not depend on
+ * the inner control project; they share only this file contract.
+ */
+export async function machinePaused(base = controlBase()) {
+  try { await readFile(join(base, 'paused'), 'utf8'); return true; } catch { return false; }
+}
 
 export async function pendingDecisions(cwd) {
   const dir = join(cwd, '.forge', 'decisions');
@@ -44,16 +58,21 @@ function lastOpen(events, openTest, closeTest) {
   return open;
 }
 
-export async function deriveSituation(cwd, board = { blocked: 0, inProgress: 0 }) {
+export async function deriveSituation(cwd, board = { blocked: 0, inProgress: 0 }, opts = {}) {
   const journal = await readJournal(cwd);
   const events = journal.events;
   const pending = await pendingDecisions(cwd);
+  // paused may be injected (tests / callers that already know); else read the flag
+  // (from an injected base if given, e.g. tests — default is the real control base).
+  const paused = opts.paused ?? await machinePaused(opts.controlBase ?? controlBase());
 
   let key = 'idle';
   if (lastOpen(events, (e) => e.kind === 'respond-open', (e) => e.kind === 'respond-close')) {
     key = 'security-response';
   } else if (lastOpen(events, (e) => e.kind === 'incident' && e.phase !== 'closed', (e) => e.kind === 'incident' && e.phase === 'closed')) {
     key = 'incident';
+  } else if (paused) {
+    key = 'paused';
   } else if (pending.length > 0 || board.blocked > 0) {
     key = 'awaiting-decision';
   } else if (board.inProgress > 0) {
@@ -61,5 +80,7 @@ export async function deriveSituation(cwd, board = { blocked: 0, inProgress: 0 }
   }
   // decision files and blocked board items usually describe the same tickets — report the larger set
   const pendingCount = Math.max(pending.length, board.blocked ?? 0);
-  return { key, ...SITUATIONS[key], pendingCount, pending };
+  // `paused` is reported independent of `key` so a higher care-situation can win the
+  // display while the gate still sees the machine is held.
+  return { key, ...SITUATIONS[key], pendingCount, pending, paused };
 }

--- a/tests/gates/situationgate-paused.test.mjs
+++ b/tests/gates/situationgate-paused.test.mjs
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { machinePaused, deriveSituation } from '../../plugin/scripts/lib/situation.mjs';
+import { evaluate, runGate } from '../../plugin/scripts/gates/situationgate.mjs';
+
+const noop = () => {};
+const tmp = () => mkdtemp(join(tmpdir(), 'forge-c4-'));
+async function pausedBase() {
+  const b = await tmp();
+  await writeFile(join(b, 'paused'), JSON.stringify({ by: 'owner', reason: 'test' }), 'utf8');
+  return b;
+}
+async function incidentCwd() {
+  const cwd = await tmp();
+  await mkdir(join(cwd, '.forge'), { recursive: true });
+  await writeFile(join(cwd, '.forge', 'journal.jsonl'), JSON.stringify({ ts: 't1', kind: 'incident', phase: 'open', ticket: '#1' }) + '\n', 'utf8');
+  return cwd;
+}
+
+describe('machinePaused (AC-C4.1)', () => {
+  it('AC-C4.1: true when <base>/paused exists, false when absent — reads the file directly', async () => {
+    expect(await machinePaused(await tmp())).toBe(false);
+    expect(await machinePaused(await pausedBase())).toBe(true);
+    expect(await machinePaused('Z:/definitely/missing')).toBe(false);
+  });
+});
+
+describe('deriveSituation + paused (AC-C4.2)', () => {
+  it('AC-C4.2: paused becomes the key when nothing higher is active', async () => {
+    const s = await deriveSituation(await tmp(), { blocked: 0, inProgress: 1 }, { paused: true });
+    expect(s.key).toBe('paused');
+    expect(s.glyph).toBe('⏸');
+    expect(s.paused).toBe(true);
+  });
+
+  it('AC-C4.2: a higher care-situation wins key, but paused is still reported', async () => {
+    const cwd = await incidentCwd();
+    const s = await deriveSituation(cwd, { blocked: 0, inProgress: 0 }, { paused: true });
+    expect(s.key).toBe('incident'); // incident outranks paused for the display
+    expect(s.paused).toBe(true);    // ...but the gate still learns the machine is held
+  });
+
+  it('AC-C4.2: not paused → prior behavior unchanged (building/idle)', async () => {
+    expect((await deriveSituation(await tmp(), { blocked: 0, inProgress: 2 }, { paused: false })).key).toBe('building');
+    expect((await deriveSituation(await tmp(), { blocked: 0, inProgress: 0 }, { paused: false })).key).toBe('idle');
+  });
+});
+
+describe('evaluate under paused (AC-C4.3)', () => {
+  it('AC-C4.3: refuses ship AND release for any situation key, naming the resume unlock', () => {
+    for (const key of ['idle', 'building', 'incident', 'awaiting-decision']) {
+      for (const action of ['ship', 'release']) {
+        const v = evaluate(key, action, { paused: true, branch: 'hotfix/1-x' });
+        expect(v.allowed).toBe(false);
+        expect(v.why).toMatch(/paused/);
+        expect(v.why).toMatch(/resume/);
+      }
+    }
+    // even a hotfix branch (the incident lane) does not ship while paused
+    expect(evaluate('incident', 'ship', { paused: true, branch: 'hotfix/1-x' }).allowed).toBe(false);
+  });
+
+  it('AC-C4.3: paused does NOT freeze backend/skill; respond during security-response still proceeds', () => {
+    expect(evaluate('idle', 'backend', { paused: true }).allowed).toBe(true);
+    expect(evaluate('security-response', 'skill', { paused: true, skill: 'respond' }).allowed).toBe(true);
+    expect(evaluate('security-response', 'skill', { paused: true, skill: 'investigate' }).allowed).toBe(true);
+  });
+
+  it('not paused → the existing situation rules are untouched', () => {
+    expect(evaluate('idle', 'ship', { paused: false, branch: 'feat/1-x' }).allowed).toBe(true);
+    expect(evaluate('incident', 'ship', { paused: false, branch: 'hotfix/1-x' }).allowed).toBe(true); // hotfix lane still open
+    expect(evaluate('incident', 'release', { paused: false }).allowed).toBe(false); // incident still pauses releases
+  });
+});
+
+describe('runGate wires the real flag (AC-C4.4)', () => {
+  it('AC-C4.4: ship/release refused under a paused machine; clearing lets it proceed', async () => {
+    const cwd = await tmp();
+    const base = await pausedBase();
+    const refused = await runGate(cwd, { action: 'ship', branch: 'feat/1-x' }, noop, { controlBase: base });
+    expect(refused.allowed).toBe(false);
+    expect(refused.paused).toBe(true);
+    const rel = await runGate(cwd, { action: 'release' }, noop, { controlBase: base });
+    expect(rel.allowed).toBe(false);
+    // an unpaused base → the same ship proceeds
+    const clear = await runGate(cwd, { action: 'ship', branch: 'feat/1-x' }, noop, { controlBase: await tmp() });
+    expect(clear.allowed).toBe(true);
+    expect(clear.paused).toBe(false);
+  });
+});


### PR DESCRIPTION
## C4 — situationgate reads the machine paused flag (spec §2/§7)

Closes #68 (board #12). The C1 kill switch (`~/.forge/control/paused`) previously only stopped the daemon from spawning (C2 `runOnce` skips when paused). C4 makes it bind the **manual** path too: the situationgate now refuses ship/release while paused, and `deriveSituation` surfaces a `paused` situation for the statusline/console.

### What's here
- **`plugin/scripts/lib/situation.mjs`** — new `paused` situation (⏸); `machinePaused(base)` reads the shared `<base>/paused` file **directly** (default `~/.forge/control`), so the distributable plugin never imports the inner control project — they share only the file contract. `deriveSituation` priority is now `security-response > incident > paused > awaiting-decision > building > idle`, and it returns a `paused` boolean alongside `key` so a higher care-situation can win the display while the gate still sees the machine is held.
- **`plugin/scripts/gates/situationgate.mjs`** — `evaluate(..., {paused})` short-circuits: `paused` + (`ship`|`release`) → refused for **any** situation key (even a hotfix during an incident), naming the resume unlock. It does NOT freeze `backend`/`skill` — paused holds *shipping*, not containment. `runGate` threads the real flag through (`controlBase` injectable for tests).

### Verification — done
- ✅ 8/8 C4 tests (AC-C4.1..C4.4); full suite **306/306** (see flake note).
- ✅ 4 gates: plandrift clean, testintent clean, depguard clean, acgate all 4 ACs covered.
- ✅ **Live dogfood against the real kill switch**: `control.mjs pause` → `situationgate --action ship` REFUSED (exit 1, `[⏸ paused]` + resume unlock) → `--action release` REFUSED → `control.mjs resume` → `ship` proceeds (exit 0, `[· idle]`). Cleanup verified: no paused file left behind.

### Verification — NOT done / caveats (honest)
- ⚠️ **One-time full-suite flake**: an initial full-suite run showed 1 failure that did not reproduce (306/306 on re-run, and my touched files passed 38/38 across 3 isolated runs). The flake is not in situation/gate code — it's a pre-existing timing/port-sensitive test under parallel load. Worth a separate look someday; not introduced here.
- ❌ **Statusline/console rendering of the ⏸ paused situation** — `deriveSituation` returns it and `status.mjs`/console consume `deriveSituation`, but I did not eyeball the ⏸ glyph in a live status line or the console card (the derivation + priority are unit-tested; the pixel is not).

### Out of scope
End-to-end ticket dogfood (C5), trace/conformance (C6), alerts (C7), quota (C8).
