### PR TITLE
feat(control): C7 alerts — journal-failure + stale-session watcher (#77)

### DIFF
--- a/console/lib/alerts.mjs
+++ b/console/lib/alerts.mjs
@@ -1,0 +1,69 @@
+/**
+ * Alerts (C7/#77; spec §3c). Pure derivation of "something went wrong" signals
+ * from state the pipeline already writes: failure-kind journal events + control
+ * sessions whose heartbeat has gone stale. No new capture. Honest limit: this is
+ * local best-effort-loud alerting (banner / feed / opt-in toast) — true
+ * push-to-phone stays the Firebase step.
+ */
+
+/** Journal kinds that mean trouble (spec §3c). */
+export const ALERT_KINDS = ['gate-fail', 'cmd-fail', 'blocked-edit', 'backend-fallback', 'incident', 'respond-open'];
+
+const HOUR = 3_600_000;
+const sev = (kind) => (kind === 'incident' || kind === 'respond-open' ? 'high' : kind === 'stale-session' ? 'high' : 'warn');
+
+function ageLabel(ts, now) {
+  const t = Date.parse(ts ?? '');
+  if (!Number.isFinite(t)) return '';
+  const s = Math.max(0, Math.round((now - t) / 1000));
+  if (s < 60) return `${s}s ago`;
+  if (s < 3600) return `${Math.round(s / 60)}m ago`;
+  return `${Math.round((s / 3600) * 10) / 10}h ago`;
+}
+
+/**
+ * Compute the current alert set.
+ *   repos:    [{ repo, journalTail:[{ts, kind, ticket, gate}], error? }]
+ *   sessions: [{ id, state, repo, ticket, lastHeartbeat }]
+ * A journal event alerts if its kind is in ALERT_KINDS and it falls within
+ * windowMs. A session alerts if it's `alive` but its heartbeat is older than
+ * staleMs. Ids are stable (repo+kind+ts / session id) so callers can dedup.
+ * Returns newest-first.
+ */
+export function deriveAlerts({ repos = [], sessions = [], now = Date.now(), staleMs = 5 * 60_000, windowMs = 24 * HOUR } = {}) {
+  const out = [];
+
+  for (const r of repos ?? []) {
+    for (const e of r?.journalTail ?? []) {
+      if (!ALERT_KINDS.includes(e?.kind)) continue;
+      const t = Date.parse(e.ts ?? '');
+      if (Number.isFinite(t) && now - t > windowMs) continue; // too old to be actionable
+      out.push({
+        id: `${r.repo}:${e.kind}:${e.ts ?? ''}`,
+        kind: e.kind,
+        repo: r.repo,
+        ticket: e.ticket ?? null,
+        ts: e.ts ?? null,
+        severity: sev(e.kind),
+        message: `${e.kind}${e.gate ? ` (${e.gate})` : ''} in ${r.repo}${e.ticket ? ` ${e.ticket}` : ''} · ${ageLabel(e.ts, now)}`,
+      });
+    }
+  }
+
+  for (const s of sessions ?? []) {
+    if (s?.state !== 'alive') continue;
+    const hb = Date.parse(s.lastHeartbeat ?? '');
+    if (!Number.isFinite(hb) || now - hb <= staleMs) continue;
+    out.push({
+      id: `session:${s.id}:stale`,
+      kind: 'stale-session',
+      repo: s.repo ?? null,
+      ticket: s.ticket ?? null,
+      ts: s.lastHeartbeat ?? null,
+      severity: 'high',
+      message: `session ${s.id} heartbeat stale (${ageLabel(s.lastHeartbeat, now)}) — hung or crashed`,
+    });
+  }
+
+  return out.sort((a, b) => (Date.parse(b.ts ?? 0) || 0) - (Date.parse(a.ts ?? 0) || 0));
+}

--- a/console/lib/toast.mjs
+++ b/console/lib/toast.mjs
@@ -1,0 +1,37 @@
+/**
+ * Opt-in OS toast (C7/#77; spec §3c). Dependency-free Windows notification via a
+ * PowerShell NotifyIcon balloon — no BurntToast module, no npm dependency. OFF by
+ * default (a user-enabled hook), and best-effort: any failure is swallowed so a
+ * missing PowerShell / non-Windows host never breaks the console. Not push: you
+ * must have opted in on this machine (true phone push stays the Firebase step).
+ */
+import { spawn } from 'node:child_process';
+
+/** Build the PowerShell one-liner that pops a tray balloon. Values are single-quote-escaped. */
+export function balloonScript(title, body) {
+  const q = (s) => String(s ?? '').replace(/'/g, "''");
+  return [
+    'Add-Type -AssemblyName System.Windows.Forms;',
+    '$n = New-Object System.Windows.Forms.NotifyIcon;',
+    '$n.Icon = [System.Drawing.SystemIcons]::Warning;',
+    '$n.Visible = $true;',
+    `$n.ShowBalloonTip(6000, '${q(title)}', '${q(body)}', [System.Windows.Forms.ToolTipIcon]::Warning);`,
+    'Start-Sleep -Milliseconds 6500; $n.Dispose();',
+  ].join(' ');
+}
+
+/**
+ * Fire one notification when enabled; a no-op otherwise. Best-effort — never
+ * throws. spawnFn injected for tests. Returns {fired, reason?}.
+ */
+export function notify(title, body, { enabled = false, spawnFn = spawn, platform = process.platform } = {}) {
+  if (!enabled) return { fired: false, reason: 'disabled' };
+  if (platform !== 'win32') return { fired: false, reason: 'not-windows' };
+  try {
+    const child = spawnFn('powershell', ['-NoProfile', '-NonInteractive', '-Command', balloonScript(title, body)], { detached: true, stdio: 'ignore' });
+    child.unref?.();
+    return { fired: true };
+  } catch (e) {
+    return { fired: false, reason: String(e?.message ?? e) };
+  }
+}

--- a/console/serve.mjs
+++ b/console/serve.mjs
@@ -19,6 +19,21 @@ import { resolveReply } from './daemon.mjs';
 import { runControl, readAudit, parseArgs as parseControlArgs, defaultBase as controlDefaultBase } from '../control/control.mjs';
 import * as controlQueue from '../control/lib/queue.mjs';
 import * as controlMachine from '../control/lib/machine.mjs';
+import { read as readRepoJournal } from '../plugin/scripts/lib/journal.mjs';
+import { deriveAlerts } from './lib/alerts.mjs';
+import { notify } from './lib/toast.mjs';
+
+/** Light per-repo journal tails for the alert watcher — tolerant of unreadable repos. */
+async function repoJournals(repos = []) {
+  const out = [];
+  for (const cwd of repos) {
+    try {
+      const j = await readRepoJournal(cwd);
+      out.push({ repo: cwd.split(/[\\/]/).filter(Boolean).pop() ?? cwd, journalTail: (j.events ?? []).slice(-25) });
+    } catch { out.push({ repo: cwd, journalTail: [] }); }
+  }
+  return out;
+}
 
 const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), 'web');
 export const DEFAULT_PORT = 7433;
