### PR TITLE
feat(agents): pin each role to a right-sized model (#101)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "forge",
   "version": "0.5.0",
-  "description": "AI dev platform: pipeline skills, agent roster with pluggable backends, GitHub Projects board automation, learning loop, graph RAG",
+  "description": "AI dev platform: pipeline skills, Claude-native agent roster, GitHub Projects board automation, learning loop, graph RAG",
   "author": {
     "name": "dngioi.dev"
   },

--- a/plugin/agents/design-reviewer.md
+++ b/plugin/agents/design-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: design-reviewer
 description: Validate a UI implementation against its committed visual spec — token-only styling, the a11y contract, stories present, spec match. Sections, not vibes.
+model: sonnet
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/plugin/agents/designer.md
+++ b/plugin/agents/designer.md
@@ -1,6 +1,7 @@
 ---
 name: designer
 description: Generate token-grounded, a11y-first mockup variants for a UI ticket (`forge:design`). The human picks; the chosen variant graduates to the visual spec.
+model: sonnet
 ---
 
 <!-- generated from plugin/cards/designer.md by scripts/backends/compile.mjs — edit the card, not this file -->

--- a/plugin/agents/devops.md
+++ b/plugin/agents/devops.md
@@ -1,6 +1,7 @@
 ---
 name: devops
 description: Own the deploy layer: Dockerfile/compose/Terraform, CI deploy jobs, infra diff review, `terraform plan`. Keep every repo production-deployable at all times (spec §10).
+model: sonnet
 ---
 
 <!-- generated from plugin/cards/devops.md by scripts/backends/compile.mjs — edit the card, not this file -->

--- a/plugin/agents/implementer.md
+++ b/plugin/agents/implementer.md
@@ -1,6 +1,7 @@
 ---
 name: implementer
 description: Make one plan task's failing tests pass — smallest correct change, repo conventions, nothing beyond the task.
+model: sonnet
 ---
 
 <!-- generated from plugin/cards/implementer.md by scripts/backends/compile.mjs — edit the card, not this file -->

--- a/plugin/agents/investigator.md
+++ b/plugin/agents/investigator.md
@@ -1,6 +1,7 @@
 ---
 name: investigator
 description: Cheap read-only fan-out: locate code, trace call paths, answer "where does X happen" — fast, factual, no judgment calls.
+model: haiku
 tools: Read, Grep, Glob
 ---
 

--- a/plugin/agents/librarian.md
+++ b/plugin/agents/librarian.md
@@ -1,6 +1,7 @@
 ---
 name: librarian
 description: Answer "does X already exist?" before anything new is written — reuse-first lookup over the repo's components, helpers, and patterns.
+model: haiku
 tools: Read, Grep, Glob
 ---
 

--- a/plugin/agents/reviewer.md
+++ b/plugin/agents/reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: reviewer
 description: Find what's wrong with a diff — correctness first, then simplification and efficiency — with severity-tagged, actionable findings.
+model: sonnet
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/plugin/agents/scoper.md
+++ b/plugin/agents/scoper.md
@@ -1,6 +1,7 @@
 ---
 name: scoper
 description: Ticket impact analysis before work starts: which components/files are touched, which tests must run, how far the blast radius reaches.
+model: sonnet
 tools: Read, Grep, Glob
 ---
 

--- a/plugin/agents/second-opinion.md
+++ b/plugin/agents/second-opinion.md
@@ -1,6 +1,7 @@
 ---
 name: second-opinion
 description: Independent second-pass critique of a spec, plan, or diff — a different model's eyes, on demand. Advisory only, never a merge gate.
+model: opus
 tools: Read, Grep, Glob
 ---
 

--- a/plugin/agents/security.md
+++ b/plugin/agents/security.md
@@ -1,6 +1,7 @@
 ---
 name: security
 description: Adversarial pass over a branch: assume the diff is hostile until proven otherwise. Injection, secrets, supply chain, CI/hook attack surface.
+model: sonnet
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/plugin/agents/test-architect.md
+++ b/plugin/agents/test-architect.md
@@ -1,6 +1,7 @@
 ---
 name: test-architect
 description: Turn acceptance criteria into a test plan and failing tests — before implementation exists. Own test *intent*; the AC gate verifies it mechanically at ship.
+model: sonnet
 ---
 
 <!-- generated from plugin/cards/test-architect.md by scripts/backends/compile.mjs — edit the card, not this file -->

--- a/plugin/scripts/backends/compile.mjs
+++ b/plugin/scripts/backends/compile.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
- * Compile backend-neutral role cards → Claude-native subagent definitions
- * (spec §5). Agents carry NO model pin — the orchestrator passes the model at
- * spawn time from the roster. Read-only roles get read-only tool allowlists.
+ * Compile role cards → Claude-native subagent definitions (spec §5). Each agent
+ * carries an explicit `model:` pin sized to its job (MODELS below) so subagents
+ * never inherit the session's model by default. Read-only roles also get
+ * read-only tool allowlists.
  */
 import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join, dirname, resolve, basename } from 'node:path';
@@ -17,6 +18,26 @@ export const ROLES = [
   'implementer', 'reviewer', 'security', 'design-reviewer', 'scoper',
   'test-architect', 'devops', 'designer', 'investigator', 'librarian', 'second-opinion',
 ];
