### PR TITLE
feat(control): C6 agent-work trace + conformance badge (#74)

### DIFF
--- a/console/lib/collect.mjs
+++ b/console/lib/collect.mjs
@@ -6,11 +6,12 @@
  * before any transport sees it.
  */
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { deriveSituation, pendingDecisions } from '../../plugin/scripts/lib/situation.mjs';
 import { read as readJournal } from '../../plugin/scripts/lib/journal.mjs';
 import { parseLedger, LEDGER_RELPATH } from '../../plugin/scripts/lib/ledger.mjs';
 import { parseBranch } from '../../plugin/scripts/lib/ticket.mjs';
+import { buildTrace, conformance, ledgerPlanRef, extractPlanFiles } from '../../plugin/scripts/lib/trace.mjs';
 
 export async function currentBranch(cwd) {
   try {
@@ -35,13 +36,36 @@ export async function ledgerCounts(cwd) {
 
 const AGE_MS_HOUR = 3_600_000;
 
+/**
+ * git diff of the branch vs base, as a name list. Local (not network) but a
+ * subprocess — so it's injectable and degrades to [] when git is absent, keeping
+ * the collector offline-safe. The console omits the trail phases check (§3b), so
+ * no gh is needed here either.
+ */
+async function defaultDiff(cwd, base = 'main') {
+  try {
+    const { run } = await import('../../plugin/scripts/lib/exec.mjs');
+    const r = await run('git', ['-C', cwd, 'diff', '--name-only', `${base}...HEAD`]);
+    return r.ok ? r.stdout.split(/\r?\n/).filter(Boolean) : [];
+  } catch { return []; }
+}
+
 /** One repo's snapshot. `now` injected — the daemon stamps once per cycle. */
-export async function collectRepo(cwd, now = Date.now()) {
+export async function collectRepo(cwd, now = Date.now(), { diff = defaultDiff } = {}) {
   const branch = await currentBranch(cwd);
   const parsed = parseBranch(branch ?? '');
   const situation = await deriveSituation(cwd);
   const pending = await pendingDecisions(cwd);
   const journal = await readJournal(cwd);
+
+  // §3a/§3b (C6): trace timeline + conformance badge from files already written.
+  const ledgerText = (await readFile(join(cwd, LEDGER_RELPATH), 'utf8').catch(() => '')) || '';
+  const ledgerTasks = parseLedger(ledgerText);
+  const planRef = ledgerPlanRef(ledgerText);
+  const planText = planRef ? await readFile(resolve(cwd, planRef), 'utf8').catch(() => null) : null;
+  const touched = await diff(cwd, 'main').catch(() => []);
+  const trace = buildTrace({ branch: branch ?? '', ledgerTasks, ledgerPlan: planRef, touchedFiles: touched, journalEvents: journal.events });
+  const badge = conformance({ branch: branch ?? '', ledgerText, planExists: planText != null, touchedFiles: touched, planFiles: extractPlanFiles(planText ?? ''), phasesSeen: null });
 
   return {
     repo: cwd.split(/[\\/]/).filter(Boolean).pop() ?? 'unknown',
@@ -51,6 +75,8 @@ export async function collectRepo(cwd, now = Date.now()) {
     ticket: parsed.ticket ? `#${parsed.ticket}` : null,
     branchKind: parsed.kind,
     ledger: await ledgerCounts(cwd),
+    trace: { steps: trace.steps, current: trace.current },
+    conformance: { level: badge.level, failing: badge.failing, checks: badge.checks },
     pendingDecisions: pending.map((d) => ({
       id: d.id,
       issue: d.issue,

--- a/console/web/app.js
+++ b/console/web/app.js
@@ -72,11 +72,18 @@ export function repoCard(r, now = Date.now()) {
     </div>`).join('');
   const journal = (r.journalTail ?? []).slice(-5).reverse().map((e) =>
     `<div title="${esc(e.ts ?? '')}">${esc(relativeTime(e.ts, now))} · ${esc(e.kind)}${e.gate ? ' (' + esc(e.gate) + ')' : ''}${e.ticket ? ' ' + esc(e.ticket) : ''}</div>`).join('');
+  // §3b conformance badge (C6): green = inside the lines, amber names the drift.
+  const cf = r.conformance;
+  const badge = cf ? `<span class="badge ${esc(cf.level)}" title="${esc((cf.checks ?? []).map((c) => `${c.pass ? '✓' : '✗'} ${c.name}: ${c.why}`).join('\n'))}">${cf.level === 'green' ? '🟢 conforms' : '🟡 ' + esc(cf.failing ?? 'drift')}</span>` : '';
+  // §3a trace phase strip (C6): the current step is lit.
+  const t = r.trace;
+  const strip = t && t.steps ? `<div class="trace" role="img" aria-label="work trace">${t.steps.map((s, i) =>
+    `${i ? '<span class="tsep">›</span>' : ''}<span class="tstep ${esc(s.state)}${s.key === t.current ? ' cur' : ''}" title="${esc(s.label)}">${esc(s.key)}</span>`).join('')}</div>` : '';
   return `<div class="repo ${esc(r.situation ?? '')}">
     <div class="repo-head"><span class="glyph">${esc(r.glyph ?? '·')}</span><span class="name">${esc(r.repo)}</span>
-      <span class="situation ${esc(r.situation)}">${esc(r.situation)}</span></div>
+      <span class="situation ${esc(r.situation)}">${esc(r.situation)}</span>${badge}</div>
     <div class="meta">${r.ticket ? `<b>${esc(r.ticket)}</b> · ` : ''}${esc(r.branch ?? 'no branch')}${l && l.total ? ` · tasks ${l.done}/${l.total}` : ''}</div>
-    ${ledger}${decisions}
+    ${strip}${ledger}${decisions}
     ${journal ? `<div class="journal">${journal}</div>` : ''}
   </div>`;
 }

--- a/console/web/index.html
+++ b/console/web/index.html
@@ -46,6 +46,17 @@
   .free { display:flex; gap:6px; margin-top:8px; }
   .free input { flex:1; background:var(--iron); color:var(--ash); border:1px solid var(--seam); padding:6px 10px; font:inherit; }
   .errline { color:var(--alarm); font-size:12px; margin-top:6px; min-height:1em; }
+  /* §3b conformance badge + §3a trace strip (C6) */
+  .badge { margin-left:auto; font-size:11px; letter-spacing:.06em; padding:2px 8px; border:1px solid var(--seam); border-radius:2px; white-space:nowrap; cursor:help; }
+  .badge.green { color:#7fbf7f; border-color:#3d5a3d; }
+  .badge.amber { color:var(--spark); border-color:var(--warm); }
+  .trace { margin-top:10px; font-size:11px; letter-spacing:.05em; color:var(--smoke); display:flex; flex-wrap:wrap; align-items:center; gap:2px; }
+  .trace .tstep { text-transform:uppercase; }
+  .trace .tstep.done { color:var(--ash); }
+  .trace .tstep.active { color:var(--spark); }
+  .trace .tstep.missing { color:var(--alarm); }
+  .trace .tstep.cur { text-decoration:underline; text-underline-offset:3px; }
+  .trace .tsep { color:var(--seam); margin:0 4px; }
   .journal { margin-top:12px; color:var(--smoke); font-size:12px; border-top:1px solid var(--seam); padding-top:8px; }
   .journal div { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   .error { color:var(--alarm); }

--- a/plugin/scripts/lib/trace.mjs
+++ b/plugin/scripts/lib/trace.mjs
@@ -1,0 +1,108 @@
+/**
+ * Agent-work trace + structure conformance (C6/#74; spec §3a/§3b). Pure
+ * functions over state the pipeline ALREADY writes — journal, ledger, plan,
+ * branch, git diff, PR. No new capture; every external read (git diff, file
+ * existence) is injected by the caller so this stays offline-safe and testable.
+ *
+ * §3a buildTrace  → an ordered timeline: "where did the agent go".
+ * §3b conformance → a green/amber badge: "does it match the forge structure".
+ */
+import { parseBranch } from './ticket.mjs';
+import { isAllowed, DEFAULT_ALLOW, extractPlanFiles } from '../gates/plandrift.mjs';
+
+/** The ledger header records `Plan: <path>` (ledger.mjs initLedger). */
+export function ledgerPlanRef(ledgerText) {
+  const m = /^Plan:\s*(.+)$/m.exec(ledgerText ?? '');
+  return m ? m[1].trim() : null;
+}
+
+/** Canonical pipeline phase order — used to light the current step + check ordering. */
+export const PHASE_ORDER = ['started', 'plan', 'tests', 'implement', 'gates', 'pr', 'ci-green', 'done'];
+
+/**
+ * §3a — reconstruct the ordered timeline from injected pipeline state.
+ *   { branch, ledgerTasks[], ledgerPlan, touchedFiles[], journalEvents[], prNumber }
+ * Returns { ticket, branch, branchKind, steps[], current, touched } where steps
+ * is the ordered "phase strip" and `current` is the active step's key.
+ */
+export function buildTrace({ branch = '', ledgerTasks = [], ledgerPlan = null, touchedFiles = [], journalEvents = [], prNumber = null } = {}) {
+  const parsed = parseBranch(branch || '');
+  const done = ledgerTasks.filter((t) => t.status === 'done').length;
+  const active = ledgerTasks.find((t) => t.status === 'in-progress') ?? null;
+  const total = ledgerTasks.length;
+
+  const steps = [
+    { key: 'plan', label: ledgerPlan ? ledgerPlan.split(/[\\/]/).pop() : 'no plan', state: ledgerPlan ? 'done' : 'missing' },
+    { key: 'tasks', label: total ? `${done}/${total} tasks${active ? ` · ${active.id}` : ''}` : 'no ledger', state: !total ? 'missing' : done === total ? 'done' : active ? 'active' : 'pending' },
+    { key: 'files', label: `${touchedFiles.length} file${touchedFiles.length === 1 ? '' : 's'}`, state: touchedFiles.length ? 'active' : 'pending' },
+    { key: 'pr', label: prNumber ? `#${prNumber}` : '—', state: prNumber ? 'done' : 'pending' },
+  ];
+  // the current step = the first non-done / non-missing step, else 'pr'
+  const current = (steps.find((s) => s.state === 'active') ?? steps.find((s) => s.state === 'pending') ?? steps[steps.length - 1]).key;
+
+  return {
+    ticket: parsed.ticket ? `#${parsed.ticket}` : null,
+    branch: branch || null,
+    branchKind: parsed.kind,
+    steps,
+    current,
+    touched: touchedFiles,
+    // the raw event stream, newest last — the literal "where it went"
+    events: (journalEvents ?? []).map((e) => ({ ts: e.ts ?? null, kind: e.kind, gate: e.gate ?? null, ticket: e.ticket ?? null })),
+  };
+}
+
+/** phasesSeen is a subsequence of PHASE_ORDER (no phase appears before an earlier one). */
+export function phasesInOrder(phasesSeen) {
+  let i = 0;
+  for (const p of phasesSeen ?? []) {
+    const at = PHASE_ORDER.indexOf(p, i);
+    if (at === -1) return false; // unknown phase or out of order
+    i = at;
+  }
+  return (phasesSeen ?? []).includes('started');
+}
+
+/**
+ * §3b — the conformance badge. All external facts injected:
+ *   { branch, ledgerText, planExists, touchedFiles[], planFiles[], phasesSeen[]|null }
+ * `phasesSeen: null` (default) OMITS the phases-in-order check — the trail lives on
+ * GitHub, so the offline console skips it while the CLI (with gh) supplies the real
+ * sequence. Returns { level: 'green'|'amber', checks: [{name, pass, why}], failing }.
+ */
+export function conformance({ branch = '', ledgerText = '', planExists = false, touchedFiles = [], planFiles = [], phasesSeen = null } = {}) {
+  const parsed = parseBranch(branch || '');
+  const planRef = ledgerPlanRef(ledgerText);
+  const validBranch = parsed.kind === 'work' || parsed.kind === 'hotfix';
+  const deviations = (touchedFiles ?? []).filter((f) => !isAllowed(f, planFiles, [], DEFAULT_ALLOW));
+
+  const checks = [
+    {
+      name: 'valid-branch',
+      pass: validBranch,
+      why: validBranch ? `on ${parsed.type}/${parsed.ticket ?? '?'}` : `branch '${branch || '?'}' is not a forge work/hotfix branch (kind: ${parsed.kind})`,
+    },
+    {
+      name: 'ledger-plan',
+      pass: !!planRef && planExists,
+      why: !planRef ? 'ledger has no Plan: reference' : !planExists ? `ledger Plan '${planRef}' is not a committed file` : `ledger → ${planRef}`,
+    },
+    {
+      name: 'files-in-scope',
+      pass: deviations.length === 0,
+      why: deviations.length === 0 ? `${(touchedFiles ?? []).length} touched, all in plan/allowed` : `off-plan: ${deviations.join(', ')}`,
+    },
+  ];
+  if (phasesSeen != null) {
+    checks.push({
+      name: 'phases-in-order',
+      pass: phasesInOrder(phasesSeen),
+      why: phasesInOrder(phasesSeen) ? `phases: ${phasesSeen.join(' → ')}` : `phases missing 'started' or out of order: ${phasesSeen.join(' → ') || 'none'}`,
+    });
+  }
+
+  const failing = checks.find((c) => !c.pass) ?? null;
+  return { level: failing ? 'amber' : 'green', checks, failing: failing?.name ?? null };
+}
+
+export { extractPlanFiles };

--- a/plugin/scripts/trace.mjs
+++ b/plugin/scripts/trace.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * forge trace CLI (C6/#74; spec §3a/§3b). Prints the agent-work timeline + the
+ * structure-conformance badge for the current repo, from files the pipeline
+ * already writes. An informal "am I inside the lines" check to run BEFORE ship
+ * (exit 0 = green/conforming, 1 = amber/drifting). Not a merge gate — the
+ * mechanical gates at ship remain the enforcement.
+ */
+import { readFile } from 'node:fs/promises';
+import { resolve, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run } from './lib/exec.mjs';
+import { read as readJournal } from './lib/journal.mjs';
+import { parseLedger, LEDGER_RELPATH } from './lib/ledger.mjs';
+import { parseBranch } from './lib/ticket.mjs';
+import { buildTrace, conformance, ledgerPlanRef, extractPlanFiles } from './lib/trace.mjs';
+
+async function readMaybe(path) { try { return await readFile(path, 'utf8'); } catch { return null; } }
+
+/** Best-effort trail phases from the ticket's gh comments (skipped if gh/ticket absent). */
+async function trailPhases(ticket, execFn) {
+  if (!ticket) return null;
+  const r = await execFn('gh', ['issue', 'view', String(ticket), '--json', 'comments', '-q', '.comments[].body']);
+  if (!r.ok) return null;
+  const known = ['started', 'plan', 'tests', 'implement', 'gates', 'pr', 'ci-green', 'done'];
+  const seen = [];
+  for (const line of r.stdout.split('\n')) {
+    const m = /\*\*([a-z-]+)\*\*/.exec(line); // trail lines lead with **<phase>**
+    if (m && known.includes(m[1]) && seen[seen.length - 1] !== m[1]) seen.push(m[1]);
+  }
+  return seen.length ? seen : null;
+}
+
+export async function runTrace(cwd, { execFn = run, base = 'main', online = true } = {}, log = console.log) {
+  const branch = (await execFn('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'])).stdout?.trim() || '';
+  const parsed = parseBranch(branch);
+
+  const ledgerText = (await readMaybe(join(cwd, LEDGER_RELPATH))) ?? '';
+  const ledgerTasks = parseLedger(ledgerText);
+  const planRef = ledgerPlanRef(ledgerText);
+  const planText = planRef ? await readMaybe(resolve(cwd, planRef)) : null;
+  const planFiles = extractPlanFiles(planText ?? '');
+
+  const diff = await execFn('git', ['-C', cwd, 'diff', '--name-only', `${base}...HEAD`]);
+  const touchedFiles = diff.ok ? diff.stdout.split(/\r?\n/).filter(Boolean) : [];
+
+  const journal = await readJournal(cwd);
+  const prMatch = /\bpr[-\s]?#?(\d+)/i.exec(ledgerText) ?? null; // best-effort PR from ledger notes
+  const trace = buildTrace({ branch, ledgerTasks, ledgerPlan: planRef, touchedFiles, journalEvents: journal.events, prNumber: prMatch ? Number(prMatch[1]) : null });
+
+  const phasesSeen = online ? await trailPhases(parsed.ticket, execFn) : null;
+  const badge = conformance({ branch, ledgerText, planExists: planText != null, touchedFiles, planFiles, phasesSeen });
+
+  // ---- render ----
+  const glyph = badge.level === 'green' ? '🟢' : '🟡';
+  log(`trace ${trace.ticket ?? '(no ticket)'} — ${branch || '(no branch)'}`);
+  log(`  ${trace.steps.map((s) => `${s.state === 'done' ? '●' : s.state === 'active' ? '◐' : s.state === 'missing' ? '○!' : '○'} ${s.key}:${s.label}`).join('   ')}`);
+  log(`  ${glyph} conformance: ${badge.level}${badge.failing ? ` (${badge.failing})` : ''}`);
+  for (const c of badge.checks) log(`    ${c.pass ? '✓' : '✗'} ${c.name} — ${c.why}`);
+
+  return { ok: true, trace, badge, conforming: badge.level === 'green' };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const online = !process.argv.includes('--offline');
+  runTrace(process.cwd(), { online }).then((r) => process.exit(r.conforming ? 0 : 1));
+}

--- a/tests/console/trace-card.test.mjs
+++ b/tests/console/trace-card.test.mjs
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectRepo } from '../../console/lib/collect.mjs';
+import { repoCard } from '../../console/web/app.js';
+
+async function repoDir({ plan = true, offPlan = false } = {}) {
+  const cwd = await mkdtemp(join(tmpdir(), 'forge-tc-'));
+  await mkdir(join(cwd, '.git'), { recursive: true });
+  await writeFile(join(cwd, '.git', 'HEAD'), 'ref: refs/heads/feat/74-trace-conformance\n', 'utf8');
+  await mkdir(join(cwd, '.forge'), { recursive: true });
+  await mkdir(join(cwd, 'docs', 'plans'), { recursive: true });
+  await writeFile(join(cwd, 'docs', 'plans', 'p.md'), '**Files:** plugin/scripts/lib/trace.mjs\n', 'utf8');
+  const planLine = plan ? 'Plan: docs/plans/p.md\n' : '';
+  await writeFile(join(cwd, '.forge', 'progress.md'), `# ledger — #74\n\n${planLine}\n- [x] T1 — a\n- [~] T2 — b\n`, 'utf8');
+  await writeFile(join(cwd, '.forge', 'journal.jsonl'), '', 'utf8');
+  const diff = async () => (offPlan ? ['src/rogue.mjs'] : ['plugin/scripts/lib/trace.mjs']);
+  return { cwd, diff };
+}
+
+describe('collectRepo attaches trace + conformance (AC-C6.4)', () => {
+  it('AC-C6.4: green when the branch/plan/files conform', async () => {
+    const { cwd, diff } = await repoDir();
+    const snap = await collectRepo(cwd, Date.now(), { diff });
+    expect(snap.trace.steps.map((s) => s.key)).toEqual(['plan', 'tasks', 'files', 'pr']);
+    expect(snap.trace.current).toBe('tasks'); // T2 in-progress
+    expect(snap.conformance.level).toBe('green');
+    // offline console omits the trail phases check
+    expect(snap.conformance.checks.map((c) => c.name)).not.toContain('phases-in-order');
+  });
+
+  it('AC-C6.4: amber names the drift (off-plan file, or missing plan)', async () => {
+    const off = await collectRepo((await repoDir({ offPlan: true })).cwd, Date.now(), { diff: async () => ['src/rogue.mjs'] });
+    expect(off.conformance.level).toBe('amber');
+    expect(off.conformance.failing).toBe('files-in-scope');
+
+    const noPlan = await repoDir({ plan: false });
+    const snap = await collectRepo(noPlan.cwd, Date.now(), { diff: noPlan.diff });
+    expect(snap.conformance.failing).toBe('ledger-plan');
+  });
+
+  it('AC-C6.4: degrades gracefully when git diff is unavailable (throws → [] touched)', async () => {
+    const { cwd } = await repoDir();
+    const snap = await collectRepo(cwd, Date.now(), { diff: async () => { throw new Error('no git'); } });
+    expect(snap.trace.steps.find((s) => s.key === 'files').label).toBe('0 files');
+    expect(snap.conformance.level).toBe('green'); // no touched files → nothing off-plan
+  });
+});
+
+describe('repoCard renders the strip + badge (AC-C6.4)', () => {
+  it('AC-C6.4: phase strip lights the current step; badge shows level', () => {
+    const html = repoCard({
+      repo: 'forge', situation: 'building', glyph: '▶', branch: 'feat/74-x', ticket: '#74',
+      trace: { steps: [{ key: 'plan', label: 'p.md', state: 'done' }, { key: 'tasks', label: '1/2', state: 'active' }, { key: 'files', label: '3 files', state: 'active' }, { key: 'pr', label: '—', state: 'pending' }], current: 'tasks' },
+      conformance: { level: 'green', failing: null, checks: [{ name: 'valid-branch', pass: true, why: 'on feat/74' }] },
+    });
+    expect(html).toContain('class="trace"');
+    expect(html).toMatch(/tstep active cur"[^>]*>tasks/); // current step lit
+    expect(html).toContain('🟢 conforms');
+
+    const amber = repoCard({ repo: 'x', situation: 'building', trace: { steps: [], current: 'plan' }, conformance: { level: 'amber', failing: 'files-in-scope', checks: [] } });
+    expect(amber).toContain('🟡 files-in-scope');
+  });
+});

--- a/tests/lib/trace.test.mjs
+++ b/tests/lib/trace.test.mjs
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildTrace, conformance, phasesInOrder, ledgerPlanRef } from '../../plugin/scripts/lib/trace.mjs';
+import { runTrace } from '../../plugin/scripts/trace.mjs';
+
+const noop = () => {};
+
+describe('buildTrace (AC-C6.1)', () => {
+  it('AC-C6.1: ordered plan→tasks→files→pr with the current step marked', () => {
+    const t = buildTrace({
+      branch: 'feat/74-trace-conformance',
+      ledgerPlan: 'docs/plans/2026-07-19-c6-trace-conformance.md',
+      ledgerTasks: [{ id: 'T1', status: 'done' }, { id: 'T2', status: 'in-progress' }, { id: 'T3', status: 'pending' }],
+      touchedFiles: ['plugin/scripts/lib/trace.mjs', 'tests/lib/trace.test.mjs'],
+      journalEvents: [{ ts: 't1', kind: 'gate-fail', gate: 'plandrift' }],
+      prNumber: null,
+    });
+    expect(t.ticket).toBe('#74');
+    expect(t.steps.map((s) => s.key)).toEqual(['plan', 'tasks', 'files', 'pr']);
+    expect(t.steps[0]).toMatchObject({ key: 'plan', state: 'done' });
+    expect(t.steps[1]).toMatchObject({ state: 'active' });      // an in-progress task
+    expect(t.steps[1].label).toContain('T2');
+    expect(t.steps[3]).toMatchObject({ key: 'pr', state: 'pending' });
+    expect(t.current).toBe('tasks');                            // first active step is lit
+    expect(t.events).toHaveLength(1);
+  });
+
+  it('AC-C6.1: empty/partial inputs degrade, never throw', () => {
+    const t = buildTrace({});
+    expect(t.steps.find((s) => s.key === 'plan').state).toBe('missing');
+    expect(t.steps.find((s) => s.key === 'tasks').state).toBe('missing');
+    expect(t.branchKind).toBe('unknown');
+    expect(() => buildTrace()).not.toThrow();
+  });
+});
+
+describe('phasesInOrder + ledgerPlanRef', () => {
+  it('a subsequence of the canonical order with started is in order; gaps ok, reversals not', () => {
+    expect(phasesInOrder(['started', 'plan', 'pr', 'ci-green'])).toBe(true);
+    expect(phasesInOrder(['started', 'pr', 'plan'])).toBe(false); // plan after pr — reversed
+    expect(phasesInOrder(['plan', 'pr'])).toBe(false);            // missing 'started'
+    expect(phasesInOrder([])).toBe(false);
+  });
+  it('extracts the ledger Plan: reference', () => {
+    expect(ledgerPlanRef('# forge execute ledger — #74\n\nPlan: docs/plans/x.md\n')).toBe('docs/plans/x.md');
+    expect(ledgerPlanRef('no plan here')).toBe(null);
+  });
+});
+
+describe('conformance (AC-C6.2)', () => {
+  const green = {
+    branch: 'feat/74-x',
+    ledgerText: 'Plan: docs/plans/p.md',
+    planExists: true,
+    touchedFiles: ['plugin/scripts/lib/trace.mjs', 'tests/lib/trace.test.mjs', 'docs/plans/p.md'],
+    planFiles: ['plugin/scripts/lib/trace.mjs'],
+  };
+
+  it('AC-C6.2: all checks pass → green (phases omitted when phasesSeen null)', () => {
+    const c = conformance(green);
+    expect(c.level).toBe('green');
+    expect(c.failing).toBe(null);
+    expect(c.checks.map((x) => x.name)).toEqual(['valid-branch', 'ledger-plan', 'files-in-scope']); // no phases check offline
+  });
+
+  it('AC-C6.2: each check fails independently, amber names the first failing', () => {
+    expect(conformance({ ...green, branch: 'random-branch' }).failing).toBe('valid-branch');
+    expect(conformance({ ...green, planExists: false }).failing).toBe('ledger-plan');
+    expect(conformance({ ...green, ledgerText: 'no plan line' }).failing).toBe('ledger-plan');
+    const drift = conformance({ ...green, touchedFiles: ['src/secret.mjs'] });
+    expect(drift.failing).toBe('files-in-scope');
+    expect(drift.checks.find((x) => x.name === 'files-in-scope').why).toContain('off-plan');
+  });
+
+  it('AC-C6.2: phases check is included only when phasesSeen is supplied (CLI path)', () => {
+    const withPhases = conformance({ ...green, phasesSeen: ['started', 'plan', 'pr'] });
+    expect(withPhases.checks.map((x) => x.name)).toContain('phases-in-order');
+    expect(withPhases.level).toBe('green');
+    expect(conformance({ ...green, phasesSeen: ['pr', 'started'] }).failing).toBe('phases-in-order');
+  });
+});
+
+describe('trace CLI (AC-C6.3)', () => {
+  async function repo(conforming) {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-trace-'));
+    await mkdir(join(cwd, '.forge'), { recursive: true });
+    await mkdir(join(cwd, 'docs', 'plans'), { recursive: true });
+    await writeFile(join(cwd, 'docs', 'plans', 'p.md'), '**Files:** plugin/scripts/lib/trace.mjs\n', 'utf8');
+    await writeFile(join(cwd, '.forge', 'progress.md'), '# ledger — #74\n\nPlan: docs/plans/p.md\n\n- [x] T1 — a\n', 'utf8');
+    await writeFile(join(cwd, '.forge', 'journal.jsonl'), '', 'utf8');
+    // fake git/gh
+    const touched = conforming ? 'plugin/scripts/lib/trace.mjs' : 'src/rogue.mjs';
+    const execFn = async (cmd, args) => {
+      const j = args.join(' ');
+      if (cmd === 'git' && j.includes('rev-parse')) return { ok: true, stdout: 'feat/74-x\n' };
+      if (cmd === 'git' && j.includes('diff')) return { ok: true, stdout: touched + '\n' };
+      if (cmd === 'gh') return { ok: true, stdout: '**started** go\n**plan** x\n**pr** y\n' };
+      return { ok: false, stdout: '', stderr: 'unrouted' };
+    };
+    return { cwd, execFn };
+  }
+
+  it('AC-C6.3: prints timeline + badge; green → conforming true (exit 0)', async () => {
+    const { cwd, execFn } = await repo(true);
+    const lines = [];
+    const r = await runTrace(cwd, { execFn }, (m) => lines.push(m));
+    expect(r.conforming).toBe(true);
+    expect(r.badge.level).toBe('green');
+    expect(lines.join('\n')).toMatch(/conformance: green/);
+    expect(lines.join('\n')).toMatch(/plan:/);
+  });
+
+  it('AC-C6.3: off-plan file → amber, conforming false (exit 1)', async () => {
+    const { cwd, execFn } = await repo(false);
+    const r = await runTrace(cwd, { execFn }, noop);
+    expect(r.conforming).toBe(false);
+    expect(r.badge.failing).toBe('files-in-scope');
+  });
+});


### PR DESCRIPTION
## C6 — agent-work trace + structure conformance (spec §3a/§3b)

Closes #74 (board #12). Answers the owner's two asks — *"where did the agent go"* and *"does it match the forge structure"* — by **reading and ordering files the pipeline already writes**. No new capture. Conformance is advisory (a badge), not a merge gate; the mechanical gates at ship stay the enforcement.

### What's here
- **`plugin/scripts/lib/trace.mjs`** — pure `buildTrace` (ordered plan→tasks→files→journal→PR phase strip, current step lit) + `conformance` (green/amber over valid-branch, ledger→plan, files-in-scope via plandrift `isAllowed`, phases-in-order). All external I/O injected → offline-safe + testable. The trail-phases check is **omitted when its source is absent** (offline console: 3-check badge; CLI with gh: 4-check).
- **`plugin/scripts/trace.mjs`** — CLI: timeline + badge for the current repo, exit 0 green / 1 amber (a before-ship "inside the lines" check).
- **`console/lib/collect.mjs` + `console/web/*`** — each repo card gets a phase strip + green/amber badge (hover shows every check); the collector degrades to `[]` touched when git is unavailable.

### Verification — done
- ✅ 13/13 C6 tests (AC-C6.1..C6.4); full suite **319/319**.
- ✅ 4 gates: plandrift clean (7 touched, all declared), testintent clean, depguard clean, acgate all 4 ACs covered.
- ✅ **Live dogfood — the CLI on its own branch**, and it read `started` from #74's real gh trail. Output was **amber (ledger-plan)** — and that's *correct*, see below.

### Honest finding (not a bug)
Running the CLI on this very branch reports amber because **my working loop is plan-doc-driven, not ledger-driven**: I commit `docs/plans/*.md` to main directly and never run `initLedger`, so there's no `.forge/progress.md` with a `Plan:` line for the conformance check to follow — which also empties `planFiles`, so files-in-scope reads everything as off-plan. The badge is accurately saying "no ledger here." `plandrift` passed on the same diff because it's handed the plan explicitly (`--plan`), whereas conformance sources the plan via the ledger.
→ **Follow-up worth filing:** let `conformance` fall back to locating the ticket's committed plan doc (like plandrift) when no ledger exists, so the plan-doc loop shows green. Deliberately not expanded here (scope).

### NOT done
- ❌ Browser render of the strip/badge (owner post-merge check, like #37/#39) — the pure `repoCard` HTML + collector are unit-tested; the pixels are not.

### Out of scope
Alerts (C7), quota (C8).
