### PR TITLE
feat(board,init): board CLI ergonomics + .gitattributes (#108, #109)

### DIFF
--- a/plugin/scripts/board/comment.mjs
+++ b/plugin/scripts/board/comment.mjs
@@ -12,11 +12,13 @@ import { upsertMarkedComment } from '../lib/issues.mjs';
 export const PHASES = ['started', 'spec', 'plan', 'pr', 'gate-fail', 'escalation', 'ci-green', 'merged', 'note'];
 
 export function parseArgs(argv) {
-  const a = { issue: null, phase: null, body: null };
+  const a = { issue: null, phase: null, body: null, actor: null, session: null };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--issue') a.issue = Number(argv[++i]);
     else if (argv[i] === '--phase') a.phase = argv[++i];
     else if (argv[i] === '--body') a.body = argv[++i];
+    else if (argv[i] === '--actor') a.actor = argv[++i];
+    else if (argv[i] === '--session') a.session = argv[++i];
   }
   return a;
 }
@@ -26,7 +28,9 @@ export async function runComment(ctx, args, log = console.log) {
   if (!PHASES.includes(args.phase)) return { ok: false, error: `unknown phase '${args.phase}' — valid: ${PHASES.join(', ')}` };
   if (!args.body) return { ok: false, error: '--body is required' };
 
-  const content = `**forge trail** — ${args.body}`;
+  // #108: optional actor + session so a picked ticket records who + which session.
+  const meta = [args.actor && `by @${args.actor}`, args.session && `session \`${args.session}\``].filter(Boolean).join(' · ');
+  const content = `**forge trail** — ${args.body}${meta ? `\n\n<sub>${meta}</sub>` : ''}`;
   const res = await upsertMarkedComment(ctx.gh, ctx.owner, ctx.repo, args.issue, `trail:${args.phase}`, content);
   if (!res.ok) return res;
   log(`#${args.issue} trail:${args.phase} ${res.action}`);

--- a/plugin/scripts/board/move.mjs
+++ b/plugin/scripts/board/move.mjs
@@ -14,22 +14,28 @@ export function parseArgs(argv) {
   return a;
 }
 
+/** Accept kebab-case status aliases (in-progress, in-review) for the camelCase config keys (#108). */
+export function normalizeStatusKey(s) {
+  return String(s ?? '').replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
 export async function runMove(ctx, args, log = console.log) {
   if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
-  const opt = ctx.resolveOption('status', args.status ?? '');
+  const status = normalizeStatusKey(args.status);
+  const opt = ctx.resolveOption('status', status);
   if (!opt.ok) return { ok: false, error: opt.error };
 
   const found = await ctx.findItemByIssue(args.issue);
   if (!found.ok) return { ok: false, error: found.error };
   if (!found.item) return { ok: false, error: `issue #${args.issue} is not on board #${ctx.projectNumber} — run board create first` };
 
-  if (ctx.itemFieldKey(found.item, 'status') === args.status) {
-    log(`#${args.issue}: already ${args.status}`);
+  if (ctx.itemFieldKey(found.item, 'status') === status) {
+    log(`#${args.issue}: already ${status}`);
     return { ok: true, changed: false };
   }
-  const set = await ctx.setSelect(found.item.id, 'status', args.status);
+  const set = await ctx.setSelect(found.item.id, 'status', status);
   if (!set.ok) return set;
-  log(`#${args.issue}: status -> ${args.status}`);
+  log(`#${args.issue}: status -> ${status}`);
   return { ok: true, changed: true };
 }
 

--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -159,6 +159,18 @@ export async function runInit(ctx) {
     say('.gitignore: added .forge/');
   }
 
+  // 7b. .gitattributes — normalize line endings to LF (#109). On Windows, CRLF
+  // causes git "LF will be replaced by CRLF" churn and breaks tests that compare
+  // generated files byte-for-byte. No-clobber: only added when absent.
+  const gaPath = join(cwd, '.gitattributes');
+  let ga = '';
+  try { ga = await readFile(gaPath, 'utf8'); } catch { /* no .gitattributes yet */ }
+  if (!ga.split(/\r?\n/).some((l) => l.trim().startsWith('* text'))) {
+    const rule = '# forge: normalize line endings to LF (avoids CRLF churn + generated-file test breakage)\n* text=auto eol=lf\n';
+    await writeFile(gaPath, ga + (ga.endsWith('\n') || ga === '' ? '' : '\n') + rule, 'utf8');
+    say('.gitattributes: added LF normalization (* text=auto eol=lf)');
+  }
+
   // 7b. Consumer CI template (spec §6; lands with SP3): install when missing
   const wfDir = join(cwd, '.github', 'workflows');
   let hasVerify = false;

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -209,6 +209,16 @@ describe('move (AC-2.2)', () => {
     const missing = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'done']), noop);
     expect(missing.error).toContain('board create');
   });
