### PR TITLE
fix(hooks): denylist tests per command segment, not whole string (#85)

### DIFF
--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -49,10 +49,23 @@ export const RULES = [
   },
 ];
 
+/**
+ * Split a command line into sub-commands on shell separators (&& || ; | newline)
+ * so each rule tests ONE sub-command, not the whole string. Without this a benign
+ * chained call false-positives — e.g. `git push … && gh api graphql -f query=…`
+ * tripped force-push because `git push` and an unrelated `-f` were both present
+ * somewhere in the string (#85). Over-splitting is safe: a destructive command is
+ * still fully contained in its own segment.
+ */
+export function segments(command) {
+  return command.split(/&&|\|\||[;|\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
 export function check(command) {
   if (typeof command !== 'string' || command.length === 0) return { blocked: false };
+  const segs = segments(command);
   for (const rule of RULES) {
-    if (rule.test(command)) return { blocked: true, rule: rule.name, msg: rule.msg };
+    if (segs.some((seg) => rule.test(seg))) return { blocked: true, rule: rule.name, msg: rule.msg };
   }
   return { blocked: false };
 }

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -1,5 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { check, handle } from '../../plugin/hooks/denylist.mjs';
+import { check, handle, segments } from '../../plugin/hooks/denylist.mjs';
+
+describe('chained-command segments (AC-B85.*, #85 — iomanage feedback)', () => {
+  it('AC-B85.1: a push chained with an unrelated `gh … -f` is NOT force-push', () => {
+    expect(check("git push origin my-branch && gh api graphql -f query='mutation{...}'").blocked).toBe(false);
+    expect(check("gh api graphql -f query='...' ; git push origin feat/1-x").blocked).toBe(false);
+    expect(check("git push origin br | tee log.txt").blocked).toBe(false);
+  });
+
+  it('AC-B85.2: a real force-push still blocks — alone or in any segment', () => {
+    expect(check('git push --force origin main').rule).toBe('force-push');
+    expect(check('git status && git push -f origin main').rule).toBe('force-push');
+    expect(check('git push --force-with-lease origin feat/1-x').blocked).toBe(false); // still allowed
+  });
+
+  it('AC-B85.3: destructive command in one segment still blocks; benign chained segments do not', () => {
+    expect(check('npm test && git reset --hard HEAD~1').rule).toBe('hard-reset');
+    expect(check('git add -A && git clean -fdx').rule).toBe('git-clean-force');
+    expect(check('git push origin --delete staging && echo done').rule).toBe('env-branch-delete');
+    expect(check('git push origin main && npm run build && gh pr create').blocked).toBe(false);
+  });
+
+  it('segments() splits on &&, ||, ;, |, and newlines', () => {
+    expect(segments('a && b || c ; d | e\nf')).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+    expect(segments('git push origin main')).toEqual(['git push origin main']);
+  });
+});
 
 describe('denylist hook (AC-3.4)', () => {
   const blocked = [


### PR DESCRIPTION
## Fix: denylist tests per command segment (#85)

Closes #85 — iomanage feedback BUG-2. `hooks/denylist.mjs` rules matched the **whole command string**, so `git push origin my-branch && gh api graphql -f query='...'` was blocked as *force-push* (a `git push` was present and the unrelated `gh -f` matched `\s-f\b`). It cost the downstream user real time — every push chained with a board mutation was refused.

### Change
New `segments(command)` splits on `&&` / `||` / `;` / `|` / newline; `check()` now tests each rule against each segment. A rule fires only when one sub-command trips it — so the force flag must belong to the same segment as `git push`. This tightens every rule, not just force-push. Over-splitting is safe (a destructive command stays whole within its segment); the documented quoted-mention fail-closed case is unchanged (no separators → one segment).

### Verification
- ✅ AC-B85.1 chained push + `gh -f` not blocked; AC-B85.2 real `git push --force`/`-f` still blocked (incl. in a segment), `--force-with-lease` allowed; AC-B85.3 hard-reset/clean/branch-delete still block in any segment, benign chains don't.
- ✅ 29/29 denylist tests; full suite green; testintent/depguard/acgate clean. (Bug — no plan doc, plandrift N/A.)
