### PR TITLE
fix(control): split entry.repo into spawn-path + trail-slug (#73)

### DIFF
--- a/control/lib/queue.mjs
+++ b/control/lib/queue.mjs
@@ -33,12 +33,15 @@ async function nextSeq(base) {
 
 function fileFor(seq, id) { return `${pad(seq)}-${id}.json`; }
 
-export async function enqueue(base, { id, ticket = null, repo, brief = '', at } = {}) {
+export async function enqueue(base, { id, ticket = null, repo, repoSlug = null, brief = '', at } = {}) {
   if (!repo) return { ok: false, error: 'enqueue needs a repo' };
   const dir = join(base, Q);
   await mkdir(dir, { recursive: true });
   const seq = await nextSeq(base);
-  const rec = { id: id ?? `q-${seq}`, seq, ticket, repo, brief, state: 'pending', enqueuedAt: at ?? new Date().toISOString() };
+  // `repo` is the filesystem path the runner spawns in (--add-dir); `repoSlug` is the
+  // owner/name used to trail the ticket on GitHub (#73). They differ — a path can't be
+  // a slug — so the trail no-ops on a path-only entry. repoSlug is optional/back-compat.
+  const rec = { id: id ?? `q-${seq}`, seq, ticket, repo, repoSlug, brief, state: 'pending', enqueuedAt: at ?? new Date().toISOString() };
   await writeFile(join(dir, fileFor(seq, rec.id)), JSON.stringify(rec), 'utf8');
   return { ok: true, entry: rec };
 }

--- a/control/lib/runner.mjs
+++ b/control/lib/runner.mjs
@@ -100,7 +100,8 @@ export async function runOnce(base, opts = {}) {
   const cost = result?.envelope?.total_cost_usd;
   await machine.markSession(base, sessionId, killedReason ? 'killed' : 'dead');
   await journal(base, { event: 'session-end', sessionId, ticket: entry.ticket, repo: entry.repo, outcome, cost, killedReason });
-  if (entry.ticket) await trail(entry.repo, entry.ticket, outcomeLine(outcome, sessionId, { cost, timeoutMs }));
+  // Trail to the GitHub slug when the entry carries one; the spawn path can't be a slug (#73).
+  if (entry.ticket) await trail(entry.repoSlug ?? entry.repo, entry.ticket, outcomeLine(outcome, sessionId, { cost, timeoutMs }));
   await queue.ack(base, entry.id);
 
   return { ok: true, sessionId, outcome, killedReason, entry };

--- a/tests/control/runner.test.mjs
+++ b/tests/control/runner.test.mjs
@@ -26,6 +26,32 @@ function fakeSpawn(mode, sink = []) {
 let idSeq = 0;
 const mintId = () => `sess-${++idSeq}`;
 
+describe('repo path vs trail slug (AC-73.1, #73)', () => {
+  it('AC-73.1: enqueue carries repoSlug; the spawner gets the path, the trail gets the slug', async () => {
+    const b = await base();
+    const e = await queue.enqueue(b, { repo: 'C:/mywp/forge', repoSlug: 'dngioidev/forge', ticket: 73, brief: 'x' });
+    expect(e.entry).toMatchObject({ repo: 'C:/mywp/forge', repoSlug: 'dngioidev/forge' });
+
+    const spawned = [];
+    const trails = [];
+    await runOnce(b, {
+      spawn: fakeSpawn('success', spawned),
+      trail: async (repo, ticket, body) => trails.push({ repo, ticket }),
+      journal: async () => {}, mintId,
+    });
+    expect(spawned[0].repo).toBe('C:/mywp/forge');          // spawner uses the PATH
+    expect(trails[0]).toMatchObject({ repo: 'dngioidev/forge', ticket: 73 }); // trail uses the SLUG
+  });
+
+  it('AC-73.1: no repoSlug → back-compat, the trail falls back to repo (path)', async () => {
+    const b = await base();
+    await queue.enqueue(b, { repo: 'C:/mywp/forge', ticket: 73, brief: 'x' });
+    const trails = [];
+    await runOnce(b, { spawn: fakeSpawn('success'), trail: async (repo) => trails.push(repo), journal: async () => {}, mintId });
+    expect(trails[0]).toBe('C:/mywp/forge'); // unchanged behavior (defaultTrail would then skip a non-slug)
+  });
+});
+
 describe('spawn shape + classify (AC-C2.3, AC-C2.4)', () => {
   it('buildArgs is the verified headless flag string; resume swaps the id flag', () => {
     expect(buildArgs({ brief: 'do X', sessionId: 'u1', repo: '/r', model: 'm', permissionMode: 'plan' }))


### PR DESCRIPTION
## Fix: split `entry.repo` into spawn-path + trail-slug (#73)

Closes #73. Found during the C5 dogfood. The C2 runner overloaded one `entry.repo`: the spawner uses it as a filesystem **path** (`cwd` + `--add-dir`), but `defaultTrail` needs an `owner/name` **slug** for `gh issue comment`. A path fails the slug regex → the trail silently no-ops (the dogfood worked around it with an injected trail).

### Change
- `queue.enqueue` accepts an optional `repoSlug` and stores it on the entry.
- `runOnce` trails to `entry.repoSlug ?? entry.repo`; the spawner still uses `entry.repo` (the path).
- **Back-compat:** a path-only entry (no `repoSlug`) behaves exactly as before.

### Verification
- ✅ New tests AC-73.1: entry carries both; spawner gets the path, trail gets the slug; no-slug → trail falls back to the path. Full suite green; testintent/depguard/acgate clean. (Polish ticket — no plan doc, so plandrift N/A.)