+
+  it('AC-108.1: accepts kebab-case status aliases (in-progress -> inProgress) (#108)', async () => {
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_2', content: { number: 5 }, status: 'Ready' }])],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const moved = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'in-progress']), noop);
+    expect(moved).toMatchObject({ ok: true, changed: true }); // resolved to inProgress, not rejected as unknown
+    expect(calls.filter((c) => c.startsWith('project item-edit')).length).toBe(1);
+  });
 });
 
 describe('comment (AC-2.3)', () => {
@@ -227,6 +237,21 @@ describe('comment (AC-2.3)', () => {
     const second = await runComment(ctx, commentArgs(['--issue', '2', '--phase', 'pr', '--body', 'PR #9 updated']), noop);
     expect(second).toMatchObject({ ok: true, action: 'updated', id: 77 });
     expect(calls.filter((c) => c.startsWith('api -X PATCH')).length).toBe(1);
+  });
+
+  it('AC-108.2: --actor/--session embed a provenance footer (#108)', async () => {
+    let comments = [];
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('api repos/') && j.includes('/comments?'), () => ({ stdout: JSON.stringify(comments) })],
+      [(j) => j.startsWith('api repos/') && j.endsWith('/comments') === false && j.includes('-f'), () => {
+        comments = [{ id: 88, body: '<!-- forge:trail:started -->' }];
+        return { stdout: JSON.stringify({ id: 88 }) };
+      }],
+    ]);
+    const res = await runComment(ctx, commentArgs(['--issue', '3', '--phase', 'started', '--body', 'picked', '--actor', 'iomanage', '--session', 'sess-1']), noop);
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.includes('by @iomanage'))).toBe(true);
+    expect(calls.some((c) => c.includes('session'))).toBe(true);
   });
 
   it('rejects unknown phases', async () => {

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -87,6 +87,10 @@ describe('runInit — fresh bootstrap (AC-1.2)', () => {
 
     const gi = await readFile(join(cwd, '.gitignore'), 'utf8');
     expect(gi).toContain('.forge/');
+
+    // #109: init writes a .gitattributes normalizing line endings to LF
+    const ga = await readFile(join(cwd, '.gitattributes'), 'utf8');
+    expect(ga).toMatch(/^\* text=auto eol=lf$/m);
   });
 
   it('AC-B64.2: fresh create links the new board to the repo (#64)', async () => {


### PR DESCRIPTION
Final PR of the iomanage batch — P2 DX. Closes #108, closes #109.

## #108 — board CLI ergonomics
- **move.mjs**: accepts kebab-case status aliases (`in-progress` → `inProgress`, `in-review` → `inReview`).
- **comment.mjs**: `--actor` / `--session` embed a provenance footer so a picked ticket logs who + which session.

**Carved out to #114** (kept #108 to the clean, testable DX wins):
- "create sets Phase" (#13) — Phase isn't a forge standard field; needs optional custom single-select support.
- a `findItemByIssue` issue-side fallback for the `gh project item-list` index lag that's been failing the post-merge `move` (worked around this batch with a direct field mutation).

## #109 — .gitattributes
`forge:init` now writes `.gitattributes` with `* text=auto eol=lf` — avoids the Windows CRLF churn and generated-file test breakage iomanage hit. No-clobber.

## Verification
- `npx vitest run` → **241 passed** (+5: AC-108.1 kebab, AC-108.2 actor/session, #109 gitattributes, + the acgate/plandrift from PR3 already merged)
- `doctor` healthy
- Bonus real-world check: filing #114 via `--body-file` exercised the #104 fix — PowerShell word-split a `--body`, and fail-fast caught it instead of silently truncating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
