### PR TITLE
feat(board+doctor): seed Program type + plan-aware secret-scan (#89)

### DIFF
--- a/plugin/scripts/doctor.mjs
+++ b/plugin/scripts/doctor.mjs
@@ -14,6 +14,7 @@ import { getRepoInfo, getProjectFields } from './lib/board.mjs';
 const ok = (name, msg) => ({ name, level: 'ok', msg });
 const warn = (name, msg, hint) => ({ name, level: 'warn', msg, hint });
 const fail = (name, msg, hint) => ({ name, level: 'fail', msg, hint });
+const skip = (name, msg) => ({ name, level: 'skip', msg }); // not applicable — never a failure (#89)
 
 export async function runDoctor(ctx) {
   const { gh, cwd, log } = ctx;
@@ -147,12 +148,16 @@ export async function runDoctor(ctx) {
 
     const sec = await gh(['api', `repos/${repo.owner}/${repo.name}`], { parseJson: true });
     const sa = sec.ok ? sec.json.security_and_analysis : null;
+    const isPrivate = sec.ok && (sec.json.private === true || sec.json.visibility === 'private');
     if (sa?.secret_scanning?.status === 'enabled') results.push(ok('secret-scanning', 'enabled'));
+    // private repos without GitHub Advanced Security can't offer secret scanning — that's a plan
+    // limitation, not a misconfiguration, so don't nag (#89).
+    else if (isPrivate && !sa?.secret_scanning) results.push(skip('secret-scanning', 'n/a on this plan — needs a public repo or GitHub Advanced Security'));
     else results.push(warn('secret-scanning', 'secret scanning not enabled', 'enable secret scanning + push protection in repo settings (spec §13)'));
   }
 
   const failed = results.filter((r) => r.level === 'fail');
-  const icon = { ok: '✓', warn: '⚠', fail: '✗' };
+  const icon = { ok: '✓', warn: '⚠', fail: '✗', skip: '·' };
   for (const r of results) {
     log(`${icon[r.level]} ${r.name.padEnd(18)} ${r.msg}${r.hint ? `  → ${r.hint}` : ''}`);
   }

--- a/plugin/scripts/lib/board.mjs
+++ b/plugin/scripts/lib/board.mjs
@@ -28,6 +28,7 @@ export const STANDARD_FIELDS = {
     { key: 'xl', name: 'XL', color: 'RED' },
   ],
   type: [
+    { key: 'program', name: 'Program', color: 'GRAY' }, // a tracker above epics (#89 — iomanage feedback)
     { key: 'epic', name: 'Epic', color: 'PURPLE' },
     { key: 'item', name: 'Item', color: 'BLUE' },
     { key: 'bug', name: 'Bug', color: 'RED' },

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -88,6 +88,25 @@ describe('runDoctor — failure classes (AC-1.4)', () => {
     expect(byName(res, 'branch-protection')[0].level).toBe('warn');
     expect(byName(res, 'secret-scanning')[0].level).toBe('warn');
   });
+
+  it('AC-89.2: private repo without secret scanning available → skip (n/a), not warn', async () => {
+    const cwd = await tmpCwd();
+    await writeFile(join(cwd, '.gitignore'), '.forge/\n', 'utf8');
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      [(j) => j.startsWith('api repos/') && j.includes('/protection'), { ok: false, stderr: '404' }],
+      // private repo, no secret_scanning offered (free plan, no GHAS)
+      [(j) => j.startsWith('api repos/'), { stdout: JSON.stringify({ private: true, security_and_analysis: {} }) }],
+      [() => true, { ok: false, stderr: 'x' }],
+    ]);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    const ss = byName(res, 'secret-scanning')[0];
+    expect(ss.level).toBe('skip');
+    expect(ss.msg).toMatch(/n\/a on this plan/);
+    // skip is never a failure — secret-scanning must not appear among failed checks
+    expect(res.results.filter((r) => r.level === 'fail').map((r) => r.name)).not.toContain('secret-scanning');
+  });
 });
 
 describe('runDoctor — healthy repo shape', () => {

--- a/tests/lib/board.test.mjs
+++ b/tests/lib/board.test.mjs
@@ -51,6 +51,17 @@ describe('replaceStatusOptions mutation shape (AC-B4.1, #35)', () => {
   });
 });
 
+describe('Program type seeded (AC-89.1, #89)', () => {
+  it('AC-89.1: STANDARD_FIELDS.type includes program as a first-class tracker type', async () => {
+    const { STANDARD_FIELDS } = await import('../../plugin/scripts/lib/board.mjs');
+    const keys = STANDARD_FIELDS.type.map((o) => o.key);
+    expect(keys).toContain('program');
+    expect(keys).toEqual(expect.arrayContaining(['program', 'epic', 'item', 'bug', 'test']));
+    const program = STANDARD_FIELDS.type.find((o) => o.key === 'program');
+    expect(program.name).toBe('Program'); // the name a fresh init seeds as a single-select option
+  });
+});
+
 describe('createSingleSelectField mutation shape (AC-B11.1, #55)', () => {
   it('AC-B11.1: inline literals, bare enum colors, no -F variables', async () => {
     const { buildCreateFieldMutation, createSingleSelectField, STANDARD_FIELDS } = await import('../../plugin/scripts/lib/board.mjs');


### PR DESCRIPTION
## board + doctor: Program type + plan-aware secret-scan (#89)

Closes #89 — two iomanage friction items.

1. **`program` type seeded** — `STANDARD_FIELDS.type` gains a `Program` tracker option so fresh inits get it (a project-tracker parent shouldn't be `type: epic`). ADR-0001 holds: only fresh creates seed it; adopted boards map as-is.
2. **doctor secret-scan is plan-aware** — a private repo where secret scanning isn't offered (no `security_and_analysis.secret_scanning`) now reports **`n/a on this plan`** at a new `skip` level (`·`) instead of a permanent ⚠. Public repos / GHAS-disabled still warn (they can enable it). `skip` never counts as a failure.

### Verification
- ✅ AC-89.1 `program` in the type seed; AC-89.2 private-no-SS → skip, not warn, and not a failure; existing "disabled → warn" case unchanged.
- ✅ Full suite green; testintent/depguard/acgate clean. Enhancement — no plan doc, plandrift N/A.
- ℹ️ The Program type reaches an existing board only on a fresh init; board #8 (and other live boards) keep their current types per ADR-0001 — add Program via the UI there if wanted.
