### PR TITLE
feat(control): C8 Claude Code quota panel (#79)

### DIFF
--- a/console/serve.mjs
+++ b/console/serve.mjs
@@ -20,8 +20,36 @@ import { runControl, readAudit, parseArgs as parseControlArgs, defaultBase as co
 import * as controlQueue from '../control/lib/queue.mjs';
 import * as controlMachine from '../control/lib/machine.mjs';
 import { read as readRepoJournal } from '../plugin/scripts/lib/journal.mjs';
+import { readSamples as readQuotaSamples, summarizeQuota } from '../plugin/scripts/lib/quota.mjs';
 import { deriveAlerts } from './lib/alerts.mjs';
 import { notify } from './lib/toast.mjs';
+
+/**
+ * Aggregate quota across configured repos (C8). 5h/7d are account-global, so the
+ * newest sample overall is the freshest quota; cost/day sums each repo's per-day
+ * peak. Repos without a captured quota file are skipped (opt-in).
+ */
+async function aggregateQuota(repos = []) {
+  const all = [];
+  for (const cwd of repos) {
+    const s = await readQuotaSamples(cwd).catch(() => []);
+    for (const x of s) all.push({ ...x, _repo: cwd });
+  }
+  if (!all.length) return { count: 0, latest: null, trend: null, costByDay: [] };
+  all.sort((a, b) => (Date.parse(a.ts ?? 0) || 0) - (Date.parse(b.ts ?? 0) || 0));
+  const summary = summarizeQuota(all);
+  const perRepoDay = new Map();
+  for (const x of all) {
+    const day = typeof x.ts === 'string' ? x.ts.slice(0, 10) : null;
+    if (!day || typeof x.cost !== 'number') continue;
+    const k = `${x._repo}|${day}`;
+    if (x.cost > (perRepoDay.get(k) ?? 0)) perRepoDay.set(k, x.cost);
+  }
+  const dayTotals = new Map();
+  for (const [k, cost] of perRepoDay) { const day = k.split('|')[1]; dayTotals.set(day, (dayTotals.get(day) ?? 0) + cost); }
+  const costByDay = [...dayTotals.entries()].sort(([a], [b]) => (a < b ? -1 : 1)).map(([day, cost]) => ({ day, cost }));
+  return { ...summary, costByDay };
+}
 
 /** Light per-repo journal tails for the alert watcher — tolerant of unreadable repos. */
 async function repoJournals(repos = []) {
@@ -112,7 +140,8 @@ export function makeApp(config, log = () => {}) {
         const cs = await controlStateOf(controlBase);
         const alerts = deriveAlerts({ repos: await repoJournals(config.repos ?? []), sessions: cs.sessions, now: Date.now() });
         fireNewToasts(alerts);
-        return send(200, { ...cs, alerts });
+        const quota = await aggregateQuota(config.repos ?? []);
+        return send(200, { ...cs, alerts, quota });
       }
       if (req.method === 'POST' && path === '/api/control') {
         let raw = '';

--- a/console/web/app.js
+++ b/console/web/app.js
@@ -113,6 +113,18 @@ export function controlPanel(state, now = Date.now()) {
   const alertBanner = alerts.length ? `<div class="cbanner alert" role="alert">🔴 ${alerts.length} alert${alerts.length === 1 ? '' : 's'} — ${esc(alerts[0].message)}</div>` : '';
   const alertFeed = alerts.length ? `<div class="ccol alerts"><h3>alerts</h3>${alerts.slice(0, 12).map((a) =>
     `<div class="crow alert ${esc(a.severity)}"><b>${esc(a.kind)}</b> ${esc(a.repo ?? '')}${a.ticket ? ' ' + esc(a.ticket) : ''}</div>`).join('')}</div>` : '';
+  // §3d quota panel (C8): account 5h/7d + trend + cost/day. Opt-in capture.
+  const arrow = (d) => (d === 'up' ? '↑' : d === 'down' ? '↓' : d === 'flat' ? '→' : '');
+  const q = s.quota;
+  const bar = (pct) => { const p = Math.max(0, Math.min(100, Math.round(pct ?? 0))); return `<span class="qbar"><span class="qfill" style="width:${p}%"></span></span> ${pct == null ? '—' : p + '%'}`; };
+  const quotaPanel = (() => {
+    if (!q || !q.count || !q.latest) return `<div class="ccol quota"><h3>quota</h3><div class="cempty">no quota captured — opt in with <code>.forge/quota.capture</code></div></div>`;
+    const days = (q.costByDay ?? []).slice(-5).map((d) => `<div class="crow">${esc(d.day)} · $${d.cost.toFixed(2)}</div>`).join('') || '<div class="cempty">no cost yet</div>';
+    return `<div class="ccol quota"><h3>quota</h3>
+      <div class="qrow">5h ${bar(q.latest.fiveHour)} <span class="qtrend">${arrow(q.trend?.fiveHour)}</span></div>
+      <div class="qrow">7d ${bar(q.latest.sevenDay)} <span class="qtrend">${arrow(q.trend?.sevenDay)}</span></div>
+      <div class="qcost">${days}</div></div>`;
+  })();
   return `<h2>forge-control${s.paused ? ' · paused' : ''}${alerts.length ? ' · ' + alerts.length + ' alert' + (alerts.length === 1 ? '' : 's') : ''}</h2>${alertBanner}${pausedBanner}
     <div class="cverbs">${buttons}</div>
     <div class="cgrid">
@@ -121,6 +133,7 @@ export function controlPanel(state, now = Date.now()) {
       <div class="ccol"><h3>audit</h3>${audit}</div>
     </div>
     ${alertFeed}
+    <div class="cgrid">${quotaPanel}</div>
     <div class="errline" role="alert"></div>`;
 }
 

--- a/console/web/index.html
+++ b/console/web/index.html
@@ -70,6 +70,14 @@
   .ccol.alerts { grid-column:1 / -1; margin-top:12px; }
   .crow.alert.high b { color:var(--alarm); }
   .crow.alert.warn b { color:var(--spark); }
+  /* §3d quota panel (C8) */
+  .ccol.quota { grid-column:1 / -1; margin-top:12px; }
+  .quota .qrow { display:flex; align-items:center; gap:8px; font-size:12px; margin:4px 0; }
+  .quota .qbar { display:inline-block; width:120px; height:7px; background:var(--seam); position:relative; }
+  .quota .qfill { position:absolute; left:0; top:0; bottom:0; background:linear-gradient(90deg,var(--warm),var(--ember)); }
+  .quota .qtrend { color:var(--smoke); }
+  .quota .qcost { margin-top:6px; color:var(--smoke); font-size:12px; }
+  .quota code { color:var(--steel); }
   .cverbs { display:flex; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
   .cverbs button[data-destructive] { border-color:var(--warm); color:var(--warm); }
   .cverbs button.armed { border-color:var(--alarm); color:var(--alarm); }

--- a/plugin/scripts/lib/quota.mjs
+++ b/plugin/scripts/lib/quota.mjs
@@ -1,0 +1,76 @@
+/**
+ * Claude Code quota capture + summary (C8/#79; spec §3d). The statusline payload
+ * carries rate_limits (5h/7d used %) and cost, but only Claude Code sees it. An
+ * OPT-IN statusline side-effect appends numeric-only samples here; the console
+ * reads them into a quota panel. Numbers only — never prompt content (§13).
+ *
+ * Opt-in by design: capture happens only when `.forge/quota.capture` exists.
+ * Honest limit: the panel is only as fresh as the last status-line refresh.
+ */
+import { appendFile, mkdir, readFile, stat } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+
+export const QUOTA_RELPATH = join('.forge', 'quota.jsonl');
+export const QUOTA_MARKER = join('.forge', 'quota.capture');
+
+const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+
+/** Opt-in switch: the marker file's presence enables capture. */
+export async function captureEnabled(cwd) {
+  try { await stat(join(cwd, QUOTA_MARKER)); return true; } catch { return false; }
+}
+
+/**
+ * Append one sample — ONLY the four numbers, nothing else can leak. No-op unless
+ * capture is enabled; silent on any failure (a status line must never break).
+ */
+export async function appendQuotaSample(cwd, { ts, fiveHour, sevenDay, cost } = {}) {
+  try {
+    if (!(await captureEnabled(cwd))) return { ok: true, wrote: false };
+    const rec = { ts: typeof ts === 'string' ? ts : new Date().toISOString(), fiveHour: num(fiveHour), sevenDay: num(sevenDay), cost: num(cost) };
+    const path = join(cwd, QUOTA_RELPATH);
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, JSON.stringify(rec) + '\n', 'utf8');
+    return { ok: true, wrote: true, rec };
+  } catch { return { ok: false, wrote: false }; }
+}
+
+/** Read parsed samples (oldest→newest), tolerant of a missing/partial file. */
+export async function readSamples(cwd, { limit = 500 } = {}) {
+  let raw;
+  try { raw = await readFile(join(cwd, QUOTA_RELPATH), 'utf8'); } catch { return []; }
+  const out = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try { out.push(JSON.parse(line)); } catch { /* skip half-written tail */ }
+  }
+  return out.slice(-limit);
+}
+
+const dir = (a, b) => (num(a) == null || num(b) == null ? null : a - b > 1 ? 'up' : b - a > 1 ? 'down' : 'flat');
+
+/**
+ * Summarize samples into panel data. `latest` = newest sample's numbers; `trend`
+ * = direction vs the window's first sample; `costByDay` = the peak session cost
+ * seen per calendar day (the payload cost is a running session total, so per-day
+ * max is the honest approximation). Empty/partial → {count:0,…}, never throws.
+ */
+export function summarizeQuota(samples, { now } = {}) {
+  void now;
+  const s = (samples ?? []).filter((x) => x && typeof x === 'object');
+  if (!s.length) return { count: 0, latest: null, trend: null, costByDay: [] };
+  const latest = s[s.length - 1];
+  const first = s[0];
+  const byDay = new Map();
+  for (const x of s) {
+    const day = typeof x.ts === 'string' ? x.ts.slice(0, 10) : null;
+    if (!day || num(x.cost) == null) continue;
+    if (x.cost > (byDay.get(day) ?? 0)) byDay.set(day, x.cost);
+  }
+  return {
+    count: s.length,
+    latest: { fiveHour: num(latest.fiveHour), sevenDay: num(latest.sevenDay), cost: num(latest.cost) },
+    trend: { fiveHour: dir(latest.fiveHour, first.fiveHour), sevenDay: dir(latest.sevenDay, first.sevenDay) },
+    costByDay: [...byDay.entries()].sort(([a], [b]) => (a < b ? -1 : 1)).map(([day, cost]) => ({ day, cost })),
+  };
+}

--- a/plugin/scripts/statusline.mjs
+++ b/plugin/scripts/statusline.mjs
@@ -13,6 +13,7 @@ import { pathToFileURL } from 'node:url';
 import { run } from './lib/exec.mjs';
 import { parseBranch } from './lib/ticket.mjs';
 import { deriveSituation } from './lib/situation.mjs';
+import { appendQuotaSample } from './lib/quota.mjs';
 
 /** Context usage across known payload shapes -> {used, max} or null. */
 export function extractContext(payload) {
@@ -89,6 +90,8 @@ async function main() {
   } catch { /* glyph degrades to branch inference */ }
 
   const projectDir = payload?.workspace?.project_dir || payload?.workspace?.current_dir || cwd;
+  const rateLimits = payload?.rate_limits || null;
+  const costUsd = typeof payload?.cost?.total_cost_usd === 'number' ? payload.cost.total_cost_usd : null;
   process.stdout.write(composeLine({
     situation, pendingCount,
     project: String(projectDir).split(/[\\/]/).filter(Boolean).pop(),
@@ -96,9 +99,16 @@ async function main() {
     context: extractContext(payload),
     model: payload?.model?.display_name || null,
     effort: payload?.effort?.level || null,
-    rateLimits: payload?.rate_limits || null,
-    costUsd: typeof payload?.cost?.total_cost_usd === 'number' ? payload.cost.total_cost_usd : null,
+    rateLimits,
+    costUsd,
   }));
+
+  // C8 (#79): opt-in quota capture — numeric-only, marker-gated, never breaks the strip.
+  await appendQuotaSample(cwd, {
+    fiveHour: rateLimits?.five_hour?.used_percentage,
+    sevenDay: rateLimits?.seven_day?.used_percentage,
+    cost: costUsd ?? undefined,
+  }).catch(() => {});
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/tests/console/quota-panel.test.mjs
+++ b/tests/console/quota-panel.test.mjs
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startServer } from '../../console/serve.mjs';
+import { controlPanel } from '../../console/web/app.js';
+import { QUOTA_RELPATH } from '../../plugin/scripts/lib/quota.mjs';
+
+const servers = [];
+afterAll(() => servers.forEach(({ server }) => server.close()));
+
+async function repoWithQuota(rows) {
+  const cwd = await mkdtemp(join(tmpdir(), 'forge-qrepo-'));
+  await mkdir(join(cwd, '.forge'), { recursive: true });
+  await writeFile(join(cwd, QUOTA_RELPATH), rows.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf8');
+  return cwd;
+}
+
+describe('/api/control/state quota (AC-C8.3)', () => {
+  it('AC-C8.3: aggregates quota across repos; sums cost/day; skips repos without data', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'forge-qbase-'));
+    const r1 = await repoWithQuota([
+      { ts: '2026-07-19T08:00:00Z', fiveHour: 20, sevenDay: 30, cost: 0.40 },
+      { ts: '2026-07-19T10:00:00Z', fiveHour: 55, sevenDay: 33, cost: 0.90 }, // newest overall
+    ]);
+    const r2 = await repoWithQuota([{ ts: '2026-07-19T09:00:00Z', fiveHour: 50, sevenDay: 32, cost: 0.25 }]);
+    const noData = await mkdtemp(join(tmpdir(), 'forge-qnone-'));
+
+    const started = await startServer({ machineId: 'm', repos: [r1, r2, noData], controlBase: base }, { port: 0 });
+    servers.push(started);
+    const s = await (await fetch(`http://127.0.0.1:${started.port}/api/control/state`)).json();
+
+    expect(s.quota.count).toBe(3);
+    expect(s.quota.latest).toMatchObject({ fiveHour: 55, sevenDay: 33 }); // newest sample overall
+    // cost/day = sum of each repo's per-day peak: r1 0.90 + r2 0.25 = 1.15
+    const day = s.quota.costByDay.find((d) => d.day === '2026-07-19');
+    expect(day.cost).toBeCloseTo(1.15, 5);
+  });
+
+  it('AC-C8.3: no captured quota anywhere → count 0, not fatal', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'forge-qbase-'));
+    const started = await startServer({ machineId: 'm', repos: [await mkdtemp(join(tmpdir(), 'forge-empty-'))], controlBase: base }, { port: 0 });
+    servers.push(started);
+    const s = await (await fetch(`http://127.0.0.1:${started.port}/api/control/state`)).json();
+    expect(s.quota).toMatchObject({ count: 0, latest: null });
+  });
+});
+
+describe('quota panel render (AC-C8.4)', () => {
+  it('AC-C8.4: renders 5h/7d bars + trend + cost/day', () => {
+    const html = controlPanel({
+      paused: false, queue: [], sessions: [], audit: [], alerts: [],
+      quota: { count: 5, latest: { fiveHour: 55, sevenDay: 33, cost: 0.9 }, trend: { fiveHour: 'up', sevenDay: 'flat' }, costByDay: [{ day: '2026-07-19', cost: 1.15 }] },
+    });
+    expect(html).toMatch(/ccol quota/);
+    expect(html).toContain('5h');
+    expect(html).toContain('55%');
+    expect(html).toContain('↑');           // up trend arrow
+    expect(html).toContain('$1.15');
+  });
+
+  it('AC-C8.4: no data → the opt-in hint', () => {
+    const html = controlPanel({ paused: false, queue: [], sessions: [], audit: [], alerts: [], quota: { count: 0, latest: null, trend: null, costByDay: [] } });
+    expect(html).toContain('opt in');
+    expect(html).toContain('.forge/quota.capture');
+  });
+});

