### PR TITLE
fix(graph): MCP server re-reads features.graph per call (#105)

### DIFF
--- a/plugin/mcp/graph/server.mjs
+++ b/plugin/mcp/graph/server.mjs
@@ -121,17 +121,33 @@ export async function isGraphEnabled(root) {
   }
 }
 
+/**
+ * Per-call graph state (#105) — re-reads features.graph on every call so a
+ * toggle in forge.json (+ `graphctl rebuild`) takes effect without restarting
+ * the MCP process. The db is opened lazily on the first enabled call and
+ * memoized (no reopen per call); flipping the flag off closes and drops it.
+ */
+export function makeGraphState(root, { open = openDb, isEnabled = isGraphEnabled } = {}) {
+  let db = null;
+  return async function resolve() {
+    const enabled = await isEnabled(root);
+    if (enabled && !db) db = open(root);
+    else if (!enabled && db) { try { db.close?.(); } catch { /* ignore */ } db = null; }
+    return { enabled, db };
+  };
+}
+
 async function main() {
   const root = process.cwd();
-  const graphEnabled = await isGraphEnabled(root);
-  const db = graphEnabled ? openDb(root) : null;
-  const handle = makeHandler({ db, root, graphEnabled });
+  const state = makeGraphState(root);
   const rl = createInterface({ input: process.stdin, terminal: false });
-  rl.on('line', (line) => {
+  rl.on('line', async (line) => {
     if (!line.trim()) return;
     let msg;
     try { msg = JSON.parse(line); } catch { process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'parse error' } }) + '\n'); return; }
-    const res = handle(msg);
+    // Resolve enabled/db fresh per line so config changes need no restart.
+    const { enabled, db } = await state();
+    const res = makeHandler({ db, root, graphEnabled: enabled })(msg);
     if (res) process.stdout.write(JSON.stringify(res) + '\n');
   });
 }

--- a/tests/graph/graph.test.mjs
+++ b/tests/graph/graph.test.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { openDb, resetDb, upsertNode, upsertEdge, deleteFileScope, counts, NODE_KINDS } from '../../plugin/mcp/graph/db.mjs';
 import { rebuild, indexFiles, fileKind, loadTsMorph } from '../../plugin/mcp/graph/indexer.mjs';
 import { findComponent, whoUses, similarProps, blastRadius, codeForTicket, reuseCandidates } from '../../plugin/mcp/graph/queries.mjs';
-import { makeHandler, validateInput, canonicalize, TOOLS } from '../../plugin/mcp/graph/server.mjs';
+import { makeHandler, validateInput, canonicalize, TOOLS, makeGraphState } from '../../plugin/mcp/graph/server.mjs';
 import { parseTicketLog, scanTickets, installHook, HOOK_MARKER } from '../../plugin/scripts/graph/graphctl.mjs';
 import { runDoctor } from '../../plugin/scripts/doctor.mjs';
 import { fakeGh, REPO_VIEW, AUTH_OK } from '../helpers/fakegh.mjs';
@@ -112,6 +112,33 @@ describe('MCP stdio protocol (AC-8.3)', () => {
     const res = h({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'find_component', arguments: { query: 'x' } } });
     expect(res.result.isError).toBe(true);
     expect(res.result.content[0].text).toContain('features.graph is off');
+  });
+
+  it('AC-105.1: graph state re-reads features.graph per call — toggle needs no restart, db opened lazily + memoized', async () => {
+    let enabled = false;
+    const opened = [];
+    const open = () => { const db = { closed: false, close() { this.closed = true; } }; opened.push(db); return db; };
+    const state = makeGraphState(FIXTURE, { isEnabled: async () => enabled, open });
+
+    // off at startup: no db opened
+    expect(await state()).toMatchObject({ enabled: false, db: null });
+    expect(opened.length).toBe(0);
+
+    // flip on mid-session (as `graphctl rebuild` would): next call sees it, db opened lazily
+    enabled = true;
+    const s1 = await state();
+    expect(s1.enabled).toBe(true);
+    expect(s1.db).toBe(opened[0]);
+    expect(opened.length).toBe(1);
+
+    // memoized — a second enabled call reuses the same db, no reopen
+    expect((await state()).db).toBe(opened[0]);
+    expect(opened.length).toBe(1);
+
+    // flip off: db closed and dropped
+    enabled = false;
+    expect(await state()).toMatchObject({ enabled: false, db: null });
+    expect(opened[0].closed).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes the graph MCP server caching `features.graph` at startup (iomanage P1 #4). Closes #105.

## Problem
`server.mjs` resolved `features.graph` once in `main()` and passed it as a constant into `makeHandler`, opening the db once. Enabling the graph mid-session (`features.graph=true` + `graphctl rebuild`) still returned "graph is off" — `/reload-plugins` doesn't restart the MCP process, so a full app restart was required.

## Fix
- New `makeGraphState(root)`: re-reads `features.graph` on **every call**, opens the db **lazily** on the first enabled call and **memoizes** it (no reopen per call), and **closes + drops** it when the flag flips off.
- `main()` resolves `{ enabled, db }` fresh per input line and builds the (cheap) handler with it.
- `makeHandler` signature unchanged (`{ db, root, graphEnabled }`) — existing behavior/tests intact.

Now a toggle in `forge.json` takes effect on the next tool call, no restart.

## Verification
- `npx vitest run` → **236 passed** (+1: AC-105.1 — toggle flips result, lazy+memoized db, closed on disable)
- `doctor` healthy
- Config re-read is one local JSON read per call; graph calls aren't hot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
