### PR TITLE
feat(board): Won't do status + board/close.mjs (#117)

### DIFF
--- a/.claude/forge.json
+++ b/.claude/forge.json
@@ -11,7 +11,8 @@
           "done": "7c5d9faa",
           "ready": "e90d0eb6",
           "inReview": "a9159ac9",
-          "blocked": "5b1d391c"
+          "blocked": "5b1d391c",
+          "wontDo": "68b3526e"
         }
       },
       "priority": {

--- a/plugin/scripts/board/close.mjs
+++ b/plugin/scripts/board/close.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * board close (#117) — close an issue for a special reason and reflect it on
+ * the board honestly. `completed` → Done; `not-planned`/`not-needed`/
+ * `superseded`/`duplicate` → a NOT_PLANNED GitHub close + the **Won't do**
+ * status (not "Done" — it wasn't done). Posts a `trail:closed` note.
+ * Idempotent: re-running on an already-closed issue just reconciles the board.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+import { upsertMarkedComment } from '../lib/issues.mjs';
+
+/** reason → GitHub close reason + board status key + human label. */
+export const REASONS = {
+  completed: { ghReason: 'completed', status: 'done', label: 'completed' },
+  'not-planned': { ghReason: 'not planned', status: 'wontDo', label: 'not planned' },
+  'not-needed': { ghReason: 'not planned', status: 'wontDo', label: 'not needed' },
+  superseded: { ghReason: 'not planned', status: 'wontDo', label: 'superseded' },
+  duplicate: { ghReason: 'not planned', status: 'wontDo', label: 'duplicate' },
+};
+
+export function parseArgs(argv) {
+  const a = { issue: null, reason: null, note: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
+    else if (argv[i] === '--reason') a.reason = argv[++i];
+    else if (argv[i] === '--note') a.note = argv[++i];
+  }
+  return a;
+}
+
+export async function runClose(ctx, args, log = console.log) {
+  if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
+  const spec = REASONS[args.reason];
+  if (!spec) return { ok: false, error: `--reason must be one of: ${Object.keys(REASONS).join(', ')}` };
+
+  // the target board status must exist (Won't do needs the option present)
+  const opt = ctx.resolveOption('status', spec.status);
+  if (!opt.ok) return { ok: false, error: `${opt.error} — run forge:init to add the '${spec.status}' status option` };
+
+  // 1. close the issue (idempotent)
+  const view = await ctx.gh(['issue', 'view', String(args.issue), '--json', 'state'], { parseJson: true });
+  if (!view.ok) return { ok: false, error: view.stderr || 'issue view failed' };
+  if (view.json.state !== 'CLOSED') {
+    const closed = await ctx.gh(['issue', 'close', String(args.issue), '--reason', spec.ghReason]);
+    if (!closed.ok) return { ok: false, error: closed.stderr || 'issue close failed' };
+    log(`#${args.issue}: closed (${spec.ghReason})`);
+  } else {
+    log(`#${args.issue}: already closed`);
+  }
+
+  // 2. reflect on the board (findItemByIssue has the lag fallback)
+  const found = await ctx.findItemByIssue(args.issue);
+  if (!found.ok) return { ok: false, error: found.error };
+  if (found.item) {
+    const set = await ctx.setSelect(found.item.id, 'status', spec.status);
+    if (!set.ok) return { ok: false, error: set.error };
+    log(`#${args.issue}: board status -> ${spec.status}`);
+  } else {
+    log(`#${args.issue}: not on the board (status not set)`);
+  }
+
+  // 3. trail note
+  const body = `**closed — ${spec.label}.**${args.note ? ` ${args.note}` : ''}`;
+  const note = await upsertMarkedComment(ctx.gh, ctx.owner, ctx.repo, args.issue, 'trail:closed', `**forge trail** — ${body}`);
+  if (!note.ok) return note;
+  log(`#${args.issue} trail:closed ${note.action}`);
+  return { ok: true, issue: args.issue, reason: args.reason, status: spec.status };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const res = await runClose(ctx, parseArgs(process.argv.slice(2)));
+    if (!res.ok) { console.error(`close failed: ${res.error}`); process.exit(1); }
+  });
+}

--- a/plugin/scripts/lib/board.mjs
+++ b/plugin/scripts/lib/board.mjs
@@ -12,6 +12,7 @@ export const STANDARD_STATUS = [
   { key: 'inReview', name: 'In review', color: 'ORANGE' },
   { key: 'blocked', name: 'Blocked / Needs decision', color: 'RED' },
   { key: 'done', name: 'Done', color: 'GREEN' },
+  { key: 'wontDo', name: "Won't do", color: 'GRAY' }, // #117: closed for a special reason (not planned / superseded), not completed
 ];
 
 export const STANDARD_FIELDS = {
@@ -36,10 +37,11 @@ export const STANDARD_FIELDS = {
   ],
 };
 
-/** "In progress" -> inProgress; "Blocked / Needs decision" -> blocked. */
+/** "In progress" -> inProgress; "Blocked / Needs decision" -> blocked; "Won't do" -> wontDo. */
 export function optionKey(name) {
   const lower = name.toLowerCase().trim();
   if (lower.startsWith('blocked')) return 'blocked';
+  if (lower.startsWith("won't") || lower.startsWith('wont')) return 'wontDo';
   return lower
     .replace(/[^a-z0-9]+(.)/g, (_, c) => c.toUpperCase())
     .replace(/[^a-zA-Z0-9]/g, '');
@@ -135,8 +137,11 @@ export async function createSingleSelectField(gh, projectId, name, optionDefs) {
  * express unquoted. Verified live in the #32 migration + SP1 spike (#35).
  */
 export function buildStatusMutation(fieldId, optionDefs) {
+  // Passing an existing option's id PRESERVES it (no re-mint); options without an
+  // id are freshly minted. This lets us append a status without disturbing the
+  // rest (#117) — the API gained `id` on the option input since the ADR-0001 note.
   const opts = optionDefs
-    .map((o) => `{name: ${JSON.stringify(o.name)}, color: ${o.color}, description: ""}`)
+    .map((o) => `{${o.id ? `id: ${JSON.stringify(o.id)}, ` : ''}name: ${JSON.stringify(o.name)}, color: ${o.color}, description: ""}`)
     .join(', ');
   return `mutation {
   updateProjectV2Field(input: { fieldId: ${JSON.stringify(fieldId)}, singleSelectOptions: [${opts}] }) {

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -8,6 +8,7 @@ import { buildAddSubIssue, addSubIssue } from '../plugin/scripts/lib/issues.mjs'
 import { runReparent, parseArgs as reparentArgs } from '../plugin/scripts/board/reparent.mjs';
 import { runMove, parseArgs as moveArgs } from '../plugin/scripts/board/move.mjs';
 import { runComment, parseArgs as commentArgs } from '../plugin/scripts/board/comment.mjs';
+import { runClose, parseArgs as closeArgs } from '../plugin/scripts/board/close.mjs';
 import { runReceipt } from '../plugin/scripts/board/receipt.mjs';
 import { runLog } from '../plugin/scripts/board/log.mjs';
 import { runDigest, renderChildTable, computeFlowMetrics, renderFlow, cycleDays } from '../plugin/scripts/board/digest.mjs';
@@ -21,7 +22,7 @@ const CFG = {
     projectNumber: 8,
     projectId: 'PVT_test',
     fields: {
-      status: { id: 'PVTSSF_s', options: { backlog: 'sb', ready: 'sr', inProgress: 'sp', inReview: 'sv', blocked: 'sk', done: 'sd' } },
+      status: { id: 'PVTSSF_s', options: { backlog: 'sb', ready: 'sr', inProgress: 'sp', inReview: 'sv', blocked: 'sk', done: 'sd', wontDo: 'sw' } },
       priority: { id: 'PVTSSF_p', options: { p0: 'a', p1: 'b', p2: 'c' } },
       size: { id: 'PVTSSF_z', options: { xs: '1', s: '2', m: '3', l: '4', xl: '5' } },
       type: { id: 'PVTSSF_t', options: { epic: 'e', item: 'i', bug: 'g', test: 't' } },
@@ -299,6 +300,50 @@ describe('comment (AC-2.3)', () => {
     const res = await runComment(ctx, commentArgs(['--issue', '2', '--phase', 'vibes', '--body', 'x']), noop);
     expect(res.ok).toBe(false);
     expect(res.error).toContain('valid:');
+  });
+});
+
+describe('close (AC-117)', () => {
+  const commentRoutes = (ref) => [
+    [(j) => j.startsWith('api repos/') && j.includes('/comments?'), () => ({ stdout: JSON.stringify(ref.comments) })],
+    [(j) => j.startsWith('api repos/') && j.endsWith('/comments') === false && j.includes('-f'), () => { ref.comments = [{ id: 5, body: '<!-- forge:trail:closed -->' }]; return { stdout: JSON.stringify({ id: 5 }) }; }],
+  ];
+
+  it('AC-117.1: --reason not-planned closes NOT_PLANNED, sets Won\'t do, trails (#117)', async () => {
+    const ref = { comments: [] };
+    const { ctx, calls } = await ctxWith([
+      ['issue view', { stdout: JSON.stringify({ state: 'OPEN' }) }],
+      ['issue close', { stdout: '' }],
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_9', content: { number: 12 }, status: 'Done' }])],
+      ['project item-edit', { stdout: '' }],
+      ...commentRoutes(ref),
+    ]);
+    const res = await runClose(ctx, closeArgs(['--issue', '12', '--reason', 'not-planned', '--note', 'superseded by ADR-0003']), noop);
+    expect(res).toMatchObject({ ok: true, status: 'wontDo' });
+    expect(calls.some((c) => c.startsWith('issue close') && c.includes('not planned'))).toBe(true);
+    expect(calls.some((c) => c.startsWith('project item-edit') && c.includes('sw'))).toBe(true); // wontDo option id
+    expect(calls.some((c) => c.includes('closed — not planned'))).toBe(true);
+  });
+
+  it('AC-117.2: already-closed issue reconciles the board without re-closing; completed -> Done (#117)', async () => {
+    const ref = { comments: [] };
+    const { ctx, calls } = await ctxWith([
+      ['issue view', { stdout: JSON.stringify({ state: 'CLOSED' }) }],
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_9', content: { number: 33 }, status: 'Ready' }])],
+      ['project item-edit', { stdout: '' }],
+      ...commentRoutes(ref),
+    ]);
+    const res = await runClose(ctx, closeArgs(['--issue', '33', '--reason', 'completed']), noop);
+    expect(res).toMatchObject({ ok: true, status: 'done' });
+    expect(calls.some((c) => c.startsWith('issue close'))).toBe(false); // already closed → no re-close
+    expect(calls.some((c) => c.startsWith('project item-edit') && c.includes('sd'))).toBe(true); // done option id
+  });
+
+  it('rejects an unknown --reason', async () => {
+    const { ctx } = await ctxWith([]);
+    const res = await runClose(ctx, closeArgs(['--issue', '1', '--reason', 'bogus']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/--reason must be one of/);
   });
 });
 

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -13,9 +13,9 @@ const BOARD8 = {
   projectId: 'PVT_kwHOCkJQ784BdZrh',
   fields: [
     { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7emI', name: 'Status', options: [
-      // six-status set since the #32 migration (ids re-minted by replaceStatusOptions)
+      // six-status set since the #32 migration; Won't do appended in #117 (ids preserved)
       { id: '8a1e2226', name: 'Backlog' }, { id: 'e90d0eb6', name: 'Ready' }, { id: '2a209b69', name: 'In progress' },
-      { id: 'a9159ac9', name: 'In review' }, { id: '5b1d391c', name: 'Blocked / Needs decision' }, { id: '7c5d9faa', name: 'Done' }] },
+      { id: 'a9159ac9', name: 'In review' }, { id: '5b1d391c', name: 'Blocked / Needs decision' }, { id: '7c5d9faa', name: 'Done' }, { id: '68b3526e', name: "Won't do" }] },
     { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7esI', name: 'Priority', options: [
       { id: '66c7f4b7', name: 'P0' }, { id: '23a624d0', name: 'P1' }, { id: 'd9b45a49', name: 'P2' }] },
     { id: 'PVTSSF_lAHOCkJQ784BdZrhzhX7esU', name: 'Size', options: [
@@ -28,7 +28,7 @@ const BOARD8 = {
 const FRESH_FULL_FIELDS = [
   { id: 'PVTSSF_new1', name: 'Status', options: [
     { id: 's1', name: 'Backlog' }, { id: 's2', name: 'Ready' }, { id: 's3', name: 'In progress' },
-    { id: 's4', name: 'In review' }, { id: 's5', name: 'Blocked / Needs decision' }, { id: 's6', name: 'Done' }] },
+    { id: 's4', name: 'In review' }, { id: 's5', name: 'Blocked / Needs decision' }, { id: 's6', name: 'Done' }, { id: 's7', name: "Won't do" }] },
   { id: 'PVTSSF_new2', name: 'Priority', options: [{ id: 'p1', name: 'P0' }, { id: 'p2', name: 'P1' }, { id: 'p3', name: 'P2' }] },
   { id: 'PVTSSF_new3', name: 'Size', options: [{ id: 'z1', name: 'XS' }, { id: 'z2', name: 'S' }] },
   { id: 'PVTSSF_new4', name: 'Type', options: [{ id: 't1', name: 'Epic' }, { id: 't2', name: 'Item' }] },

--- a/tests/lib/board.test.mjs
+++ b/tests/lib/board.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildStatusMutation, replaceStatusOptions, STANDARD_STATUS, linkProject } from '../../plugin/scripts/lib/board.mjs';
+import { buildStatusMutation, replaceStatusOptions, STANDARD_STATUS, linkProject, optionKey } from '../../plugin/scripts/lib/board.mjs';
 
 describe('linkProject (AC-B64.1, #64)', () => {
   it('AC-B64.1: issues gh project link <n> --owner <o> --repo <slug>', async () => {
@@ -48,6 +48,21 @@ describe('replaceStatusOptions mutation shape (AC-B4.1, #35)', () => {
     expect(seen.filter((a) => a === '-F')).toHaveLength(0);
     expect(seen.filter((a) => a === '-f')).toHaveLength(1);
     expect(seen.find((a) => a.startsWith('query='))).toContain('color: GREEN');
+  });
+});
+
+describe('Won\'t do status (AC-117, #117)', () => {
+  it("AC-117.3: optionKey maps Won't do -> wontDo; STANDARD_STATUS carries it", () => {
+    expect(optionKey("Won't do")).toBe('wontDo');
+    expect(optionKey('Wont do')).toBe('wontDo');
+    const wd = STANDARD_STATUS.find((s) => s.key === 'wontDo');
+    expect(wd?.name).toBe("Won't do");
+  });
+
+  it('AC-117.4: buildStatusMutation preserves an existing option id, mints when absent (safe append)', () => {
+    const m = buildStatusMutation('PVTSSF_x', [{ id: 'keep1', name: 'Done', color: 'GREEN' }, { name: "Won't do", color: 'GRAY' }]);
+    expect(m).toContain('{id: "keep1", name: "Done", color: GREEN, description: ""}'); // preserved
+    expect(m).toContain(`{name: "Won't do", color: GRAY, description: ""}`); // no id → minted
   });
 });
 


### PR DESCRIPTION
Owner feedback: tickets closed for special reasons (not planned / not needed / superseded) were missed on the board — GitHub closes them NOT_PLANNED but the board showed "Done" (#12) or nothing (#33). Closes #117.

## What's added
- **"Won't do" status** (`wontDo`) in `STANDARD_STATUS`; `optionKey` maps `"Won't do"` → `wontDo`.
- **`buildStatusMutation` preserves option ids** — the option input gained `id`, so a status can be appended without re-minting the rest. The ADR-0001/#32 "re-mint" hazard is now avoidable (documented in code).
- **`board/close.mjs`**: `--issue N --reason <not-planned|not-needed|superseded|duplicate|completed> [--note]` → closes with the correct GitHub state reason, sets the board status (**Won't do** for declines, **Done** for completed), posts a `trail:closed` note. Idempotent — safe on already-closed issues.

## Applied live
- Board #8: appended **Won't do** (`68b3526e`) preserving all 6 existing option ids (verified); `forge.json` + the `BOARD8` test fixture updated to match.
- **#12** reconciled: `Done` → **Won't do** via the new script (it was closed NOT_PLANNED — never actually done).
- #33 (completed, no status) was set to Done earlier this session.

## Verification
- `npx vitest run` → **251 passed** (+4: optionKey/append shape, close not-planned→Won't do, idempotent already-closed→Done, bad-reason error)
- `doctor` healthy (validates the new `wontDo` option)
- Live: `board close --issue 12` moved it to Won't do + trailed it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
