### PR TITLE
fix(control): conformance falls back to the ticket's plan doc when no ledger (#76)

### DIFF
--- a/console/lib/collect.mjs
+++ b/console/lib/collect.mjs
@@ -5,13 +5,22 @@
  * to snapshot a repo even when offline. Output goes through sanitize.mjs
  * before any transport sees it.
  */
-import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
 import { deriveSituation, pendingDecisions } from '../../plugin/scripts/lib/situation.mjs';
 import { read as readJournal } from '../../plugin/scripts/lib/journal.mjs';
 import { parseLedger, LEDGER_RELPATH } from '../../plugin/scripts/lib/ledger.mjs';
 import { parseBranch } from '../../plugin/scripts/lib/ticket.mjs';
-import { buildTrace, conformance, ledgerPlanRef, extractPlanFiles } from '../../plugin/scripts/lib/trace.mjs';
+import { buildTrace, conformance, resolvePlan } from '../../plugin/scripts/lib/trace.mjs';
+
+/** docs/plans/*.md listing [{path, text}] for the plan-doc conformance fallback (#76). */
+async function readPlanDocs(cwd) {
+  let names;
+  try { names = (await readdir(join(cwd, 'docs', 'plans'))).filter((f) => f.endsWith('.md')).sort(); } catch { return []; }
+  const out = [];
+  for (const n of names) out.push({ path: `docs/plans/${n}`, text: (await readFile(join(cwd, 'docs', 'plans', n), 'utf8').catch(() => '')) });
+  return out;
+}
 
 export async function currentBranch(cwd) {
   try {
@@ -61,11 +70,11 @@ export async function collectRepo(cwd, now = Date.now(), { diff = defaultDiff } 
   // §3a/§3b (C6): trace timeline + conformance badge from files already written.
   const ledgerText = (await readFile(join(cwd, LEDGER_RELPATH), 'utf8').catch(() => '')) || '';
   const ledgerTasks = parseLedger(ledgerText);
-  const planRef = ledgerPlanRef(ledgerText);
-  const planText = planRef ? await readFile(resolve(cwd, planRef), 'utf8').catch(() => null) : null;
+  // #76: resolve the plan from the ledger ref first, else the ticket's committed plan doc.
+  const plan = resolvePlan({ ledgerText, ticket: parsed.ticket, plans: await readPlanDocs(cwd) });
   const touched = await diff(cwd, 'main').catch(() => []);
-  const trace = buildTrace({ branch: branch ?? '', ledgerTasks, ledgerPlan: planRef, touchedFiles: touched, journalEvents: journal.events });
-  const badge = conformance({ branch: branch ?? '', ledgerText, planExists: planText != null, touchedFiles: touched, planFiles: extractPlanFiles(planText ?? ''), phasesSeen: null });
+  const trace = buildTrace({ branch: branch ?? '', ledgerTasks, ledgerPlan: plan.ref, touchedFiles: touched, journalEvents: journal.events });
+  const badge = conformance({ branch: branch ?? '', ledgerText, planExists: plan.found, planSource: plan.source, planRef: plan.ref, touchedFiles: touched, planFiles: plan.files, phasesSeen: null });
 
   return {
     repo: cwd.split(/[\\/]/).filter(Boolean).pop() ?? 'unknown',

--- a/plugin/scripts/lib/trace.mjs
+++ b/plugin/scripts/lib/trace.mjs
@@ -16,6 +16,32 @@ export function ledgerPlanRef(ledgerText) {
   return m ? m[1].trim() : null;
 }
 
+/**
+ * Resolve the plan governing this work (#76). Ledger `Plan:` ref first; else the
+ * ticket's committed plan doc — so the plan-doc loop (plans in docs/plans/ + main,
+ * no `initLedger`) is recognized instead of read as drift. `plans` is the injected
+ * docs/plans listing [{path, text}] (name-sorted, newest last). Returns
+ * { found, ref, files, source: 'ledger'|'plandoc'|null }.
+ */
+export function resolvePlan({ ledgerText = '', ticket = null, plans = [] } = {}) {
+  const norm = (s) => String(s ?? '').replaceAll('\\', '/');
+  const ref = ledgerPlanRef(ledgerText);
+  if (ref) {
+    const nref = norm(ref);
+    const hit = (plans ?? []).find((p) => { const np = norm(p?.path); return np && (np === nref || np.endsWith(nref) || nref.endsWith(np)); });
+    if (hit) return { found: true, ref, files: extractPlanFiles(hit.text), source: 'ledger' };
+  }
+  if (ticket != null) {
+    const tag = new RegExp(`#${ticket}\\b`);
+    const cands = (plans ?? []).filter((p) => tag.test(p?.text ?? '') || tag.test(p?.path ?? ''));
+    if (cands.length) {
+      const pick = cands[cands.length - 1]; // callers pass name-sorted; date-prefixed newest last
+      return { found: true, ref: pick.path, files: extractPlanFiles(pick.text ?? ''), source: 'plandoc' };
+    }
+  }
+  return { found: false, ref: ref ?? null, files: [], source: null };
+}
+
 /** Canonical pipeline phase order — used to light the current step + check ordering. */
 export const PHASE_ORDER = ['started', 'plan', 'tests', 'implement', 'gates', 'pr', 'ci-green', 'done'];
 
@@ -70,11 +96,14 @@ export function phasesInOrder(phasesSeen) {
  * GitHub, so the offline console skips it while the CLI (with gh) supplies the real
  * sequence. Returns { level: 'green'|'amber', checks: [{name, pass, why}], failing }.
  */
-export function conformance({ branch = '', ledgerText = '', planExists = false, touchedFiles = [], planFiles = [], phasesSeen = null } = {}) {
+export function conformance({ branch = '', ledgerText = '', planExists = false, planSource = null, planRef = null, touchedFiles = [], planFiles = [], phasesSeen = null } = {}) {
   const parsed = parseBranch(branch || '');
-  const planRef = ledgerPlanRef(ledgerText);
+  const ledgerRef = ledgerPlanRef(ledgerText);
   const validBranch = parsed.kind === 'work' || parsed.kind === 'hotfix';
   const deviations = (touchedFiles ?? []).filter((f) => !isAllowed(f, planFiles, [], DEFAULT_ALLOW));
+  // A plan counts when found via the ledger ref OR (#76) the ticket's committed plan doc.
+  // Legacy callers pass no planSource → the check stays exactly ledger-only (back-compat).
+  const planPass = planExists && (!!ledgerRef || planSource === 'plandoc');
 
   const checks = [
     {
@@ -84,8 +113,10 @@ export function conformance({ branch = '', ledgerText = '', planExists = false, 
     },
     {
       name: 'ledger-plan',
-      pass: !!planRef && planExists,
-      why: !planRef ? 'ledger has no Plan: reference' : !planExists ? `ledger Plan '${planRef}' is not a committed file` : `ledger → ${planRef}`,
+      pass: planPass,
+      why: planSource === 'plandoc' ? `plan doc → ${planRef ?? '?'}`
+        : !ledgerRef ? 'no plan: ledger has no Plan: line and no plan doc references this ticket'
+          : !planExists ? `ledger Plan '${ledgerRef}' is not a committed file` : `ledger → ${ledgerRef}`,
     },
     {
       name: 'files-in-scope',

--- a/plugin/scripts/trace.mjs
+++ b/plugin/scripts/trace.mjs
@@ -10,12 +10,22 @@ import { readFile } from 'node:fs/promises';
 import { resolve, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { run } from './lib/exec.mjs';
+import { readdir } from 'node:fs/promises';
 import { read as readJournal } from './lib/journal.mjs';
 import { parseLedger, LEDGER_RELPATH } from './lib/ledger.mjs';
 import { parseBranch } from './lib/ticket.mjs';
-import { buildTrace, conformance, ledgerPlanRef, extractPlanFiles } from './lib/trace.mjs';
+import { buildTrace, conformance, resolvePlan } from './lib/trace.mjs';
 
 async function readMaybe(path) { try { return await readFile(path, 'utf8'); } catch { return null; } }
+
+/** The docs/plans/*.md listing [{path, text}], name-sorted (date-prefixed → newest last). */
+async function readPlanDocs(cwd) {
+  let names;
+  try { names = (await readdir(join(cwd, 'docs', 'plans'))).filter((f) => f.endsWith('.md')).sort(); } catch { return []; }
+  const out = [];
+  for (const n of names) out.push({ path: `docs/plans/${n}`, text: (await readMaybe(join(cwd, 'docs', 'plans', n))) ?? '' });
+  return out;
+}
 
 /** Best-effort trail phases from the ticket's gh comments (skipped if gh/ticket absent). */
 async function trailPhases(ticket, execFn) {
@@ -37,19 +47,18 @@ export async function runTrace(cwd, { execFn = run, base = 'main', online = true
 
   const ledgerText = (await readMaybe(join(cwd, LEDGER_RELPATH))) ?? '';
   const ledgerTasks = parseLedger(ledgerText);
-  const planRef = ledgerPlanRef(ledgerText);
-  const planText = planRef ? await readMaybe(resolve(cwd, planRef)) : null;
-  const planFiles = extractPlanFiles(planText ?? '');
+  // #76: resolve the plan from the ledger ref first, else the ticket's committed plan doc.
+  const plan = resolvePlan({ ledgerText, ticket: parsed.ticket, plans: await readPlanDocs(cwd) });
 
   const diff = await execFn('git', ['-C', cwd, 'diff', '--name-only', `${base}...HEAD`]);
   const touchedFiles = diff.ok ? diff.stdout.split(/\r?\n/).filter(Boolean) : [];
 
   const journal = await readJournal(cwd);
   const prMatch = /\bpr[-\s]?#?(\d+)/i.exec(ledgerText) ?? null; // best-effort PR from ledger notes
-  const trace = buildTrace({ branch, ledgerTasks, ledgerPlan: planRef, touchedFiles, journalEvents: journal.events, prNumber: prMatch ? Number(prMatch[1]) : null });
+  const trace = buildTrace({ branch, ledgerTasks, ledgerPlan: plan.ref, touchedFiles, journalEvents: journal.events, prNumber: prMatch ? Number(prMatch[1]) : null });
 
   const phasesSeen = online ? await trailPhases(parsed.ticket, execFn) : null;
-  const badge = conformance({ branch, ledgerText, planExists: planText != null, touchedFiles, planFiles, phasesSeen });
+  const badge = conformance({ branch, ledgerText, planExists: plan.found, planSource: plan.source, planRef: plan.ref, touchedFiles, planFiles: plan.files, phasesSeen });
 
   // ---- render ----
   const glyph = badge.level === 'green' ? '🟢' : '🟡';

--- a/tests/lib/trace.test.mjs
+++ b/tests/lib/trace.test.mjs
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { buildTrace, conformance, phasesInOrder, ledgerPlanRef } from '../../plugin/scripts/lib/trace.mjs';
+import { buildTrace, conformance, phasesInOrder, ledgerPlanRef, resolvePlan } from '../../plugin/scripts/lib/trace.mjs';
 import { runTrace } from '../../plugin/scripts/trace.mjs';
 
 const noop = () => {};
@@ -82,6 +82,39 @@ describe('conformance (AC-C6.2)', () => {
   });
 });
 
+describe('resolvePlan + plan-doc fallback (AC-76.1, #76)', () => {
+  const plans = [
+    { path: 'docs/plans/2026-07-19-c6.md', text: '# C6\n**Ticket:** #74\n**Files:** plugin/scripts/lib/trace.mjs' },
+    { path: 'docs/plans/2026-07-19-other.md', text: '# other #99\n**Files:** x.mjs' },
+  ];
+
+  it('AC-76.1: ledger Plan: ref wins when it resolves to a listed plan (source ledger)', () => {
+    const r = resolvePlan({ ledgerText: 'Plan: docs/plans/2026-07-19-c6.md', ticket: 74, plans });
+    expect(r).toMatchObject({ found: true, source: 'ledger', ref: 'docs/plans/2026-07-19-c6.md' });
+    expect(r.files).toContain('plugin/scripts/lib/trace.mjs');
+  });
+
+  it('AC-76.1: no ledger → falls back to the ticket\'s plan doc (source plandoc)', () => {
+    const r = resolvePlan({ ledgerText: '', ticket: 74, plans });
+    expect(r).toMatchObject({ found: true, source: 'plandoc', ref: 'docs/plans/2026-07-19-c6.md' });
+    expect(r.files).toContain('plugin/scripts/lib/trace.mjs');
+  });
+
+  it('AC-76.1: no ledger and no matching plan doc → not found', () => {
+    expect(resolvePlan({ ledgerText: '', ticket: 12345, plans })).toMatchObject({ found: false, source: null });
+    expect(() => resolvePlan()).not.toThrow();
+  });
+
+  it('AC-76.1: conformance goes GREEN on the plan-doc loop (no ledger) via planSource', () => {
+    const r = resolvePlan({ ledgerText: '', ticket: 74, plans });
+    const c = conformance({ branch: 'feat/74-x', ledgerText: '', planExists: r.found, planSource: r.source, planRef: r.ref, touchedFiles: ['plugin/scripts/lib/trace.mjs'], planFiles: r.files });
+    expect(c.level).toBe('green');
+    expect(c.checks.find((x) => x.name === 'ledger-plan').why).toMatch(/plan doc/);
+    // back-compat: with no planSource and no ledger ref, ledger-plan still fails
+    expect(conformance({ branch: 'feat/74-x', ledgerText: '', planExists: true, touchedFiles: [], planFiles: [] }).failing).toBe('ledger-plan');
+  });
+});
+
 describe('trace CLI (AC-C6.3)', () => {
   async function repo(conforming) {
     const cwd = await mkdtemp(join(tmpdir(), 'forge-trace-'));
@@ -117,5 +150,23 @@ describe('trace CLI (AC-C6.3)', () => {
     const r = await runTrace(cwd, { execFn }, noop);
     expect(r.conforming).toBe(false);
     expect(r.badge.failing).toBe('files-in-scope');
+  });
+
+  it('AC-76.1: plan-doc loop (no ledger, plan in docs/plans) resolves green via the CLI', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-trace-'));
+    await mkdir(join(cwd, '.forge'), { recursive: true });
+    await mkdir(join(cwd, 'docs', 'plans'), { recursive: true });
+    await writeFile(join(cwd, 'docs', 'plans', '2026-07-19-c6.md'), '# C6\n**Ticket:** #74\n**Files:** plugin/scripts/lib/trace.mjs\n', 'utf8');
+    await writeFile(join(cwd, '.forge', 'journal.jsonl'), '', 'utf8'); // NO ledger on purpose
+    const execFn = async (cmd, args) => {
+      const j = args.join(' ');
+      if (cmd === 'git' && j.includes('rev-parse')) return { ok: true, stdout: 'feat/74-x\n' };
+      if (cmd === 'git' && j.includes('diff')) return { ok: true, stdout: 'plugin/scripts/lib/trace.mjs\n' };
+      if (cmd === 'gh') return { ok: true, stdout: '**started** go\n' };
+      return { ok: false, stdout: '', stderr: 'unrouted' };
+    };
+    const r = await runTrace(cwd, { execFn }, noop);
+    expect(r.conforming).toBe(true);                                   // was amber before #76
+    expect(r.badge.checks.find((c) => c.name === 'ledger-plan').why).toMatch(/plan doc/);
   });
 });


### PR DESCRIPTION
## Fix: conformance falls back to the ticket's plan doc when no ledger (#76)

Closes #76. Found during C6: `conformance` sourced the plan only via the ledger's `Plan:` line, but the maintainer loop is **plan-doc-driven** (plans committed to `docs/plans/` + main, no `initLedger`) — so genuinely conforming branches showed **amber**.

### Change
- New pure **`resolvePlan({ledgerText, ticket, plans})`** — resolves the plan via the ledger ref first, else the ticket's committed plan doc (newest referencing `#<ticket>`). Returns `{found, ref, files, source: 'ledger'|'plandoc'|null}`. Separator-tolerant path match (Windows `\` vs `/`).
- `conformance` gains a `planSource` — the plan-doc path passes the `ledger-plan` check. **Back-compat:** legacy callers (no `planSource`) keep the exact ledger-only behavior, so the C6 tests are untouched.
- The trace CLI and the console collector now supply the `docs/plans/` listing.

### Verification
- ✅ New tests AC-76.1: `resolvePlan` (ledger match / plandoc fallback / none), conformance goes green on the plan-doc loop, back-compat preserved, and an end-to-end CLI run on a no-ledger repo → green.
- ✅ Full suite **338/338**; testintent/depguard/acgate clean. (Polish ticket — no plan doc, plandrift N/A.)
- ✅ Live real-files check: `resolvePlan` for #74 resolved the actual `docs/plans/2026-07-19-c6-trace-conformance.md` (source plandoc, 28 files) — the exact case that was amber before.
