### PR TITLE
fix(board,ci): P0 consumer bugs — gitleaks perms + create.mjs flags (#103, #104)

### DIFF
--- a/plugin/scripts/board/create.mjs
+++ b/plugin/scripts/board/create.mjs
@@ -15,13 +15,18 @@ export function withDefaults(spec = {}) {
   return { title: null, body: '', type: 'item', priority: 'p1', size: 'm', status: 'backlog', parent: null, assignee: null, ...spec };
 }
 
+const KNOWN_FLAGS = '--title --body --body-file --type --priority --size --status --parent --assignee --from';
+
 export function parseArgs(argv) {
   const a = withDefaults();
   a.from = null;
+  a.bodyFile = null;
+  a.unknownFlags = [];
   for (let i = 0; i < argv.length; i++) {
     const k = argv[i];
     if (k === '--title') a.title = argv[++i];
     else if (k === '--body') a.body = argv[++i];
+    else if (k === '--body-file') a.bodyFile = argv[++i];
     else if (k === '--type') a.type = argv[++i];
     else if (k === '--priority') a.priority = argv[++i];
     else if (k === '--size') a.size = argv[++i];
@@ -29,6 +34,7 @@ export function parseArgs(argv) {
     else if (k === '--parent') a.parent = Number(argv[++i]);
     else if (k === '--assignee') a.assignee = argv[++i];
     else if (k === '--from') a.from = argv[++i];
+    else a.unknownFlags.push(k); // #104: never silently drop — a swallowed --body-file made empty-body tickets
   }
   return a;
 }
@@ -55,6 +61,15 @@ export async function runCreateBatch(ctx, specs, log = console.log) {
 }
 
 export async function runCreate(ctx, args, log = console.log) {
+  // #104: fail-fast on unrecognized flags rather than dropping them silently.
+  if (args.unknownFlags?.length) {
+    return { ok: false, error: `unrecognized flag(s): ${args.unknownFlags.join(', ')} — supported: ${KNOWN_FLAGS}` };
+  }
+  // #104: --body-file reads the body from a file (the flag that used to be swallowed).
+  if (args.bodyFile) {
+    try { args = { ...args, body: await readFile(args.bodyFile, 'utf8') }; }
+    catch (e) { return { ok: false, error: `--body-file: cannot read ${args.bodyFile}: ${e.message}` }; }
+  }
   if (!args.title) return { ok: false, error: '--title is required' };
   // validate option keys up front so we fail before creating anything
   for (const [f, k] of [['type', args.type], ['priority', args.priority], ['size', args.size], ['status', args.status]]) {

--- a/plugin/templates/verify.yml
+++ b/plugin/templates/verify.yml
@@ -29,6 +29,11 @@ jobs:
 
   gitleaks:
     runs-on: ubuntu-latest
+    # gitleaks-action lists PR commits via the API — needs pull-requests: read,
+    # else the first PR of every repo 403s "Resource not accessible by integration".
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -106,6 +106,31 @@ describe('create (AC-2.1)', () => {
     expect(res.error).toContain('valid priority keys');
     expect(calls.some((c) => c.startsWith('issue'))).toBe(false);
   });
+
+  it('AC-104.1: unrecognized flags fail fast — never a silent empty-body ticket (#104)', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--bogus']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unrecognized flag/);
+    expect(res.error).toContain('--bogus');
+    expect(calls.some((c) => c.startsWith('issue'))).toBe(false); // created nothing
+  });
+
+  it('AC-104.2: --body-file loads the body from a file (#104)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-bodyfile-'));
+    const bf = join(dir, 'body.md');
+    await writeFile(bf, 'Body loaded from file, not empty.', 'utf8');
+    const { ctx, calls } = await ctxWith([
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: createdIssueUrl }],
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--body-file', bf]), noop);
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.includes('Body loaded from file, not empty.'))).toBe(true);
+  });
 });
 
 describe('batch create --from (AC-87.1, #87)', () => {

--- a/tests/ci-template.test.mjs
+++ b/tests/ci-template.test.mjs
@@ -36,6 +36,8 @@ describe('consumer CI template (AC-3.5)', () => {
     expect(wf).toContain('run: pnpm verify');
     expect(wf).not.toContain('{{VERIFY}}');
     expect(wf).toContain('gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7');
+    // #103: gitleaks job must grant pull-requests: read or it 403s on the first PR
+    expect(wf).toMatch(/gitleaks:[\s\S]*?permissions:[\s\S]*?pull-requests: read/);
   });
 
   it('init respects an existing verify workflow (no overwrite, any filename)', async () => {


### PR DESCRIPTION
Two P0 consumer bugs from the iomanage batch (docs/feedback/iomanage-feedback-forge-0.5.0.md). Closes #103, closes #104.

## #103 — gitleaks 403 on every repo's first PR
`verify.yml` set only top-level `contents: read`; `gitleaks-action` lists PR commits → `403 "Resource not accessible by integration"`. Added a job-level `permissions: { contents: read, pull-requests: read }` to the gitleaks job.

## #104 — create.mjs swallowed unknown flags → empty-body tickets
`parseArgs` silently dropped unrecognized flags, so a passed `--body-file` vanished and the ticket was created empty. Now:
- unrecognized flags **fail fast** with the flag named + the supported list (nothing is created)
- `--body-file <path>` is supported (reads the body from a file)

## Verification
- `npx vitest run` → **235 passed** (+2: AC-104.1 fail-fast, AC-104.2 body-file; + a gitleaks-permissions assertion)
- `doctor` healthy
- verify.yml YAML validated by actionlint in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
