### PR TITLE
docs(control): adopt Option 2 — console/control ship as repo tooling (#91)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 ## Decisions (ADRs)
 
 - [ADR-0001 — Status field options](decisions/0001-status-field-options.md) — built-in Status options are GraphQL-mutable but replacement mints new IDs; init replaces on fresh (empty) projects only, maps-as-is on live boards.
+- [ADR-0002 — Console/control distribution](decisions/0002-console-control-distribution.md) — the console + control plane ship as repo tooling run from a checkout, not in the packaged plugin; it's a machine-global operator tool, not a per-project artifact (#91).
 
 ## Guides
 

--- a/docs/decisions/0002-console-control-distribution.md
+++ b/docs/decisions/0002-console-control-distribution.md
@@ -1,0 +1,29 @@
+# ADR-0002 — The console + control plane ship as repo tooling, not in the plugin
+
+**Date:** 2026-07-19 · **Status:** accepted · **Ticket:** #91 (iomanage feedback)
+
+## Context
+
+forge is distributed as a Claude Code plugin: `.claude-plugin/marketplace.json` declares `source: ./plugin`, so **only `plugin/` is packaged** and delivered via `/plugin update`. The forge-control console and control plane live in top-level `console/` and `control/` directories — siblings of `plugin/` — so they are **not** in the installed plugin. A downstream user (iomanage) hit this: on the installed plugin they could not reach the console control at all.
+
+Three options were weighed (#91):
+
+1. **Move `console/` + `control/` under `plugin/`** so they ship. Makes the control plane a first-class plugin feature, at the cost of a broad import-path refactor (both dirs import `../../plugin/scripts/lib/*`; all their tests import `../../console|control/*`).
+2. **Keep them as repo tooling; document the checkout path as intended.**
+3. **Bootstrap helper** — a plugin command that clones/points at a forge checkout and launches the console.
+
+## Decision
+
+**Option 2.** The console + control plane are **repo-level operator tooling**, run from a forge checkout. This is deliberate, not a temporary gap:
+
+- The control plane is **machine-global** — it watches *many* repos (via `~/.forge/daemon.json`) and spawns headless sessions on the host. That is an operator/orchestration tool for the machine, not an artifact scoped to one project's plugin install.
+- Packaging it into a per-project plugin would put a session-spawning daemon into every consumer's `~/.claude/plugins/` cache, which is a larger surface than the feature warrants.
+- The pipeline plugin (skills, agents, board automation, hooks, gates) is what belongs in `/plugin update`; the control plane is cloned and run.
+
+## Consequences
+
+- Plugin users reach the console control by cloning forge and running `node console/daemon.mjs serve` — documented in [the console-control guide](../guides/console-control.md).
+- `console/`/`control/` keep their current layout and import paths; no refactor.
+- **Revisit if:** the control plane is later deemed a first-class *plugin* feature (→ Option 1), or checkout friction proves painful in practice (→ Option 3, a bootstrap launcher — the checkout stays the source of truth either way).
+
+Option 3 (a one-command bootstrap launcher) remains an open ergonomic follow-up, not a blocker.

--- a/docs/guides/console-control.md
+++ b/docs/guides/console-control.md
@@ -5,12 +5,13 @@ running agent sessions, the audit trail, alerts, quota, and a per-repo work trac
 badge — plus buttons to pause, resume, and kill work. It's how you *see and steer* the agents
 running on your machine.
 
-> **Read this first — where it lives.** The console and control plane are **repo-level tooling**
-> (`console/` and `control/` in the forge repo). They are **not packaged in the installed plugin**
-> today, and the plugin is still tagged **0.3.0** (the C1–C8 control-plane work is merged to `main`
-> but unreleased). So you run the console control **from a forge checkout**, not from
-> `~/.claude/plugins/…`. Until a release packages them, `/plugin update` will not give you these
-> features. See [Limits & status](#limits--status).
+> **Read this first — where it lives.** The console and control plane are **repo-level operator
+> tooling** (`console/` and `control/` in the forge repo), run from a **forge checkout** — not from
+> the installed plugin (`~/.claude/plugins/…`). This is **by design**, not a gap: the control plane
+> is a machine-global tool that watches many repos and spawns sessions, so it isn't a per-project
+> plugin artifact ([ADR-0002](../decisions/0002-console-control-distribution.md)). `/plugin update`
+> maintains the pipeline plugin; the console control you clone and run. See
+> [Distribution model](#distribution-model).
 
 ---
 
@@ -150,12 +151,13 @@ Clearing the switch is **always a human action** (`resume`, or delete the file) 
 
 ---
 
-## 8. Limits & status
+## 8. Distribution model
 
-- **Not in the plugin yet.** `console/` + `control/` ship as repo tooling, not in the packaged
-  plugin, and no release since 0.3.0 includes the C1–C8 work. To use the console control you need a
-  forge **checkout**. Packaging them (and cutting a release) is the follow-up that makes
-  `/plugin update` deliver this.
+- **Run from a checkout, by design.** `console/` + `control/` are repo-level operator tooling, not
+  part of the packaged plugin — a deliberate choice ([ADR-0002](../decisions/0002-console-control-distribution.md)):
+  the control plane is machine-global (it watches many repos and spawns sessions), so it isn't a
+  per-project plugin artifact. The pipeline plugin you install/update; the console control you clone
+  and run. A one-command bootstrap launcher may come later, but the checkout stays the source of truth.
 - **Best-effort-loud, not push.** Alerts/toast require the console open or the toast enabled; there
   is no phone push without Firebase.
 - **Quota is as fresh as your last status-line refresh**, and cost-per-day is approximate (derived


### PR DESCRIPTION
## Adopt Option 2 — console/control ship as repo tooling (#91)

Closes #91. Owner chose **Option 2**: the console + control plane are repo-level operator tooling run from a forge checkout, **not** packaged in the plugin — a machine-global tool (it watches many repos + spawns sessions) isn't a per-project plugin artifact.

- **ADR-0002** records the decision, the three options weighed, and the revisit conditions.
- **console-control guide** reframed: the "Read this first" callout and §8 now present the checkout model as *intentional* (not a temporary gap), drop the stale `0.3.0` note (v0.4.0 is out), and link the ADR. A one-command bootstrap launcher is noted as an open ergonomic follow-up.
- Linked ADR-0002 from the docs index.

### Verification
- ✅ Docs-only; full suite unaffected; testintent clean. No plan doc (decision ticket) → plandrift/acgate N/A.