--- a/tests/lib/quota.test.mjs
+++ b/tests/lib/quota.test.mjs
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { captureEnabled, appendQuotaSample, readSamples, summarizeQuota, QUOTA_RELPATH, QUOTA_MARKER } from '../../plugin/scripts/lib/quota.mjs';
+
+const tmp = () => mkdtemp(join(tmpdir(), 'forge-quota-'));
+async function enable(cwd) { await mkdir(join(cwd, '.forge'), { recursive: true }); await writeFile(join(cwd, QUOTA_MARKER), '', 'utf8'); }
+
+describe('capture (AC-C8.1)', () => {
+  it('AC-C8.1: opt-in — writes only with the marker; numeric-only; no throw on bad dir', async () => {
+    const off = await tmp();
+    expect((await appendQuotaSample(off, { fiveHour: 10, sevenDay: 20, cost: 0.5 })).wrote).toBe(false); // no marker
+    expect(await captureEnabled(off)).toBe(false);
+    expect(await readSamples(off)).toEqual([]);
+
+    const on = await tmp();
+    await enable(on);
+    // pass extra junk fields — only the four numbers may survive
+    const r = await appendQuotaSample(on, { fiveHour: 12, sevenDay: 34, cost: 1.25, prompt: 'SECRET TEXT', foo: 'bar' });
+    expect(r.wrote).toBe(true);
+    const raw = await readFile(join(on, QUOTA_RELPATH), 'utf8');
+    expect(raw).not.toContain('SECRET TEXT');
+    expect(raw).not.toContain('foo');
+    const rec = JSON.parse(raw.trim());
+    expect(Object.keys(rec).sort()).toEqual(['cost', 'fiveHour', 'sevenDay', 'ts']);
+    expect(rec).toMatchObject({ fiveHour: 12, sevenDay: 34, cost: 1.25 });
+
+    // non-numeric values are stored as null, never text
+    await appendQuotaSample(on, { fiveHour: 'lots', sevenDay: undefined, cost: NaN });
+    const last = (await readSamples(on)).at(-1);
+    expect(last).toMatchObject({ fiveHour: null, sevenDay: null, cost: null });
+
+    // a failing write is silent (returns ok:false, does not throw)
+    expect((await appendQuotaSample('Z:/nope/nope', { fiveHour: 1 })).wrote).toBe(false);
+  });
+});
+
+describe('summarizeQuota (AC-C8.2)', () => {
+  it('AC-C8.2: latest + trend vs window start + per-day peak cost', () => {
+    const s = [
+      { ts: '2026-07-18T09:00:00Z', fiveHour: 10, sevenDay: 30, cost: 0.20 },
+      { ts: '2026-07-18T18:00:00Z', fiveHour: 25, sevenDay: 33, cost: 0.55 }, // day peak 0.55
+      { ts: '2026-07-19T08:00:00Z', fiveHour: 40, sevenDay: 34, cost: 0.10 },
+    ];
+    const q = summarizeQuota(s);
+    expect(q.count).toBe(3);
+    expect(q.latest).toMatchObject({ fiveHour: 40, sevenDay: 34, cost: 0.10 });
+    expect(q.trend.fiveHour).toBe('up');   // 40 vs 10
+    expect(q.trend.sevenDay).toBe('up');   // 34 vs 30
+    expect(q.costByDay).toEqual([{ day: '2026-07-18', cost: 0.55 }, { day: '2026-07-19', cost: 0.10 }]);
+  });
+
+  it('AC-C8.2: flat/down trends; empty/partial → count 0, never throws', () => {
+    expect(summarizeQuota([{ ts: 't', fiveHour: 50 }, { ts: 't2', fiveHour: 20 }]).trend.fiveHour).toBe('down');
+    expect(summarizeQuota([{ ts: 't', fiveHour: 50 }, { ts: 't2', fiveHour: 50 }]).trend.fiveHour).toBe('flat');
+    expect(summarizeQuota([])).toEqual({ count: 0, latest: null, trend: null, costByDay: [] });
+    expect(() => summarizeQuota(null)).not.toThrow();
+    expect(() => summarizeQuota([null, {}])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## C8 — Claude Code quota panel (spec §3d) — the final control-plane epic

Closes #79 (board #12). The statusline sees `rate_limits` (5h/7d %) + `cost`; the console didn't. C8 captures them — an **opt-in** statusline side-effect appends **numeric-only** samples to `.forge/quota.jsonl` — and reads them into a console **quota panel**. **Honest limit (unchanged):** as fresh as your last status-line refresh; no capture → the console is blind (it's in no file it owns).

### What's here
- **`plugin/scripts/lib/quota.mjs`** — `captureEnabled` (marker `.forge/quota.capture`), `appendQuotaSample` (writes ONLY `{ts, fiveHour, sevenDay, cost}` — no prompt content can leak; silent on failure), `readSamples`, and pure `summarizeQuota` → `{count, latest, trend, costByDay}`.
- **`plugin/scripts/statusline.mjs`** — after it extracts rate_limits+cost, appends a sample **iff the marker is present**. Off by default; silent; never breaks the strip.
- **`console/serve.mjs`** — `/api/control/state` gains aggregated `quota` (account 5h/7d from the newest sample; cost/day summed from each repo's per-day peak); repos without data skipped.
- **`console/web/*`** — a quota panel in the control tab: 5h/7d bars + trend arrows + cost/day, or an opt-in hint.

### Verification — done
- ✅ 7/7 C8 tests (AC-C8.1..C8.4); full suite **333/333**.
- ✅ 4 gates: plandrift clean (7 touched, all declared), testintent clean, depguard clean, acgate all 4 ACs covered.
- ✅ **Live dogfood with the REAL statusline** (opt-in marker on, in a throwaway repo): the strip rendered `▶ c8-qrepo · #79 feat/79-x · Opus 4.8 · 5h 37% / 7d 53% · $1.23` AND captured two numeric-only samples; `summarizeQuota` → `latest {5h:41, 7d:53.1, $1.51}`, `trend {5h:up, 7d:flat}`, `costByDay $1.51`. The captured file contained only `{ts, fiveHour, sevenDay, cost}` — no text.

### Verification — NOT done (honest)
- ❌ **Browser render of the quota panel** — pure `controlPanel` HTML + the endpoint are unit-tested + dogfooded; the pixels are an owner post-merge check (like #37/#39).
- ⚠️ **cost/day is approximate** — the payload `cost` is a running session total, so per-day cost is the per-repo session peak summed across repos, not an exact ledger of spend. Documented in the code.
- ℹ️ **Capture stays off** on your repos until you `touch .forge/quota.capture` — the dogfood enabled it only in a throwaway dir, never your working tree.

### Out of scope
True push-to-phone (Firebase).

---
**This completes C1–C8 — the entire forge-control initiative.**