@@ -65,6 +80,16 @@ export function controlArgsFromBody(body) {
 
 export function makeApp(config, log = () => {}) {
   const controlBase = config.controlBase ?? controlDefaultBase();
+  // Toast dedup: fire an OS toast at most once per alert id (in-memory across polls).
+  const toastedIds = new Set();
+  const fireNewToasts = (alerts) => {
+    if (!config.toastEnabled) return;
+    for (const a of alerts) {
+      if (toastedIds.has(a.id)) continue;
+      toastedIds.add(a.id);
+      notify('forge alert', a.message, { enabled: true, spawnFn: config.toastSpawn, platform: config.toastPlatform });
+    }
+  };
   return async function handle(req, res) {
     const send = (code, body, type = 'application/json') => {
       res.writeHead(code, { 'Content-Type': type, 'Cache-Control': 'no-store' });
@@ -84,7 +109,10 @@ export function makeApp(config, log = () => {}) {
         return send(200, await stateOf(config));
       }
       if (req.method === 'GET' && path === '/api/control/state') {
-        return send(200, await controlStateOf(controlBase));
+        const cs = await controlStateOf(controlBase);
+        const alerts = deriveAlerts({ repos: await repoJournals(config.repos ?? []), sessions: cs.sessions, now: Date.now() });
+        fireNewToasts(alerts);
+        return send(200, { ...cs, alerts });
       }
       if (req.method === 'POST' && path === '/api/control') {
         let raw = '';

--- a/console/web/app.js
+++ b/console/web/app.js
@@ -107,14 +107,20 @@ export function controlPanel(state, now = Date.now()) {
     `<div class="crow">${esc(relativeTime(a.ts, now))} · <b>${esc(a.verb)}</b>${a.repo ? ' ' + esc(a.repo) : ''}${a.ticket ? ' #' + esc(a.ticket) : ''} <span class="cby">${esc(a.by ?? '')}</span></div>`, 'no audit yet');
   const buttons = CONTROL_VERBS.map((v) =>
     `<button data-verb="${esc(v)}"${CONTROL_DESTRUCTIVE.includes(v) ? ' data-destructive="1"' : ''}>${esc(v)}</button>`).join('');
-  const banner = s.paused ? `<div class="cbanner">⏸ PAUSED — the runner spawns nothing until resumed (human-only clear)</div>` : '';
-  return `<h2>forge-control${s.paused ? ' · paused' : ''}</h2>${banner}
+  const pausedBanner = s.paused ? `<div class="cbanner">⏸ PAUSED — the runner spawns nothing until resumed (human-only clear)</div>` : '';
+  // §3c alerts (C7): a red banner when anything is wrong + a feed of the events.
+  const alerts = s.alerts ?? [];
+  const alertBanner = alerts.length ? `<div class="cbanner alert" role="alert">🔴 ${alerts.length} alert${alerts.length === 1 ? '' : 's'} — ${esc(alerts[0].message)}</div>` : '';
+  const alertFeed = alerts.length ? `<div class="ccol alerts"><h3>alerts</h3>${alerts.slice(0, 12).map((a) =>
+    `<div class="crow alert ${esc(a.severity)}"><b>${esc(a.kind)}</b> ${esc(a.repo ?? '')}${a.ticket ? ' ' + esc(a.ticket) : ''}</div>`).join('')}</div>` : '';
+  return `<h2>forge-control${s.paused ? ' · paused' : ''}${alerts.length ? ' · ' + alerts.length + ' alert' + (alerts.length === 1 ? '' : 's') : ''}</h2>${alertBanner}${pausedBanner}
     <div class="cverbs">${buttons}</div>
     <div class="cgrid">
       <div class="ccol"><h3>queue</h3>${queue}</div>
       <div class="ccol"><h3>sessions</h3>${sessions}</div>
       <div class="ccol"><h3>audit</h3>${audit}</div>
     </div>
+    ${alertFeed}
     <div class="errline" role="alert"></div>`;
 }
 

--- a/console/web/index.html
+++ b/console/web/index.html
@@ -66,6 +66,10 @@
   #control h2 { font:600 13px Bahnschrift,'Arial Narrow',sans-serif; letter-spacing:.14em; text-transform:uppercase; color:var(--smoke); margin-bottom:10px; }
   #control.paused h2 { color:var(--alarm); }
   .cbanner { border:1px dashed var(--alarm); color:var(--alarm); padding:8px 12px; margin-bottom:12px; font-size:12px; }
+  .cbanner.alert { border-style:solid; background:rgba(226,72,61,.10); font-weight:600; }
+  .ccol.alerts { grid-column:1 / -1; margin-top:12px; }
+  .crow.alert.high b { color:var(--alarm); }
+  .crow.alert.warn b { color:var(--spark); }
   .cverbs { display:flex; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
   .cverbs button[data-destructive] { border-color:var(--warm); color:var(--warm); }
   .cverbs button.armed { border-color:var(--alarm); color:var(--alarm); }

--- a/tests/console/alerts.test.mjs
+++ b/tests/console/alerts.test.mjs
@@ -1,0 +1,129 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { request } from 'node:http';
+import { startServer } from '../../console/serve.mjs';
+import { deriveAlerts, ALERT_KINDS } from '../../console/lib/alerts.mjs';
+import { notify, balloonScript } from '../../console/lib/toast.mjs';
+import { controlPanel } from '../../console/web/app.js';
+import * as machine from '../../control/lib/machine.mjs';
+
+const NOW = Date.parse('2026-07-19T12:00:00Z');
+const ago = (ms) => new Date(NOW - ms).toISOString();
+const servers = [];
+afterAll(() => servers.forEach(({ server }) => server.close()));
+
+describe('deriveAlerts (AC-C7.1)', () => {
+  it('AC-C7.1: failure-kind journal events become alerts; non-failures do not; stable ids', () => {
+    const repos = [{ repo: 'forge', journalTail: [
+      { ts: ago(60_000), kind: 'gate-fail', gate: 'plandrift', ticket: '#5' },
+      { ts: ago(120_000), kind: 'auto-approve' },       // not a failure kind → ignored
+      { ts: ago(180_000), kind: 'incident', ticket: '#9' },
+    ] }];
+    const a = deriveAlerts({ repos, sessions: [], now: NOW });
+    expect(a).toHaveLength(2);
+    expect(a.map((x) => x.kind)).toEqual(['gate-fail', 'incident']); // newest-first
+    expect(a[0].id).toBe(`forge:gate-fail:${ago(60_000)}`);          // stable id
+    expect(a.find((x) => x.kind === 'incident').severity).toBe('high');
+    expect(ALERT_KINDS).toContain('backend-fallback');
+  });
+
+  it('AC-C7.1: stale alive session alerts; fresh / dead sessions do not; window drops old events', () => {
+    const sessions = [
+      { id: 's-stale', state: 'alive', repo: 'forge', ticket: 66, lastHeartbeat: ago(10 * 60_000) },
+      { id: 's-fresh', state: 'alive', repo: 'forge', lastHeartbeat: ago(30_000) },
+      { id: 's-dead', state: 'dead', repo: 'forge', lastHeartbeat: ago(60 * 60_000) },
+    ];
+    const a = deriveAlerts({ repos: [], sessions, now: NOW, staleMs: 5 * 60_000 });
+    expect(a.map((x) => x.id)).toEqual(['session:s-stale:stale']);
+    // an event older than the window is dropped
+    const old = deriveAlerts({ repos: [{ repo: 'r', journalTail: [{ ts: ago(48 * 3_600_000), kind: 'cmd-fail' }] }], now: NOW, windowMs: 24 * 3_600_000 });
+    expect(old).toHaveLength(0);
+  });
+
+  it('AC-C7.1: partial / empty input never throws', () => {
+    expect(deriveAlerts()).toEqual([]);
+    expect(() => deriveAlerts({ repos: [{}], sessions: [null] })).not.toThrow();
+  });
+});
+
+describe('toast (AC-C7.3)', () => {
+  it('AC-C7.3: disabled → no-op; wrong platform → no-op; enabled+win32 → exactly one spawn; errors swallowed', () => {
+    const calls = [];
+    const spawnFn = (...args) => { calls.push(args); return { unref() {} }; };
+    expect(notify('t', 'b', { enabled: false, spawnFn }).fired).toBe(false);
+    expect(notify('t', 'b', { enabled: true, spawnFn, platform: 'linux' }).fired).toBe(false);
+    expect(calls).toHaveLength(0);
+    const r = notify('t', 'b', { enabled: true, spawnFn, platform: 'win32' });
+    expect(r.fired).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('powershell');
+    // a throwing spawn is swallowed, never propagates
+    const bad = notify('t', 'b', { enabled: true, platform: 'win32', spawnFn: () => { throw new Error('no ps'); } });
+    expect(bad.fired).toBe(false);
+    expect(bad.reason).toMatch(/no ps/);
+  });
+
+  it('balloonScript escapes single quotes (no injection through title/body)', () => {
+    expect(balloonScript("it's", "a'b")).toContain("''");
+    expect(balloonScript('x', 'y')).toContain('ShowBalloonTip');
+  });
+});
+
+describe('/api/control/state alerts + toast dedup (AC-C7.2, AC-C7.3)', () => {
+  async function seeded() {
+    const base = await mkdtemp(join(tmpdir(), 'forge-alert-'));
+    // a stale alive session → one alert. Heartbeat is relative to the REAL clock
+    // because the server derives alerts with Date.now() (not the test's fixed NOW).
+    await machine.registerSession(base, { id: 's-hung', repo: 'forge', ticket: 66 });
+    await machine.updateSession(base, 's-hung', { lastHeartbeat: new Date(Date.now() - 30 * 60_000).toISOString() });
+    // a repo with a failure journal event
+    const repo = await mkdtemp(join(tmpdir(), 'forge-alertrepo-'));
+    await mkdir(join(repo, '.forge'), { recursive: true });
+    await writeFile(join(repo, '.forge', 'journal.jsonl'), JSON.stringify({ ts: new Date().toISOString(), kind: 'gate-fail', gate: 'acgate', ticket: '#5' }) + '\n', 'utf8');
+    return { base, repo };
+  }
+
+  it('AC-C7.2: alerts feed present; Host guard applies; AC-C7.3: one toast per new id', async () => {
+    const { base, repo } = await seeded();
+    const toasts = [];
+    const config = { machineId: 'm', repos: [repo], controlBase: base, toastEnabled: true, toastPlatform: 'win32', toastSpawn: (...a) => { toasts.push(a); return { unref() {} }; } };
+    const started = await startServer(config, { port: 0 });
+    servers.push(started);
+    const url = `http://127.0.0.1:${started.port}`;
+
+    const s = await (await fetch(`${url}/api/control/state`)).json();
+    expect(Array.isArray(s.alerts)).toBe(true);
+    expect(s.alerts.some((a) => a.kind === 'stale-session')).toBe(true);
+    expect(s.alerts.some((a) => a.kind === 'gate-fail')).toBe(true);
+    const firstCount = toasts.length;
+    expect(firstCount).toBeGreaterThanOrEqual(1);
+    // a second poll must NOT re-toast the same alert ids
+    await (await fetch(`${url}/api/control/state`)).json();
+    expect(toasts.length).toBe(firstCount);
+
+    // Host guard still applies to the control state
+    const status = await new Promise((res, rej) => {
+      const r = request(`${url}/api/control/state`, { headers: { Host: 'evil.example' } }, (rs) => { rs.resume(); res(rs.statusCode); });
+      r.on('error', rej); r.end();
+    });
+    expect(status).toBe(403);
+  });
+});
+
+describe('control tab alert banner (AC-C7.4)', () => {
+  it('AC-C7.4: banner + feed when alerts present; none → no banner', () => {
+    const withAlerts = controlPanel({ paused: false, queue: [], sessions: [], audit: [], alerts: [
+      { id: 'a1', kind: 'gate-fail', repo: 'forge', ticket: '#5', severity: 'warn', message: 'gate-fail (acgate) in forge #5' },
+    ] });
+    expect(withAlerts).toContain('cbanner alert');
+    expect(withAlerts).toContain('🔴');
+    expect(withAlerts).toMatch(/ccol alerts/);
+    expect(withAlerts).toContain('gate-fail');
+
+    const none = controlPanel({ paused: false, queue: [], sessions: [], audit: [], alerts: [] });
+    expect(none).not.toContain('cbanner alert');
+    expect(none).not.toContain('🔴');
+  });
+});


### PR DESCRIPTION
## C7 — alerts (spec §3c)

Closes #77 (board #12). Get told when something goes wrong: the console watches each repo's journal tail for **failure-kind events** (`gate-fail`, `cmd-fail`, `blocked-edit`, `backend-fallback`, `incident`, `respond-open`) and **control sessions whose heartbeat has gone stale**, and surfaces new ones as a **red banner + alerts feed** in the control tab plus an **opt-in Windows toast**. **Honest limit (unchanged):** local best-effort-loud — not push-to-phone; that stays the Firebase step. Console open or toast enabled required.

### What's here
- **`console/lib/alerts.mjs`** — pure `deriveAlerts({repos, sessions, now, staleMs, windowMs})`: failure-kind journal events (within a recency window) + alive sessions with a stale `lastHeartbeat` → alerts `{id, kind, repo, ticket, ts, severity, message}`, stable ids, newest-first.
- **`console/lib/toast.mjs`** — opt-in `notify()`: dependency-free Windows NotifyIcon balloon via PowerShell; **off by default**; best-effort (swallows every error); single-quote-escaped; injectable spawn.
- **`console/serve.mjs`** — `/api/control/state` gains an `alerts` array (control sessions + a light journal read per configured repo); newly-seen alert ids fire **at most one toast** (in-memory dedup across polls); a repo that errors doesn't sink the response.
- **`console/web/*`** — control tab red banner when any alert + an alerts feed.

### Verification — done
- ✅ 7/7 C7 tests (AC-C7.1..C7.4); full suite **326/326**.
- ✅ 4 gates: plandrift clean (6 touched, all declared), testintent clean, depguard clean, acgate all 4 ACs covered.
- ✅ **Live dogfood**: fired a **real toast on this machine** (`notify(...) → {fired:true}`, PowerShell spawned with no error), and the live `/api/control/state` returned **both** alert kinds — `gate-fail` (from a seeded repo journal) and `stale-session` (20m stale heartbeat).

### Verification — NOT done (honest)
- ❌ **Visual confirmation the balloon rendered** — `notify` reports the PowerShell process spawned successfully, but I can't see the desktop to confirm the tray balloon actually popped. By design the toast is best-effort (a missing/blocked PowerShell must never break the console), so "spawned without error" is the contract; the owner enabling `toastEnabled` will see (or not see) the visual.
- ❌ **Browser render of the banner/feed** — pure `controlPanel` HTML + the endpoint are unit-tested + dogfooded; the pixels are an owner post-merge check (like #37/#39).
- ⚠️ **Toast dedup is per-process (in-memory)** — restarting the console re-arms the seen-set, so a still-active alert can toast once more after a restart. Acceptable for a local console; noted.

### Out of scope
Quota panel (C8); true push-to-phone (Firebase).
