### PR TITLE
feat(skills): forge:execute-agents — subagent fan-out mode (#118)

### DIFF
--- a/docs/guides/handbook.md
+++ b/docs/guides/handbook.md
@@ -34,7 +34,7 @@ The normal path, with your touch-points marked **[you]**:
 3. **Shape** (bigger features) — `forge:brainstorm` explores approaches and ends in a spec; **[you] approve the spec via a decision comment** — reply with your choice on the issue or in-session.
 4. **Design** (UI-flagged tickets) — `forge:design` generates 2–3 real-token variants; **[you] pick one via decision comment**; the winner becomes a visual spec (speclint-enforced) that later review validates against.
 5. **Plan** — `forge:plan` writes `docs/plans/…` with tasks and **AC-IDs** (acceptance criteria that must map to passing tests). Committed to main before work starts.
-6. **Execute** — `forge:execute` works the plan task-by-task against a `.forge/progress.md` ledger (resumable mid-task). Tests come with the code.
+6. **Execute** — `forge:execute` works the plan task-by-task against a `.forge/progress.md` ledger (resumable mid-task). Tests come with the code. Variant: **`forge:execute-agents`** runs the same loop but fans each task out to role **subagents** (scoper → test-architect → implementer → reviewer) while the main loop keeps the ledger + gates.
 7. **Ship** — `forge:ship` runs the gate ladder (section 6), opens the PR with the AC checklist + honest verification, waits for CI, posts trail comments throughout.
 8. **Merge** — **[you] review and merge.** The agent then runs the post-merge ritual: receipt comment, delivery-log row, board → Done, branch cleanup, digest refresh.
 9. **Release** — `forge:release` when you want a named version: computed readiness checklist → semver from conventional commits → changelog → tag → GitHub Release. In deploy repos it names the staging-verified image digest — release never builds.

--- a/plugin/skills/execute-agents/SKILL.md
+++ b/plugin/skills/execute-agents/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: execute-agents
+description: Like forge:execute, but each plan task is driven by real subagents — scoper → test-architect → implementer → reviewer spawned via the Task tool, while the main loop keeps the ledger, gates, and resume protocol. Use when you want the per-task work fanned out to fresh-context role subagents instead of run inline.
+---
+
+# forge:execute-agents
+
+The subagent-fan-out variant of `forge:execute`. Same order-is-law loop and the same ledger — the difference is **who does the work**: every role step is a **Task-tool subagent spawn**, not inline main-loop work. Use this when you want each task's scope/test/implement/review done by a fresh-context specialist; use plain `forge:execute` when inline is enough.
+
+## Division of labour (the rule that makes this worth it)
+
+- **The orchestrator (this main loop) owns state and never writes task code itself:** branch, `.forge/progress.md` ledger, `.forge/scope.json`, the gates, trail comments, the resume protocol, and every escalation decision.
+- **Subagents own one unit of work each and return a report, not a conversation.** Spawn them from the compiled definitions in `plugin/agents/<role>.md` (Task tool, `subagent_type: <role>`). Each returns its terminal JSON report (`verdict` + `findings`); the orchestrator consumes the JSON, updates the ledger, and decides the next step. Never let a subagent drive the loop or spawn its own subagents.
+
+## Setup
+
+1. Branch per git conventions: `<type>/<issue#>-<slug>` cut from up-to-date main.
+2. Init the ledger: `.forge/progress.md`, one line per plan task (`- [ ] T1 — title`). Trail-comment `--phase started`.
+
+## Per-task loop (orchestrator marks `[~]` at start, `[x]` + note at end)
+
+For each task, spawn in order and act on each report before the next:
+
+1. **Scope** — spawn `scoper` (read-only) with a brief: ticket ref, the task's declared Files list, the plan section. It returns the touched surface + blast radius. Legitimate extra surface → the orchestrator writes `.forge/scope.json` (never the subagent, never silently).
+2. **Failing tests first** — spawn `test-architect` with a brief: the task's AC ids + test plan. It writes AC-ID-titled tests and confirms each fails for the expected reason. Bug fixes: regression test first, no exceptions. The orchestrator verifies red before proceeding.
+3. **Implement** — spawn `implementer` with a brief: the failing tests, the task's Files list, repo conventions. It makes the tests pass with the smallest correct change and nothing beyond the task. Orchestrator runs the scoped tests + full verify green.
+4. **Per-task review** — spawn `reviewer` (and `design-reviewer` on UI tasks when `features.designReview`) on the task diff. Findings come back severity-tagged; the orchestrator fixes them (a fresh `implementer` spawn) or tickets them **before** marking the task done.
+5. New dependency introduced? Run the dep guard now, not at ship: `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/depguard.mjs"`.
+
+Independent read-only briefs (e.g. scoping several tasks up front) may be spawned concurrently; the write steps (2→3→4) are strictly sequential within a task.
+
+## Whole-branch finish
+
+1. Spawn `reviewer` + `security` on the full branch diff; fix waves (fresh `implementer` spawns) until both come back clean.
+2. Mechanical gates (same as `forge:ship`, run by the orchestrator — subagent reports are never a substitute for these):
+   - `gates/plandrift.mjs --plan <plan>` — off-plan files ⇒ escalate or extend `scope.json` with a reviewer-visible note.
+   - `gates/testintent.mjs` — weakened existing assertions ⇒ reviewer sign-off in the PR or revert.
+   - `vitest run --reporter=json --outputFile=.forge/results.json` then `gates/acgate.mjs --plan <plan> --ticket <n> --results .forge/results.json`.
+3. Hand to `forge:ship`.
+
+## Report contract (what the orchestrator relies on)
+
+Every role subagent ends with the terminal JSON block its card specifies (`{"verdict":"pass|fail","findings":[…]}`). The orchestrator consumes **that**, never the prose. A subagent that returns no parseable report is re-spawned once with the violation named; a second miss is an escalation, not a guess.
+
+## Resume protocol (spec §4 — no human re-briefing)
+
+A fresh session: read `.forge/progress.md` (`next()` = first non-done task) → read `.forge/decisions/` for resolved answers (`escalate.mjs --check`) → `git status`/log to confirm branch state matches the ledger → resume the loop from that task, spawning subagents as above.
+
+## Escalation triggers here (spec §7)
+
+Same gate failing twice · blast radius beyond the plan · reviewer/implementer deadlock across re-spawns · a subagent that can't produce a valid report · any denylist-blocked need. `escalate.mjs`, then stop.

--- a/tests/skills/execute-agents.test.mjs
+++ b/tests/skills/execute-agents.test.mjs
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => readFile(join(root, rel), 'utf8');
+
+describe('forge:execute-agents skill (AC-118, #118)', () => {
+  it('AC-118.1: exists, names itself, and mandates subagent fan-out per task', async () => {
+    const s = await read('plugin/skills/execute-agents/SKILL.md');
+    expect(s).toMatch(/^name:\s*execute-agents$/m);
+    expect(s).toMatch(/Task tool/);            // real spawns, not inline
+    expect(s).toMatch(/subagent/i);
+    for (const role of ['scoper', 'test-architect', 'implementer', 'reviewer']) {
+      expect(s, `missing role ${role}`).toContain(role);
+    }
+    expect(s).toMatch(/ledger/);               // orchestrator keeps state
+    expect(s).toMatch(/acgate\.mjs|gates\//);  // and the mechanical gates
+    expect(s).toMatch(/verdict/);              // consumes the terminal JSON report
+  });
+
+  it('AC-118.2: every role it spawns has a compiled agent definition', async () => {
+    for (const role of ['scoper', 'test-architect', 'implementer', 'reviewer', 'security', 'design-reviewer']) {
+      const agent = await read(`plugin/agents/${role}.md`);
+      expect(agent.length, `agent ${role} missing`).toBeGreaterThan(50);
+    }
+  });
+});


### PR DESCRIPTION
Owner feedback: `forge:execute` runs the per-task loop **inline in the main loop**, not as real subagents. This adds a command that mandates the fan-out. Closes #118.

## What's added
`plugin/skills/execute-agents/SKILL.md` — the subagent variant of execute. Same order-is-law loop and the same ledger; the difference is **who does the work**:

- **Orchestrator (main loop) owns state, never writes task code:** branch, `.forge/progress.md` ledger, `.forge/scope.json`, gates, trail, resume, escalations.
- **Subagents own one unit each and return a report:** per task it spawns `scoper` → `test-architect` (failing tests) → `implementer` (make pass) → `reviewer` from `plugin/agents/<role>.md` via the Task tool. Each returns its terminal JSON report (`verdict` + `findings`); the orchestrator consumes the JSON, updates the ledger, and decides the next step. Subagents never drive the loop or gate themselves.
- Whole-branch finish spawns `reviewer` + `security`; the mechanical gates (plandrift/testintent/acgate) still run in the orchestrator — subagent reports are never a substitute.

The existing inline `forge:execute` is untouched (this is the opt-in fan-out variant). Handbook lane list updated.

## Verification
- `npx vitest run` → **253 passed** (+2: AC-118.1 the skill mandates fan-out + keeps ledger/gates; AC-118.2 every spawned role has a compiled agent)
- `doctor` healthy
- Connects back to the orchestration review earlier this session: execute was prose-driven/inline; this makes a genuine subagent-orchestration path explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
