### PR TITLE
feat(board): findItemByIssue lag-fallback + optional Phase field (#114)

### DIFF
--- a/plugin/scripts/board/create.mjs
+++ b/plugin/scripts/board/create.mjs
@@ -12,10 +12,10 @@ import { getIssueNode, addSubIssue } from '../lib/issues.mjs';
 
 /** Defaults applied to a single ticket spec (flags or a --from JSON entry). */
 export function withDefaults(spec = {}) {
-  return { title: null, body: '', type: 'item', priority: 'p1', size: 'm', status: 'backlog', parent: null, assignee: null, ...spec };
+  return { title: null, body: '', type: 'item', priority: 'p1', size: 'm', status: 'backlog', phase: null, parent: null, assignee: null, ...spec };
 }
 
-const KNOWN_FLAGS = '--title --body --body-file --type --priority --size --status --parent --assignee --from';
+const KNOWN_FLAGS = '--title --body --body-file --type --priority --size --status --phase --parent --assignee --from';
 
 export function parseArgs(argv) {
   const a = withDefaults();
@@ -31,6 +31,7 @@ export function parseArgs(argv) {
     else if (k === '--priority') a.priority = argv[++i];
     else if (k === '--size') a.size = argv[++i];
     else if (k === '--status') a.status = argv[++i];
+    else if (k === '--phase') a.phase = argv[++i];
     else if (k === '--parent') a.parent = Number(argv[++i]);
     else if (k === '--assignee') a.assignee = argv[++i];
     else if (k === '--from') a.from = argv[++i];
@@ -74,6 +75,12 @@ export async function runCreate(ctx, args, log = console.log) {
   // validate option keys up front so we fail before creating anything
   for (const [f, k] of [['type', args.type], ['priority', args.priority], ['size', args.size], ['status', args.status]]) {
     const r = ctx.resolveOption(f, k);
+    if (!r.ok) return { ok: false, error: r.error };
+  }
+  // #114: optional Phase, only when the consumer configured a Phase field
+  if (args.phase != null) {
+    if (!ctx.fields.phase) return { ok: false, error: '--phase given but no Phase field is configured — forge:init maps it when the project has a "Phase" single-select' };
+    const r = ctx.resolveOption('phase', args.phase);
     if (!r.ok) return { ok: false, error: r.error };
   }
 
@@ -130,7 +137,9 @@ export async function runCreate(ctx, args, log = console.log) {
   }
 
   // 4. fields — set only what differs (resume-friendly)
-  for (const [fieldKey, wanted] of [['type', args.type], ['priority', args.priority], ['size', args.size], ['status', args.status]]) {
+  const fieldSets = [['type', args.type], ['priority', args.priority], ['size', args.size], ['status', args.status]];
+  if (args.phase != null) fieldSets.push(['phase', args.phase]);
+  for (const [fieldKey, wanted] of fieldSets) {
     const current = existing.item ? ctx.itemFieldKey(existing.item, fieldKey) : null;
     if (current === wanted) continue;
     const set = await ctx.setSelect(itemId, fieldKey, wanted);

--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -124,15 +124,22 @@ export async function runInit(ctx) {
   }
 
   // 6. Write forge.json (merge — never clobber consumer customizations)
+  const fields = {
+    status: toConfigField(pf.fields['status']),
+    priority: toConfigField(pf.fields['priority']),
+    size: toConfigField(pf.fields['size']),
+    type: toConfigField(pf.fields['type']),
+  };
+  // #114: map an optional consumer-defined Phase single-select when present
+  // (forge never creates it — it's opt-in roadmap tracking).
+  if (pf.fields['phase']) {
+    fields.phase = toConfigField(pf.fields['phase']);
+    say('fields: mapped optional Phase field');
+  }
   const board = {
     projectNumber: project.number,
     projectId: project.id,
-    fields: {
-      status: toConfigField(pf.fields['status']),
-      priority: toConfigField(pf.fields['priority']),
-      size: toConfigField(pf.fields['size']),
-      type: toConfigField(pf.fields['type']),
-    },
+    fields,
     ...(deliveryLogIssue != null ? { deliveryLogIssue } : {}),
   };
   const defaults = adopt ? {} : {

--- a/plugin/scripts/lib/boardctx.mjs
+++ b/plugin/scripts/lib/boardctx.mjs
@@ -46,7 +46,28 @@ export async function makeBoardCtx({ gh, cwd }) {
     async findItemByIssue(issueNumber) {
       const list = await this.listItems();
       if (!list.ok) return list;
-      return { ok: true, item: list.items.find((i) => i.content?.number === issueNumber) ?? null };
+      const fromList = list.items.find((i) => i.content?.number === issueNumber);
+      if (fromList) return { ok: true, item: fromList };
+      // Fallback (#114): `gh project item-list` indexes lag behind item creation,
+      // so a freshly-added item (e.g. from a batch) can be absent for a while and
+      // move/receipt would wrongly report "not on board". The issue side is
+      // consistent immediately — ask it for membership + the item id.
+      return this.findItemViaIssue(issueNumber);
+    },
+
+    /** Issue-side lookup: parameterized GraphQL (inline-literal law), returns a minimal item or null. */
+    async findItemViaIssue(issueNumber) {
+      const res = await gh([
+        'api', 'graphql',
+        '-F', `number=${issueNumber}`,
+        '-f', `owner=${repo.owner}`,
+        '-f', `name=${repo.name}`,
+        '-f', 'query=query($owner:String!,$name:String!,$number:Int!){ repository(owner:$owner,name:$name){ issue(number:$number){ projectItems(first:20){ nodes { id project { number } } } } } }',
+      ], { parseJson: true });
+      if (!res.ok) return { ok: true, item: null }; // best-effort: no fallback item
+      const nodes = res.json?.data?.repository?.issue?.projectItems?.nodes ?? [];
+      const node = nodes.find((n) => n.project?.number === board.projectNumber);
+      return { ok: true, item: node ? { id: node.id, content: { number: issueNumber }, viaFallback: true } : null };
     },
 
     async addItemByUrl(url) {

--- a/plugin/scripts/lib/config.mjs
+++ b/plugin/scripts/lib/config.mjs
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 export const CONFIG_RELPATH = join('.claude', 'forge.json');
 
 const FIELD_KEYS = ['status', 'priority', 'size', 'type'];
+const OPTIONAL_FIELD_KEYS = ['phase']; // #114: consumer-defined single-selects, mapped by init when the project has them
 
 /**
  * Structural validation of .claude/forge.json — plain checks, no schema
@@ -31,12 +32,7 @@ export function validateConfig(cfg) {
     if (!board.fields || typeof board.fields !== 'object') {
       push('board.fields: missing block');
     } else {
-      for (const key of FIELD_KEYS) {
-        const f = board.fields[key];
-        if (!f || typeof f !== 'object') {
-          push(`board.fields.${key}: missing`);
-          continue;
-        }
+      const checkFieldShape = (key, f) => {
         if (typeof f.id !== 'string' || !/^PVTSSF_/.test(f.id)) {
           push(`board.fields.${key}.id: must be a single-select field id (PVTSSF_…)`);
         }
@@ -47,6 +43,17 @@ export function validateConfig(cfg) {
             if (typeof id !== 'string' || id.length === 0) push(`board.fields.${key}.options.${name}: empty option id`);
           }
         }
+      };
+      for (const key of FIELD_KEYS) {
+        const f = board.fields[key];
+        if (!f || typeof f !== 'object') { push(`board.fields.${key}: missing`); continue; }
+        checkFieldShape(key, f);
+      }
+      for (const key of OPTIONAL_FIELD_KEYS) {
+        const f = board.fields[key];
+        if (f === undefined) continue; // optional — only validated when present
+        if (typeof f !== 'object') { push(`board.fields.${key}: must be an object when present`); continue; }
+        checkFieldShape(key, f);
       }
     }
     if (board.deliveryLogIssue !== undefined && (!Number.isInteger(board.deliveryLogIssue) || board.deliveryLogIssue <= 0)) {

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -25,6 +25,7 @@ const CFG = {
       priority: { id: 'PVTSSF_p', options: { p0: 'a', p1: 'b', p2: 'c' } },
       size: { id: 'PVTSSF_z', options: { xs: '1', s: '2', m: '3', l: '4', xl: '5' } },
       type: { id: 'PVTSSF_t', options: { epic: 'e', item: 'i', bug: 'g', test: 't' } },
+      phase: { id: 'PVTSSF_ph', options: { alpha: 'ph1', beta: 'ph2' } }, // #114 optional Phase
     },
     deliveryLogIssue: 15,
   },
@@ -56,6 +57,24 @@ describe('boardctx', () => {
     expect(r.ok).toBe(false);
     expect(r.error).toContain('backlog');
     expect(r.error).toContain('done');
+  });
+
+  it('AC-114.1: findItemByIssue falls back to the issue side when item-list lags (#114)', async () => {
+    // item-list index lag: empty, but the issue is attached on the project
+    const { ctx } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      [(j) => j.startsWith('api graphql') && j.includes('projectItems'),
+        { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [{ id: 'ITEM_X', project: { number: 8 } }] } } } } }) }],
+    ]);
+    expect(await ctx.findItemByIssue(5)).toMatchObject({ ok: true, item: { id: 'ITEM_X', viaFallback: true } });
+
+    // genuinely absent → null (not on this project)
+    const { ctx: ctx2 } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      [(j) => j.startsWith('api graphql') && j.includes('projectItems'),
+        { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [] } } } } }) }],
+    ]);
+    expect((await ctx2.findItemByIssue(9)).item).toBe(null);
   });
 });
 
@@ -130,6 +149,27 @@ describe('create (AC-2.1)', () => {
     const res = await runCreate(ctx, createArgs(['--title', 'X', '--body-file', bf]), noop);
     expect(res.ok).toBe(true);
     expect(calls.some((c) => c.includes('Body loaded from file, not empty.'))).toBe(true);
+  });
+
+  it('AC-114.2: --phase sets the configured Phase field (#114)', async () => {
+    const { ctx, calls } = await ctxWith([
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: createdIssueUrl }],
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      [(j) => j.startsWith('api graphql') && j.includes('projectItems'), { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [] } } } } }) }],
+      ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--phase', 'alpha']), noop);
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.includes('PVTSSF_ph') && c.includes('ph1'))).toBe(true); // phase field set to alpha
+  });
+
+  it('AC-114.3: --phase without a configured Phase field errors clearly (#114)', async () => {
+    const ctx = { fields: {}, resolveOption: () => ({ ok: true }) }; // no phase configured
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--phase', 'alpha']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/no Phase field is configured/);
   });
 });
 

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -93,6 +93,32 @@ describe('runInit — fresh bootstrap (AC-1.2)', () => {
     expect(ga).toMatch(/^\* text=auto eol=lf$/m);
   });
 
+  it('AC-114.5: maps an optional Phase field into forge.json when the project has one (#114)', async () => {
+    const cwd = await tmpCwd();
+    const withPhase = [...FRESH_FULL_FIELDS, { id: 'PVTSSF_ph', name: 'Phase', options: [{ id: 'ph1', name: 'Alpha' }, { id: 'ph2', name: 'Beta' }] }];
+    let fieldsCall = 0;
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project create', { stdout: JSON.stringify({ id: 'PVT_new', number: 9, title: 'forge' }) }],
+      ['project link', { stdout: '' }],
+      [(j) => j.startsWith('api graphql') && j.includes('fields(first: 50)'), () => {
+        fieldsCall += 1;
+        return fieldsCall === 1
+          ? fieldsResponse(0, [{ id: 'PVTSSF_new1', name: 'Status', options: [{ id: 'a', name: 'Todo' }, { id: 'b', name: 'In Progress' }, { id: 'c', name: 'Done' }] }])
+          : fieldsResponse(0, withPhase);
+      }],
+      [(j) => j.includes('updateProjectV2Field'), { stdout: JSON.stringify({ data: { updateProjectV2Field: { projectV2Field: { id: 'PVTSSF_new1', options: [] } } } }) }],
+      [(j) => j.includes('createProjectV2Field'), { stdout: JSON.stringify({ data: { createProjectV2Field: { projectV2Field: { id: 'PVTSSF_x', options: [] } } } }) }],
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/42\n' }],
+    ]);
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--create-project', 'forge', '--skip-doctor']) });
+    expect(res.ok).toBe(true);
+    const cfg = await readJson(join(cwd, '.claude', 'forge.json'));
+    expect(cfg.board.fields.phase).toEqual({ id: 'PVTSSF_ph', options: { alpha: 'ph1', beta: 'ph2' } });
+  });
+
   it('AC-B64.2: fresh create links the new board to the repo (#64)', async () => {
     const cwd = await tmpCwd();
     const { gh, calls } = fakeGh(freshRoutes());

--- a/tests/lib/config.test.mjs
+++ b/tests/lib/config.test.mjs
@@ -63,6 +63,21 @@ describe('validateConfig', () => {
     expect(r.errors.some((e) => e.includes('features.graph'))).toBe(true);
   });
 
+  it('AC-114.4: an optional phase field is allowed when absent, validated when present (#114)', () => {
+    expect(validateConfig(validCfg()).ok).toBe(true); // absent → fine
+
+    const ok = validCfg();
+    ok.board.fields.phase = { id: 'PVTSSF_ph', options: { alpha: 'p1' } };
+    expect(validateConfig(ok)).toEqual({ ok: true, errors: [] }); // present + valid → fine
+
+    const bad = validCfg();
+    bad.board.fields.phase = { id: 'wrong', options: {} };
+    const r = validateConfig(bad);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes('board.fields.phase.id'))).toBe(true);
+    expect(r.errors.some((e) => e.includes('board.fields.phase.options'))).toBe(true);
+  });
+
   it('requires at least one maintainer when team.members present', () => {
     const cfg = validCfg();
     cfg.team.members = [{ github: 'alice', roles: ['developer'] }];


### PR DESCRIPTION
Board-tooling robustness — the two parts carved out of #108. Closes #114.

## Part 1 — findItemByIssue issue-side fallback (the recurring ritual pain)
`gh project item-list` indexes **lag behind item creation**, so a freshly-added item (e.g. from a batch) is absent for a while and `move`/`receipt` wrongly report "not on board". This broke the post-merge status move for **every ticket in the #103–#109 batch** (I completed each by hand with a direct field mutation).

`boardctx.findItemByIssue` now falls back to the **issue side** — parameterized GraphQL (`issue.projectItems`, inline-literal law) to confirm membership + get the item id — when `item-list` misses. Backward-compatible: a genuinely-absent issue (or an unrouted call in tests) → `item: null`, exactly as before.

## Part 2 — optional Phase field (#13)
- **config**: validates an optional `board.fields.phase` when present; never required.
- **init**: maps a consumer-defined `Phase` single-select into `forge.json` when the project has one (forge never *creates* it — opt-in roadmap tracking).
- **create.mjs**: `--phase <key>` sets it, but only when a Phase field is configured (clear error otherwise).

## Verification
- `npx vitest run` → **246 passed** (+5: AC-114.1 fallback, .2 create --phase, .3 unconfigured error, .4 config optional, .5 init mapping)
- `doctor` healthy
- The fallback uses the same GraphQL that unblocked every ritual this session by hand — now automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
