### PR TITLE
fix(test): deriveSituation machine-state independence via FORGE_CONTROL_BASE (#93)

### DIFF
--- a/control/control.mjs
+++ b/control/control.mjs
@@ -22,7 +22,9 @@ import * as machine from './lib/machine.mjs';
 
 export const ALLOWED_VERBS = ['enqueue', 'dequeue', 'list', 'status', 'pause', 'resume', 'kill', 'kill-all'];
 
-export const defaultBase = (home = homedir()) => join(home, '.forge', 'control');
+// FORGE_CONTROL_BASE overrides the base (relocate it; tests point it at a clean dir — #93).
+// Kept independent of situation.mjs's controlBase() by design (no plugin↔control import).
+export const defaultBase = (home = homedir()) => process.env.FORGE_CONTROL_BASE || join(home, '.forge', 'control');
 
 export function parseArgs(argv) {
   const a = { verb: argv[0] ?? null, repo: null, ticket: null, brief: '', id: null, reason: '', by: 'owner' };

--- a/plugin/scripts/lib/situation.mjs
+++ b/plugin/scripts/lib/situation.mjs
@@ -18,8 +18,12 @@ export const SITUATIONS = {
   idle: { glyph: '·', label: 'idle' },
 };
 
-/** Default forge-control base — the same path C1's control plane writes to. */
-export const controlBase = (home = homedir()) => join(home, '.forge', 'control');
+/**
+ * Default forge-control base — the same path C1's control plane writes to.
+ * `FORGE_CONTROL_BASE` overrides it (relocates the base; and lets tests point at a
+ * clean dir so they don't read the real machine kill switch — #93).
+ */
+export const controlBase = (home = homedir()) => process.env.FORGE_CONTROL_BASE || join(home, '.forge', 'control');
 
 /**
  * The C1 machine kill switch: `<base>/paused` present = engaged (#68). Read

--- a/tests/control/control.test.mjs
+++ b/tests/control/control.test.mjs
@@ -107,7 +107,13 @@ describe('control CLI allowlist + audit (AC-C1.4)', () => {
     expect((await runControl(b, parseArgs(['dequeue']), noop)).ok).toBe(false); // needs --id
   });
 
-  it('defaultBase lives under ~/.forge/control', () => {
-    expect(defaultBase('/home/u')).toBe(join('/home/u', '.forge', 'control'));
+  it('defaultBase lives under ~/.forge/control, FORGE_CONTROL_BASE overrides (#93)', () => {
+    const saved = process.env.FORGE_CONTROL_BASE;
+    try {
+      delete process.env.FORGE_CONTROL_BASE;
+      expect(defaultBase('/home/u')).toBe(join('/home/u', '.forge', 'control'));
+      process.env.FORGE_CONTROL_BASE = '/custom/control';
+      expect(defaultBase('/home/u')).toBe('/custom/control');
+    } finally { if (saved === undefined) delete process.env.FORGE_CONTROL_BASE; else process.env.FORGE_CONTROL_BASE = saved; }
   });
 });

--- a/tests/lib/situation.test.mjs
+++ b/tests/lib/situation.test.mjs
@@ -3,7 +3,27 @@ import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { append } from '../../plugin/scripts/lib/journal.mjs';
-import { deriveSituation, pendingDecisions } from '../../plugin/scripts/lib/situation.mjs';
+import { deriveSituation, pendingDecisions, controlBase, machinePaused } from '../../plugin/scripts/lib/situation.mjs';
+
+describe('control base is env-overridable (AC-93.1, AC-93.2, #93)', () => {
+  it('AC-93.1: controlBase() honors FORGE_CONTROL_BASE, else ~/.forge/control', () => {
+    const saved = process.env.FORGE_CONTROL_BASE;
+    try {
+      process.env.FORGE_CONTROL_BASE = '/custom/control';
+      expect(controlBase()).toBe('/custom/control');
+      delete process.env.FORGE_CONTROL_BASE;
+      expect(controlBase('/home/u')).toBe(join('/home/u', '.forge', 'control'));
+    } finally { if (saved === undefined) delete process.env.FORGE_CONTROL_BASE; else process.env.FORGE_CONTROL_BASE = saved; }
+  });
+
+  it('AC-93.2: with the base pointed at a clean dir, situation is machine-state-independent', async () => {
+    // vitest already sets FORGE_CONTROL_BASE to a clean temp dir → no paused file there,
+    // so these do NOT read the real machine kill switch regardless of its state.
+    expect(await machinePaused(controlBase())).toBe(false);
+    expect((await deriveSituation(await tmp(), { blocked: 0, inProgress: 0 })).key).toBe('idle');
+    expect((await deriveSituation(await tmp(), { blocked: 0, inProgress: 2 })).key).toBe('building');
+  });
+});
 
 async function tmp() {
   return mkdtemp(join(tmpdir(), 'forge-sit-'));

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,8 +1,15 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     include: ['tests/**/*.test.mjs'],
     watch: false,
+    // Point the forge-control base at a clean temp dir so tests never read the real
+    // machine kill switch (~/.forge/control/paused) — otherwise an engaged pause makes
+    // deriveSituation-based tests fail locally while CI (clean machines) passes (#93).
+    // Tests that exercise paused inject their own base and are unaffected.
+    env: { FORGE_CONTROL_BASE: join(tmpdir(), 'forge-vitest-no-control') },
   },
 });


### PR DESCRIPTION
## Fix: deriveSituation machine-state independence (#93)

Closes #93. C4 latent bug surfaced this session: `deriveSituation` (via `machinePaused`) reads the real `~/.forge/control/paused` by default, so a developer whose machine has the kill switch engaged sees **8 local tests fail** (situation/status/incident/collectors/serve) while CI — always a clean machine — stays green. A stale `paused` from dogfooding did exactly this.

### Fix
`controlBase()` (situation.mjs) and `defaultBase()` (control.mjs) now honor a **`FORGE_CONTROL_BASE`** env override — kept independent (no plugin↔control import) — and `vitest.config.mjs` points it at a clean temp dir so tests never touch the real switch. Production is unchanged (env unset → real `~/.forge/control`); the env doubles as a legit way to relocate the control base.

### Verification
- ✅ AC-93.1 override resolves; AC-93.2 situation is machine-state-independent.
- ✅ **Full suite 353/353 green with a real `paused` file planted** (before this fix that produced 8 failures). testintent/depguard/acgate clean. Bug — no plan doc, plandrift N/A.
