### PR TITLE
feat(board): batch create (--from) + reparent script (#87)

### DIFF
--- a/plugin/scripts/board/create.mjs
+++ b/plugin/scripts/board/create.mjs
@@ -3,14 +3,21 @@
  * board create — issue + parent sub-issue + board item + fields + assignee,
  * one command, resumable (spec §6 idempotency law; plan T2, AC-2.1).
  */
+import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { run, makeGh } from '../lib/exec.mjs';
 import { makeBoardCtx } from '../lib/boardctx.mjs';
 import { getIssueNode, addSubIssue } from '../lib/issues.mjs';
 
+/** Defaults applied to a single ticket spec (flags or a --from JSON entry). */
+export function withDefaults(spec = {}) {
+  return { title: null, body: '', type: 'item', priority: 'p1', size: 'm', status: 'backlog', parent: null, assignee: null, ...spec };
+}
+
 export function parseArgs(argv) {
-  const a = { title: null, body: '', type: 'item', priority: 'p1', size: 'm', status: 'backlog', parent: null, assignee: null };
+  const a = withDefaults();
+  a.from = null;
   for (let i = 0; i < argv.length; i++) {
     const k = argv[i];
     if (k === '--title') a.title = argv[++i];
@@ -21,8 +28,30 @@ export function parseArgs(argv) {
     else if (k === '--status') a.status = argv[++i];
     else if (k === '--parent') a.parent = Number(argv[++i]);
     else if (k === '--assignee') a.assignee = argv[++i];
+    else if (k === '--from') a.from = argv[++i];
   }
   return a;
+}
+
+/**
+ * Batch create from a list of specs (#87). Runs the same idempotent create per
+ * entry, sequentially, and CONTINUES past a per-entry failure — one bad ticket
+ * doesn't sink the rest. Returns a summary + per-entry results. Run it in the
+ * background for large batches (it's N round-trips, one invocation).
+ */
+export async function runCreateBatch(ctx, specs, log = console.log) {
+  if (!Array.isArray(specs) || specs.length === 0) return { ok: false, error: '--from file must be a non-empty JSON array of ticket specs' };
+  const results = [];
+  let created = 0; let skipped = 0; let failed = 0;
+  for (const [i, raw] of specs.entries()) {
+    const spec = withDefaults(raw);
+    log(`[${i + 1}/${specs.length}] ${spec.title ?? '(no title)'}`);
+    const r = await runCreate(ctx, spec, log);
+    if (r.ok) { r.resumed ? skipped++ : created++; results.push({ ok: true, title: spec.title, number: r.number }); }
+    else { failed++; results.push({ ok: false, title: spec.title, error: r.error }); log(`  ✗ ${r.error}`); }
+  }
+  log(`batch: ${created} created, ${skipped} resumed, ${failed} failed of ${specs.length}`);
+  return { ok: failed === 0, created, skipped, failed, results };
 }
 
 export async function runCreate(ctx, args, log = console.log) {
@@ -40,6 +69,7 @@ export async function runCreate(ctx, args, log = console.log) {
   );
   if (!found.ok) return { ok: false, error: found.stderr || 'issue list failed' };
   let issue = found.json.find((i) => i.title === args.title) ?? null;
+  const resumed = !!issue;
   if (issue) {
     log(`issue: exists #${issue.number} (resuming)`);
   } else {
@@ -93,7 +123,7 @@ export async function runCreate(ctx, args, log = console.log) {
     log(`field: ${fieldKey}=${wanted}`);
   }
 
-  return { ok: true, number: issue.number, itemId };
+  return { ok: true, number: issue.number, itemId, resumed };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
@@ -101,7 +131,14 @@ if (isMain) {
   const gh = makeGh(run);
   makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
     if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
-    const res = await runCreate(ctx, parseArgs(process.argv.slice(2)));
+    const args = parseArgs(process.argv.slice(2));
+    if (args.from) {
+      let specs;
+      try { specs = JSON.parse(await readFile(args.from, 'utf8')); } catch (e) { console.error(`--from: cannot read/parse ${args.from}: ${e.message}`); process.exit(1); }
+      const res = await runCreateBatch(ctx, specs);
+      process.exit(res.ok ? 0 : 1); // failures already logged per-entry
+    }
+    const res = await runCreate(ctx, args);
     if (!res.ok) { console.error(`create failed: ${res.error}`); process.exit(1); }
     console.log(`created/verified #${res.number}`);
   });

--- a/plugin/scripts/board/reparent.mjs
+++ b/plugin/scripts/board/reparent.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * board reparent — move a sub-issue to a different parent epic (#87).
+ * Restructuring the tree previously meant hand-written GraphQL `addSubIssue`
+ * with `replaceParent`; this wraps it.
+ *
+ *   reparent.mjs --issue <n> --parent <m>
+ *
+ * Uses addSubIssue({replaceParent:true}) so a child that already has a parent is
+ * moved, not rejected. Idempotent: if it's already under <m>, it's a no-op.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { getRepoInfo } from '../lib/board.mjs';
+import { getIssueNode, addSubIssue } from '../lib/issues.mjs';
+
+export function parseArgs(argv) {
+  const a = { issue: null, parent: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
+    else if (argv[i] === '--parent') a.parent = Number(argv[++i]);
+  }
+  return a;
+}
+
+export async function runReparent(gh, owner, repo, args, log = console.log) {
+  if (!Number.isInteger(args.issue) || !Number.isInteger(args.parent)) {
+    return { ok: false, error: '--issue <n> and --parent <m> are both required' };
+  }
+  if (args.issue === args.parent) return { ok: false, error: 'an issue cannot be its own parent' };
+
+  const child = await getIssueNode(gh, owner, repo, args.issue);
+  if (!child.ok) return { ok: false, error: child.error };
+  if (child.parentNumber === args.parent) {
+    log(`reparent: #${args.issue} already under #${args.parent} — no-op`);
+    return { ok: true, moved: false };
+  }
+  const parent = await getIssueNode(gh, owner, repo, args.parent);
+  if (!parent.ok) return { ok: false, error: parent.error };
+
+  const r = await addSubIssue(gh, parent.id, child.id, { replaceParent: true });
+  if (!r.ok) return { ok: false, error: r.error };
+  log(`reparent: #${args.issue} moved${child.parentNumber ? ` from #${child.parentNumber}` : ''} to #${args.parent}`);
+  return { ok: true, moved: true, from: child.parentNumber ?? null, to: args.parent };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  getRepoInfo(gh).then(async (repo) => {
+    if (!repo.ok) { console.error(repo.error); process.exit(1); }
+    const res = await runReparent(gh, repo.owner, repo.name, parseArgs(process.argv.slice(2)));
+    if (!res.ok) { console.error(`reparent failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/lib/issues.mjs
+++ b/plugin/scripts/lib/issues.mjs
@@ -19,13 +19,16 @@ export async function getIssueNode(gh, owner, repo, number) {
   return { ok: true, id: issue.id, parentNumber: issue.parent?.number ?? null };
 }
 
-const ADD_SUB_ISSUE = `mutation($parentId: ID!, $childId: ID!) {
-  addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) { issue { number } }
+/** replaceParent:true moves a child that already has a parent (re-parent, #87). */
+export function buildAddSubIssue(replaceParent = false) {
+  return `mutation($parentId: ID!, $childId: ID!) {
+  addSubIssue(input: { issueId: $parentId, subIssueId: $childId${replaceParent ? ', replaceParent: true' : ''} }) { issue { number } }
 }`;
+}
 
-export async function addSubIssue(gh, parentNodeId, childNodeId) {
+export async function addSubIssue(gh, parentNodeId, childNodeId, { replaceParent = false } = {}) {
   const res = await gh(
-    ['api', 'graphql', '-f', `query=${ADD_SUB_ISSUE}`, '-f', `parentId=${parentNodeId}`, '-f', `childId=${childNodeId}`],
+    ['api', 'graphql', '-f', `query=${buildAddSubIssue(replaceParent)}`, '-f', `parentId=${parentNodeId}`, '-f', `childId=${childNodeId}`],
     { parseJson: true },
   );
   if (!res.ok) return { ok: false, error: res.stderr || 'addSubIssue failed' };

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -3,7 +3,9 @@ import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { makeBoardCtx } from '../plugin/scripts/lib/boardctx.mjs';
-import { runCreate, parseArgs as createArgs } from '../plugin/scripts/board/create.mjs';
+import { runCreate, runCreateBatch, parseArgs as createArgs } from '../plugin/scripts/board/create.mjs';
+import { buildAddSubIssue, addSubIssue } from '../plugin/scripts/lib/issues.mjs';
+import { runReparent, parseArgs as reparentArgs } from '../plugin/scripts/board/reparent.mjs';
 import { runMove, parseArgs as moveArgs } from '../plugin/scripts/board/move.mjs';
 import { runComment, parseArgs as commentArgs } from '../plugin/scripts/board/comment.mjs';
 import { runReceipt } from '../plugin/scripts/board/receipt.mjs';
@@ -103,6 +105,62 @@ describe('create (AC-2.1)', () => {
     expect(res.ok).toBe(false);
     expect(res.error).toContain('valid priority keys');
     expect(calls.some((c) => c.startsWith('issue'))).toBe(false);
+  });
+});
+
+describe('batch create --from (AC-87.1, #87)', () => {
+  it('AC-87.1: creates each spec, continues past a per-entry failure, returns a summary', async () => {
+    const { ctx } = await ctxWith([
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/20\n' }],
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreateBatch(ctx, [
+      { title: 'Alpha' },                     // valid → created
+      { title: 'Beta', priority: 'urgent' },  // invalid option → fails before any gh, batch continues
+    ], noop);
+    expect(res).toMatchObject({ ok: false, created: 1, failed: 1 });
+    expect(res.results[0]).toMatchObject({ ok: true, title: 'Alpha' });
+    expect(res.results[1]).toMatchObject({ ok: false, title: 'Beta' });
+  });
+
+  it('AC-87.1: a non-array / empty file is refused', async () => {
+    const { ctx } = await ctxWith([]);
+    expect((await runCreateBatch(ctx, [], noop)).ok).toBe(false);
+    expect((await runCreateBatch(ctx, null, noop)).ok).toBe(false);
+  });
+});
+
+describe('reparent (AC-87.2, AC-87.3, #87)', () => {
+  it('AC-87.2: addSubIssue carries replaceParent only when asked', async () => {
+    expect(buildAddSubIssue(true)).toContain('replaceParent: true');
+    expect(buildAddSubIssue(false)).not.toContain('replaceParent');
+    let seen = null;
+    const gh = async (a) => { seen = a; return { ok: true, json: { data: { addSubIssue: { issue: { number: 5 } } } } }; };
+    await addSubIssue(gh, 'P', 'C', { replaceParent: true });
+    expect(seen.find((x) => x.startsWith('query='))).toContain('replaceParent: true');
+  });
+
+  it('AC-87.3: moves a child to a new parent via replaceParent', async () => {
+    const f = fakeGh([
+      [(j) => j.includes('parent { number }') && j.includes('number=5'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I5', parent: { number: 9 } } } } }) }],
+      [(j) => j.includes('parent { number }') && j.includes('number=3'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I3', parent: null } } } }) }],
+      [(j) => j.includes('addSubIssue'), { stdout: JSON.stringify({ data: { addSubIssue: { issue: { number: 5 } } } }) }],
+    ]);
+    const res = await runReparent(f.gh, 'dngioidev', 'forge', reparentArgs(['--issue', '5', '--parent', '3']), noop);
+    expect(res).toMatchObject({ ok: true, moved: true, from: 9, to: 3 });
+    expect(f.calls.some((c) => c.includes('replaceParent: true'))).toBe(true);
+  });
+
+  it('AC-87.3: no-op when already under the parent; refuses missing/self args', async () => {
+    const f = fakeGh([
+      [(j) => j.includes('parent { number }') && j.includes('number=5'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I5', parent: { number: 3 } } } } }) }],
+    ]);
+    expect(await runReparent(f.gh, 'o', 'r', reparentArgs(['--issue', '5', '--parent', '3']), noop)).toMatchObject({ ok: true, moved: false });
+    expect((await runReparent(f.gh, 'o', 'r', reparentArgs(['--issue', '5']), noop)).ok).toBe(false);
+    expect((await runReparent(f.gh, 'o', 'r', reparentArgs(['--issue', '5', '--parent', '5']), noop)).ok).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Board scripting: batch create + reparent (#87)

Closes #87 — iomanage friction (Issue 3).

- **`create.mjs --from tickets.json`** — creates a JSON array of ticket specs (same shape as the flags) in one invocation, reusing the existing idempotent create per entry, **continuing past a per-entry failure**, and returning `{created, skipped, failed, results}`. One command instead of N manually-sharded ones (run it in the background for big batches).
- **`board/reparent.mjs --issue <n> --parent <m>`** — moves a sub-issue to a new epic. `issues.mjs addSubIssue` gains `{replaceParent}` (default off = unchanged) so a child that already has a parent is moved, not rejected. Idempotent (no-op if already under the parent), refuses missing/self args.

### Verification
- ✅ AC-87.1 batch creates + continues past failure + summary; empty/non-array refused. AC-87.2 `replaceParent` only in the mutation when asked. AC-87.3 reparent moves via replaceParent, no-op when already parented, refuses bad args.
- ✅ 22/22 board tests; full suite green; testintent/depguard/acgate clean. Enhancement — no plan doc, plandrift N/A.
- ⚠️ NOT verified live against real GitHub (fake-gh unit level, like the rest of the board suite); the reparent mutation shape matches the existing `addSubIssue` path already used live by `create.mjs`.
