### PR TITLE
fix(gates): plandrift bare-name resolve + acgate multi-results (#106, #107)

### DIFF
--- a/plugin/scripts/gates/acgate.mjs
+++ b/plugin/scripts/gates/acgate.mjs
@@ -4,7 +4,7 @@
  * runner's JSON output. Machine evidence only — role reports are never
  * consulted. Vitest JSON reporter format (v1).
  */
-import { readFile } from 'node:fs/promises';
+import { readFile, glob } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -37,14 +37,28 @@ export function checkAcCoverage(acIds, tests) {
 }
 
 export function parseArgs(argv) {
-  const a = { plan: null, ticket: null, results: null, acs: null };
+  const a = { plan: null, ticket: null, results: [], acs: null };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--plan') a.plan = argv[++i];
     else if (argv[i] === '--ticket') a.ticket = Number(argv[++i]);
-    else if (argv[i] === '--results') a.results = argv[++i];
+    else if (argv[i] === '--results') a.results.push(argv[++i]); // #107: repeatable; each value may be a glob
     else if (argv[i] === '--acs') a.acs = argv[++i];
   }
   return a;
+}
+
+/** Resolve --results paths (repeatable; each may be a glob) into a concrete file list, cwd-relative. */
+export async function resolveResultFiles(results, cwd = process.cwd()) {
+  const specs = Array.isArray(results) ? results : (results ? [results] : []);
+  const files = [];
+  for (const spec of specs) {
+    if (/[*?[]/.test(spec)) {
+      for await (const f of glob(spec, { cwd })) files.push(resolve(cwd, f));
+    } else {
+      files.push(resolve(cwd, spec));
+    }
+  }
+  return [...new Set(files)];
 }
 
 export async function runAcGate(args, log = console.log) {
@@ -53,10 +67,13 @@ export async function runAcGate(args, log = console.log) {
   else if (args.plan) acIds = extractAcIds(await readFile(args.plan, 'utf8'), args.ticket);
   else return { ok: false, error: 'need --acs "AC-7.1,…" or --plan <file> [--ticket N]' };
   if (acIds.length === 0) return { ok: false, error: 'no AC ids found — the plan must map ACs (AC-<ticket>.<n>) to tests' };
-  if (!args.results) return { ok: false, error: '--results <vitest-json-file> is required (run: vitest run --reporter=json --outputFile=<file>)' };
 
-  const json = JSON.parse(await readFile(args.results, 'utf8'));
-  const check = checkAcCoverage(acIds, flattenResults(json));
+  const files = await resolveResultFiles(args.results, args.cwd);
+  if (files.length === 0) return { ok: false, error: '--results <vitest-json-file> is required — repeatable, and each value may be a glob for monorepos (run: vitest run --reporter=json --outputFile=<file>)' };
+
+  const tests = [];
+  for (const f of files) tests.push(...flattenResults(JSON.parse(await readFile(f, 'utf8'))));
+  const check = checkAcCoverage(acIds, tests);
   for (const id of acIds) {
     const state = check.missing.includes(id) ? '✗ no test' : check.failing.includes(id) ? '✗ failing' : '✓';
     log(`${state.padEnd(10)} ${id}`);

--- a/plugin/scripts/gates/plandrift.mjs
+++ b/plugin/scripts/gates/plandrift.mjs
@@ -13,13 +13,25 @@ import { readJson } from '../lib/jsonfile.mjs';
 /** Always allowed: the artifacts every task legitimately produces. */
 export const DEFAULT_ALLOW = ['tests/', 'docs/', '.forge/', 'CHANGELOG.md', 'pnpm-lock.yaml', 'package-lock.json'];
 
-/** Pull file paths from every `**Files:**` line in the plan. */
+/**
+ * Pull file paths from every `**Files:**` line in the plan. Shorthand where a
+ * bare filename follows a full path on the same line (e.g.
+ * `packages/ui/src/Button.tsx, TextField.tsx`) resolves the bare name against
+ * the preceding path's directory (#106) — otherwise it read as off-plan.
+ */
 export function extractPlanFiles(planText) {
   const files = [];
   for (const m of (planText ?? '').matchAll(/\*\*Files:\*\*\s*(.+)$/gm)) {
+    let lastDir = null; // dir of the most recent path token on THIS line
     for (const raw of m[1].split(/[,\s]+/)) {
       const f = raw.replace(/[`()]/g, '').trim();
-      if (f && !f.startsWith('+')) files.push(f);
+      if (!f || f.startsWith('+')) continue;
+      if (f.includes('/')) {
+        files.push(f);
+        lastDir = f.endsWith('/') ? f.replace(/\/$/, '') : f.slice(0, f.lastIndexOf('/'));
+      } else {
+        files.push(lastDir ? `${lastDir}/${f}` : f);
+      }
     }
   }
   return [...new Set(files)];

--- a/tests/gates/acgate.test.mjs
+++ b/tests/gates/acgate.test.mjs
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { extractAcIds, flattenResults, checkAcCoverage } from '../../plugin/scripts/gates/acgate.mjs';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extractAcIds, flattenResults, checkAcCoverage, runAcGate } from '../../plugin/scripts/gates/acgate.mjs';
+
+const noop = () => {};
+const pass = (title) => ({ testResults: [{ assertionResults: [{ title, fullName: title, status: 'passed' }] }] });
 
 const RESULTS = {
   testResults: [
@@ -31,5 +37,23 @@ describe('ac gate (AC-5.2)', () => {
   it('a failing test with the id does not count as coverage even when another test passes without it', () => {
     const tests = flattenResults(RESULTS);
     expect(checkAcCoverage(['AC-7.2'], tests).ok).toBe(false);
+  });
+
+  it('AC-107.1: merges multiple --results files — an AC passing in any file counts (#107)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-acgate-'));
+    await writeFile(join(dir, 'a.json'), JSON.stringify(pass('AC-7.1: alpha')), 'utf8');
+    await writeFile(join(dir, 'b.json'), JSON.stringify(pass('AC-7.2: beta')), 'utf8');
+    const res = await runAcGate({ acs: 'AC-7.1,AC-7.2', results: [join(dir, 'a.json'), join(dir, 'b.json')] }, noop);
+    expect(res).toMatchObject({ ok: true, covered: 2 });
+  });
+
+  it('AC-107.2: --results accepts a glob for per-package result files (#107)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-acgate-'));
+    await mkdir(join(dir, 'p1'), { recursive: true });
+    await mkdir(join(dir, 'p2'), { recursive: true });
+    await writeFile(join(dir, 'p1', 'results.json'), JSON.stringify(pass('AC-7.1: alpha')), 'utf8');
+    await writeFile(join(dir, 'p2', 'results.json'), JSON.stringify(pass('AC-7.2: beta')), 'utf8');
+    const res = await runAcGate({ acs: 'AC-7.1,AC-7.2', results: ['*/results.json'], cwd: dir }, noop);
+    expect(res).toMatchObject({ ok: true, covered: 2 });
   });
 });

--- a/tests/gates/plandrift.test.mjs
+++ b/tests/gates/plandrift.test.mjs
@@ -14,6 +14,15 @@ describe('plan-drift gate (AC-5.3)', () => {
     expect(files).toContain('plugin/scripts/gates/');
   });
 
+  it('AC-106.1: a bare filename after a full path resolves to that dir (#106)', () => {
+    const plan = '**Files:** packages/ui/src/components/Button.tsx, TextField.tsx, Select.tsx\n**Files:** README.md';
+    const files = extractPlanFiles(plan);
+    expect(files).toContain('packages/ui/src/components/Button.tsx');
+    expect(files).toContain('packages/ui/src/components/TextField.tsx'); // resolved, not off-plan
+    expect(files).toContain('packages/ui/src/components/Select.tsx');
+    expect(files).toContain('README.md'); // top-level bare name (no preceding dir) stays as-is
+  });
+
   it('isAllowed: declared exact + dir prefixes + scope extras + default allow', () => {
     const declared = ['src/a.mjs', 'src/widgets/'];
     expect(isAllowed('src/a.mjs', declared, [], DEFAULT_ALLOW)).toBe(true);


### PR DESCRIPTION
Two P1 gate fixes from the iomanage batch. Closes #106, closes #107.

## #106 — plandrift false-positives on shorthand Files lines
Plans write `packages/ui/src/components/Button.tsx, TextField.tsx, …`; the bare names never matched the touched paths → mass off-plan false-positives (26 files in their #49), forcing a scope.json open. `extractPlanFiles` now resolves a bare filename against the directory of the nearest preceding full path on the same line. A truly top-level bare name (no preceding dir) stays as-is.

## #107 — acgate single results file, awkward for monorepos
Turborepo runs vitest per-package; results had to be hand-merged before acgate. `--results` is now **repeatable** and each value may be a **glob** (`'*/results.json'`); all matches are merged (an AC passing in any file counts). Single `--results` unchanged.

## Verification
- `npx vitest run` → **239 passed** (+3: AC-106.1, AC-107.1 merge, AC-107.2 glob)
- `doctor` healthy
- glob uses `node:fs/promises` `glob`, cwd-relative

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