+
+/**
+ * Per-role model pin (#101) — "enough to do, not too generous":
+ *   haiku  — pure search/lookup, safe to be cheap
+ *   sonnet — reasoning + writing, and the review/security gates (don't skimp on the safety net)
+ *   opus   — only second-opinion: its whole value is stronger independent eyes, and it's on-demand
+ */
+export const MODELS = {
+  investigator: 'haiku',
+  librarian: 'haiku',
+  reviewer: 'sonnet',
+  security: 'sonnet',
+  scoper: 'sonnet',
+  'test-architect': 'sonnet',
+  implementer: 'sonnet',
+  designer: 'sonnet',
+  'design-reviewer': 'sonnet',
+  devops: 'sonnet',
+  'second-opinion': 'opus',
+};
 
 /** Read-only roles (spec §13 blast-radius control). Reviewer-shaped roles get Bash for diffs/tests. */
 const TOOLS = {
@@ -33,8 +54,9 @@ const TOOLS = {
 export function compileCard(role, cardBody) {
   const missionMatch = /## Mission\r?\n(.+?)(?:\r?\n)/s.exec(cardBody);
   const description = (missionMatch?.[1] ?? role).trim();
+  const model = MODELS[role] ? `\nmodel: ${MODELS[role]}` : '';
   const tools = TOOLS[role] ? `\ntools: ${TOOLS[role]}` : '';
-  return `---\nname: ${role}\ndescription: ${description}${tools}\n---\n\n<!-- generated from plugin/cards/${role}.md by scripts/backends/compile.mjs — edit the card, not this file -->\n\n${cardBody}`;
+  return `---\nname: ${role}\ndescription: ${description}${model}${tools}\n---\n\n<!-- generated from plugin/cards/${role}.md by scripts/backends/compile.mjs — edit the card, not this file -->\n\n${cardBody}`;
 }
 
 export async function compileAll({ cardsDir = CARDS_DIR, agentsDir = AGENTS_DIR } = {}) {

--- a/tests/backends/cards.test.mjs
+++ b/tests/backends/cards.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readdir, readFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
-import { CARDS_DIR, AGENTS_DIR, compileCard, ROLES } from '../../plugin/scripts/backends/compile.mjs';
+import { CARDS_DIR, AGENTS_DIR, compileCard, ROLES, MODELS } from '../../plugin/scripts/backends/compile.mjs';
 
 describe('role cards (AC-4.1)', () => {
   it('all 11 roles have a card and only those', async () => {
@@ -36,10 +36,16 @@ describe('role cards (AC-4.1)', () => {
     }
   });
 
-  it('compiled agents carry no model pin; read-only roles carry tool allowlists', async () => {
+  it('AC-101.1: every role pins a right-sized model; read-only roles carry tool allowlists', async () => {
+    // "enough to do, not too generous": lookup on haiku, gates/writing on sonnet, only second-opinion on opus.
+    expect(MODELS.investigator).toBe('haiku');
+    expect(MODELS.librarian).toBe('haiku');
+    expect(MODELS.reviewer).toBe('sonnet');   // the security net — not skimped to a cheaper tier
+    expect(MODELS.security).toBe('sonnet');
+    expect(MODELS['second-opinion']).toBe('opus');
     for (const role of ROLES) {
       const agent = await readFile(join(AGENTS_DIR, `${role}.md`), 'utf8');
-      expect(agent).not.toMatch(/^model:/m);
+      expect(agent, `${role} missing its model pin`).toMatch(new RegExp(`^model: ${MODELS[role]}$`, 'm'));
     }
     const librarian = await readFile(join(AGENTS_DIR, 'librarian.md'), 'utf8');
     expect(librarian).toMatch(/^tools: Read, Grep, Glob$/m);


### PR DESCRIPTION
Pins each compiled agent to a right-sized `model:` in frontmatter, so subagents stop inheriting the session default (Opus) after the roster was removed in #99. Closes #101.

## Mapping — "enough to do, not too generous"
| tier | roles | why |
|---|---|---|
| `haiku` | investigator, librarian | pure search/lookup, safe to be cheap |
| `sonnet` | reviewer, security, scoper, test-architect, implementer, designer, design-reviewer, devops | reasoning + writing; the review/security gates are **not** skimped to a cheaper tier |
| `opus` | second-opinion | its whole value is stronger independent eyes, and it's on-demand/rare |

Corrects the old inert `DEFAULTS`, which pinned reviewer/security to `fable` — a guess carried forward without scrutiny. Those are the catch-the-problem gates, so they get a tier whose capability is known-sharp.

## Changes
- `compile.mjs`: `MODELS` map + emit `model:` into frontmatter; recompiled all 11 agents
- `cards.test.mjs`: assertion flipped from "no model pin" to "each role carries its expected pin" (AC-101.1)
- `plugin/.claude-plugin/plugin.json`: dropped the stale "pluggable backends" phrase from the description (leftover from #99)

## Verification
- `npx vitest run` → **233 passed**; compile freshness gate green (recompiled, no diff)
- `doctor` → healthy
- Spot-checked frontmatter: security=sonnet, librarian=haiku, second-opinion=opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
