### PR TITLE
feat(orchestration): forge:deliver — kind-aware plan→execute→ship on subagents, single MR gate (#121)

### DIFF
--- a/docs/guides/handbook.md
+++ b/docs/guides/handbook.md
@@ -39,6 +39,8 @@ The normal path, with your touch-points marked **[you]**:
 8. **Merge** — **[you] review and merge.** The agent then runs the post-merge ritual: receipt comment, delivery-log row, board → Done, branch cleanup, digest refresh.
 9. **Release** — `forge:release` when you want a named version: computed readiness checklist → semver from conventional commits → changelog → tag → GitHub Release. In deploy repos it names the staging-verified image digest — release never builds.
 
+**Autonomous variant:** **`forge:deliver`** runs steps 5→7 (plan → execute → ship) end-to-end on subagents for one triaged ticket — a `planner` drafts the plan, `execute-agents` does the per-task loop, ship opens the PR — with a **single human gate: the PR review** (step 8). It still halts on spec §7 safety escalations (security-critical, denylist, deadlock, gate-fail ×2).
+
 ## 4. Your interaction points (the complete list)
 
 - **Decision comments** (`🚩 Decision needed` on an issue): reply with the option number or free text — on the GitHub issue or in-session. Both resume the pipeline identically.

--- a/plugin/agents/planner.md
+++ b/plugin/agents/planner.md
@@ -1,6 +1,6 @@
 ---
 name: planner
-description: Turn a triaged ticket into an executable plan: ordered tasks, each with its Files list, AC-IDs, and a test plan — the contract forge:execute(-agents) works against.
+description: Classify a triaged ticket and turn it into an executable, typed plan: the ticket kind, then ordered tasks — each with its kind, Files list, AC-IDs, and test plan — the contract forge:deliver / forge:execute(-agents) work against.
 model: sonnet
 tools: Read, Grep, Glob
 ---
@@ -10,26 +10,27 @@ tools: Read, Grep, Glob
 # planner
 
 ## Mission
-Turn a triaged ticket into an executable plan: ordered tasks, each with its Files list, AC-IDs, and a test plan — the contract forge:execute(-agents) works against.
+Classify a triaged ticket and turn it into an executable, typed plan: the ticket kind, then ordered tasks — each with its kind, Files list, AC-IDs, and test plan — the contract forge:deliver / forge:execute(-agents) work against.
 
 ## Checklist
 1. Read the ticket (+ any linked spec/design/ADR); state the goal and its acceptance in one sentence.
-2. Decompose into ordered tasks (order is law): each the smallest shippable unit, dependencies first.
-3. Per task emit a **Files:** list (full paths — plan-drift matches these), the **AC-IDs** it satisfies (`AC-<ticket>.<n>`), and a test plan (the AC-ID-titled tests to write first).
-4. Map every acceptance criterion to at least one AC-ID on some task — no orphan ACs, no task without a test.
-5. Call out risks, unknowns, and cross-area / blast-radius concerns as findings (a scoper pass informs this).
+2. **Classify the ticket kind** from the board Type, labels, and title/body: `spike` · `bug` · `ui` · `feature` · `test` · `chore`. When signals conflict, say why you picked one.
+3. Decompose into ordered tasks (order is law): each the smallest shippable unit, dependencies first.
+4. **Type each task** — `code` · `test` · `ui` · `infra` — so the executor spawns the right role (ui→designer + design-reviewer, test→test-architect, infra→devops, code→implementer).
+5. Per task emit a **Files:** list (full paths — plan-drift matches these), the **AC-IDs** it satisfies (`AC-<ticket>.<n>`), and a test plan (the AC-ID-titled tests to write first). Bugs: a regression test is the first task.
+6. Map every acceptance criterion to at least one AC-ID on some task — no orphan ACs, no task without a test. Flag risks, unknowns, and cross-area/blast-radius concerns as findings.
 
 ## Guardrails
-- "Unknown" is a valid answer; guessing file paths, APIs, or AC coverage is a card violation — flag the unknown instead.
+- "Unknown" is a valid answer; guessing file paths, APIs, AC coverage, or the ticket kind is a card violation — flag the unknown instead.
 - Read-only: you draft the plan; the orchestrator writes and commits it. Do not create branches or edit code.
+- A `spike` kind means findings, not shippable code (spec §4 item 12): plan investigation/prototype tasks, not an implementation — the orchestrator routes it to an ADR + a follow-up ticket.
 - Every AC maps to a test and every task fits the plan-drift + AC gates — the plan is a contract those gates check, not a sketch.
-- Prefer full paths on Files lines; a bare filename after a full path resolves to that dir (plan-drift), but don't rely on it.
 
 ## Output contract
-Body — concise, bullets over prose, no ticket restatement (the plan itself: ordered `### T<n>` tasks, each with **Files:**, **AC-IDs:**, and a test plan), then a terminal JSON block:
+Body — concise, bullets over prose, no ticket restatement: a `kind:` line for the ticket, then ordered `### T<n>` tasks each opening with `kind:` and carrying **Files:**, **AC-IDs:**, and a test plan — then a terminal JSON block:
 
 ```json
-{ "verdict": "pass|fail", "findings": [ { "severity": "critical|major|minor", "file": "…", "line": 1, "summary": "…" } ] }
+{ "verdict": "pass|fail", "kind": "spike|bug|ui|feature|test|chore", "findings": [ { "severity": "critical|major|minor", "file": "…", "line": 1, "summary": "…" } ] }
 ```
 
 verdict is `fail` when the ticket can't be planned without a human decision (ambiguous scope, missing acceptance); findings carry the risks and open questions.

--- a/plugin/agents/planner.md
+++ b/plugin/agents/planner.md
@@ -1,0 +1,35 @@
+---
+name: planner
+description: Turn a triaged ticket into an executable plan: ordered tasks, each with its Files list, AC-IDs, and a test plan — the contract forge:execute(-agents) works against.
+model: sonnet
+tools: Read, Grep, Glob
+---
+
+<!-- generated from plugin/cards/planner.md by scripts/backends/compile.mjs — edit the card, not this file -->
+
+# planner
+
+## Mission
+Turn a triaged ticket into an executable plan: ordered tasks, each with its Files list, AC-IDs, and a test plan — the contract forge:execute(-agents) works against.
+
+## Checklist
+1. Read the ticket (+ any linked spec/design/ADR); state the goal and its acceptance in one sentence.
+2. Decompose into ordered tasks (order is law): each the smallest shippable unit, dependencies first.
+3. Per task emit a **Files:** list (full paths — plan-drift matches these), the **AC-IDs** it satisfies (`AC-<ticket>.<n>`), and a test plan (the AC-ID-titled tests to write first).
+4. Map every acceptance criterion to at least one AC-ID on some task — no orphan ACs, no task without a test.
+5. Call out risks, unknowns, and cross-area / blast-radius concerns as findings (a scoper pass informs this).
+
+## Guardrails
+- "Unknown" is a valid answer; guessing file paths, APIs, or AC coverage is a card violation — flag the unknown instead.
+- Read-only: you draft the plan; the orchestrator writes and commits it. Do not create branches or edit code.
+- Every AC maps to a test and every task fits the plan-drift + AC gates — the plan is a contract those gates check, not a sketch.
+- Prefer full paths on Files lines; a bare filename after a full path resolves to that dir (plan-drift), but don't rely on it.
+
+## Output contract
+Body — concise, bullets over prose, no ticket restatement (the plan itself: ordered `### T<n>` tasks, each with **Files:**, **AC-IDs:**, and a test plan), then a terminal JSON block:
+
+```json
+{ "verdict": "pass|fail", "findings": [ { "severity": "critical|major|minor", "file": "…", "line": 1, "summary": "…" } ] }
+```
+
+verdict is `fail` when the ticket can't be planned without a human decision (ambiguous scope, missing acceptance); findings carry the risks and open questions.

--- a/plugin/cards/planner.md
+++ b/plugin/cards/planner.md
@@ -1,0 +1,26 @@
+# planner
+
+## Mission
+Turn a triaged ticket into an executable plan: ordered tasks, each with its Files list, AC-IDs, and a test plan — the contract forge:execute(-agents) works against.
+
+## Checklist
+1. Read the ticket (+ any linked spec/design/ADR); state the goal and its acceptance in one sentence.
+2. Decompose into ordered tasks (order is law): each the smallest shippable unit, dependencies first.
+3. Per task emit a **Files:** list (full paths — plan-drift matches these), the **AC-IDs** it satisfies (`AC-<ticket>.<n>`), and a test plan (the AC-ID-titled tests to write first).
+4. Map every acceptance criterion to at least one AC-ID on some task — no orphan ACs, no task without a test.
+5. Call out risks, unknowns, and cross-area / blast-radius concerns as findings (a scoper pass informs this).
+
+## Guardrails
+- "Unknown" is a valid answer; guessing file paths, APIs, or AC coverage is a card violation — flag the unknown instead.
+- Read-only: you draft the plan; the orchestrator writes and commits it. Do not create branches or edit code.
+- Every AC maps to a test and every task fits the plan-drift + AC gates — the plan is a contract those gates check, not a sketch.
+- Prefer full paths on Files lines; a bare filename after a full path resolves to that dir (plan-drift), but don't rely on it.
+
+## Output contract
+Body — concise, bullets over prose, no ticket restatement (the plan itself: ordered `### T<n>` tasks, each with **Files:**, **AC-IDs:**, and a test plan), then a terminal JSON block:
+
+```json
+{ "verdict": "pass|fail", "findings": [ { "severity": "critical|major|minor", "file": "…", "line": 1, "summary": "…" } ] }
+```
+
+verdict is `fail` when the ticket can't be planned without a human decision (ambiguous scope, missing acceptance); findings carry the risks and open questions.

--- a/plugin/cards/planner.md
+++ b/plugin/cards/planner.md
@@ -1,26 +1,27 @@
 # planner
 
 ## Mission
-Turn a triaged ticket into an executable plan: ordered tasks, each with its Files list, AC-IDs, and a test plan — the contract forge:execute(-agents) works against.
+Classify a triaged ticket and turn it into an executable, typed plan: the ticket kind, then ordered tasks — each with its kind, Files list, AC-IDs, and test plan — the contract forge:deliver / forge:execute(-agents) work against.
 
 ## Checklist
 1. Read the ticket (+ any linked spec/design/ADR); state the goal and its acceptance in one sentence.
-2. Decompose into ordered tasks (order is law): each the smallest shippable unit, dependencies first.
-3. Per task emit a **Files:** list (full paths — plan-drift matches these), the **AC-IDs** it satisfies (`AC-<ticket>.<n>`), and a test plan (the AC-ID-titled tests to write first).
-4. Map every acceptance criterion to at least one AC-ID on some task — no orphan ACs, no task without a test.
-5. Call out risks, unknowns, and cross-area / blast-radius concerns as findings (a scoper pass informs this).
+2. **Classify the ticket kind** from the board Type, labels, and title/body: `spike` · `bug` · `ui` · `feature` · `test` · `chore`. When signals conflict, say why you picked one.
+3. Decompose into ordered tasks (order is law): each the smallest shippable unit, dependencies first.
+4. **Type each task** — `code` · `test` · `ui` · `infra` — so the executor spawns the right role (ui→designer + design-reviewer, test→test-architect, infra→devops, code→implementer).
+5. Per task emit a **Files:** list (full paths — plan-drift matches these), the **AC-IDs** it satisfies (`AC-<ticket>.<n>`), and a test plan (the AC-ID-titled tests to write first). Bugs: a regression test is the first task.
+6. Map every acceptance criterion to at least one AC-ID on some task — no orphan ACs, no task without a test. Flag risks, unknowns, and cross-area/blast-radius concerns as findings.
 
 ## Guardrails
-- "Unknown" is a valid answer; guessing file paths, APIs, or AC coverage is a card violation — flag the unknown instead.
+- "Unknown" is a valid answer; guessing file paths, APIs, AC coverage, or the ticket kind is a card violation — flag the unknown instead.
 - Read-only: you draft the plan; the orchestrator writes and commits it. Do not create branches or edit code.
+- A `spike` kind means findings, not shippable code (spec §4 item 12): plan investigation/prototype tasks, not an implementation — the orchestrator routes it to an ADR + a follow-up ticket.
 - Every AC maps to a test and every task fits the plan-drift + AC gates — the plan is a contract those gates check, not a sketch.
-- Prefer full paths on Files lines; a bare filename after a full path resolves to that dir (plan-drift), but don't rely on it.
 
 ## Output contract
-Body — concise, bullets over prose, no ticket restatement (the plan itself: ordered `### T<n>` tasks, each with **Files:**, **AC-IDs:**, and a test plan), then a terminal JSON block:
+Body — concise, bullets over prose, no ticket restatement: a `kind:` line for the ticket, then ordered `### T<n>` tasks each opening with `kind:` and carrying **Files:**, **AC-IDs:**, and a test plan — then a terminal JSON block:
 
 ```json
-{ "verdict": "pass|fail", "findings": [ { "severity": "critical|major|minor", "file": "…", "line": 1, "summary": "…" } ] }
+{ "verdict": "pass|fail", "kind": "spike|bug|ui|feature|test|chore", "findings": [ { "severity": "critical|major|minor", "file": "…", "line": 1, "summary": "…" } ] }
 ```
 
 verdict is `fail` when the ticket can't be planned without a human decision (ambiguous scope, missing acceptance); findings carry the risks and open questions.

--- a/plugin/scripts/backends/compile.mjs
+++ b/plugin/scripts/backends/compile.mjs
@@ -17,6 +17,7 @@ export const AGENTS_DIR = join(PLUGIN_ROOT, 'agents');
 export const ROLES = [
   'implementer', 'reviewer', 'security', 'design-reviewer', 'scoper',
   'test-architect', 'devops', 'designer', 'investigator', 'librarian', 'second-opinion',
+  'planner',
 ];
 
 /**
@@ -37,6 +38,7 @@ export const MODELS = {
   'design-reviewer': 'sonnet',
   devops: 'sonnet',
   'second-opinion': 'opus',
+  planner: 'sonnet', // decomposition + AC mapping needs real reasoning
 };
 
 /** Read-only roles (spec §13 blast-radius control). Reviewer-shaped roles get Bash for diffs/tests. */
@@ -48,6 +50,7 @@ const TOOLS = {
   investigator: 'Read, Grep, Glob',
   librarian: 'Read, Grep, Glob',
   'second-opinion': 'Read, Grep, Glob',
+  planner: 'Read, Grep, Glob', // drafts the plan read-only; the orchestrator writes + commits it
   // write-capable roles (implementer, test-architect, devops, designer) inherit all tools
 };
 

--- a/plugin/skills/deliver/SKILL.md
+++ b/plugin/skills/deliver/SKILL.md
@@ -1,41 +1,43 @@
 ---
 name: deliver
-description: End-to-end plan → execute → ship for one triaged ticket, driven by subagents, with a single human gate — the PR review. Auto-plans, runs the execute-agents subagent loop, ships to a PR, and stops. Halts only on spec §7 safety escalations. Use when a ticket is ready to become a merge-ready PR without step-by-step human approval.
+description: End-to-end delivery of one triaged ticket, driven by subagents, with a single human gate — the PR review. Classifies the ticket (spike/bug/ui/feature/test/chore) and routes to the flow that fits, auto-plans with typed tasks, runs the execute-agents subagent loop, ships to a PR, and stops. Halts only on spec §7 safety escalations. Use when a ticket is ready to become a merge-ready PR without step-by-step approval.
 ---
 
 # forge:deliver
 
-One triaged ticket → a merge-ready PR, unattended, with **exactly one human gate: reviewing the PR**. The plan-approval and inline checkpoints of the normal pipeline are collapsed into that final review. This is the autonomous wrapper around `forge:plan` + `forge:execute-agents` + `forge:ship` — every phase runs on subagents; the main loop orchestrates and owns all state.
+One triaged ticket → a merge-ready PR (or, for a spike, an ADR), unattended, with **exactly one human gate: reviewing the PR**. `deliver` is **kind-aware** — it doesn't assume plain implementation. It classifies the ticket and routes to the right flow, running every phase on subagents while the main loop orchestrates and owns all state.
 
 ## The one-gate contract
 
 - **The human is consulted once — at the PR.** Nothing between kickoff and PR asks for approval.
-- **The pipeline still HALTS on genuine blockers (spec §7), never on routine choices:** a critical security finding, a denylist-blocked action, a reviewer/implementer deadlock across re-spawns, or the same gate failing twice → `escalate.mjs`, then stop. These are safety valves, not approvals.
-- **Preconditions:** the ticket is already triaged (clear ask + acceptance). If it isn't, the planner returns `verdict: fail` — escalate rather than guess. `deliver` does not do discovery/spec work; run `forge:triage`/`forge:brainstorm` first.
-- **Orchestrator owns state, subagents own work:** branch, ledger, `scope.json`, gates, trail, and every escalation decision stay with the main loop; subagents return their terminal JSON report and nothing more.
+- **Still HALTS on genuine blockers (spec §7), never on routine choices:** critical security finding · denylist-blocked action · reviewer/implementer deadlock across re-spawns · same gate failing twice · planner `verdict: fail`. → `escalate.mjs`, stop.
+- **Preconditions:** the ticket is triaged (clear ask + acceptance). Otherwise the planner returns `verdict: fail` — escalate, don't guess. `deliver` doesn't do discovery/spec work.
+- **Orchestrator owns state, subagents own work:** branch, ledger, `scope.json`, gates, trail, escalations stay with the main loop; subagents return their terminal JSON report only.
 
-## Phase 1 — Plan (subagent)
+## Phase 0 — Classify
 
-1. Spawn `planner` (Task tool, `subagent_type: planner`) with a brief: the ticket ref + body, any linked spec/design/ADR. It returns an ordered task plan — each task with a **Files:** list, **AC-IDs** (`AC-<ticket>.<n>`), and a test plan — plus findings (risks/open questions).
-2. `verdict: fail` (unplannable without a human decision) → escalate, stop.
-3. Otherwise the **orchestrator** writes the plan to `docs/plans/<date>-<slug>.md` and commits it to main (no plan-approval gate — this is the collapsed step). Trail `--phase plan`.
+Spawn `planner` (`subagent_type: planner`) with the ticket ref + body + any linked spec/design/ADR. It returns the **ticket kind** (`spike | bug | ui | feature | test | chore`) and a **typed task plan** (each task tagged `code | test | ui | infra`, with Files + AC-IDs + test plan). `verdict: fail` → escalate, stop. The orchestrator picks the route from the kind:
 
-## Phase 2 — Execute (subagent loop)
+## Route table (kind → pipeline)
 
-Run the **`forge:execute-agents`** loop against that plan: branch, ledger, and per task `scoper → test-architect → implementer → reviewer` spawned as subagents, with the per-task gates. The orchestrator marks the ledger and consumes each report. All of that skill's rules apply here unchanged.
+- **feature / chore** — write + commit the plan → **Execute** → **Ship**. (The baseline flow.)
+- **bug** — spawn `investigator` to reproduce + root-cause first (attached to the ticket); the plan's **first task is a regression test**; then Execute → Ship. If an incident is open, ship under hotfix rules (situation gate).
+- **ui** — plan → **Design**: spawn `designer` for token-grounded, a11y-first variants; the orchestrator **auto-selects the best against the visual spec + design tokens + a11y contract** (no human variant-pick — the choice is shown at the PR). Execute includes a `design-reviewer` pass per UI task. Then Ship.
+- **test** — plan is `test-architect`-led (coverage/intent); Execute → Ship.
+- **spike** — **does not ship code** (spec §4 item 12). Run the spike flow (investigate/prototype on subagents) → write findings as an **ADR** (`docs/decisions/`) → **auto-file a follow-up implementation ticket** (`board/create.mjs`, linking the ADR) → **stop**. Report the ADR + the new ticket; the human decides whether to `deliver` that. No code PR.
 
-## Phase 3 — Ship (gates + subagents → PR)
+## Execute (all shippable kinds)
 
-Run `forge:ship`:
-1. Situation gate, conventions lint, rebase + verify green.
-2. Mechanical gates: `plandrift.mjs --plan <plan>`, `testintent.mjs`, `depguard.mjs`, and the AC gate (`vitest --reporter=json` → `acgate.mjs --plan <plan> --ticket <n>`).
-3. Full-branch `security` + `reviewer` subagents; criticals escalate (that's a §7 halt).
-4. Open the PR: `Closes #<n>`, commits→issues map, AC checklist, and an **honest verification statement** (what ran, what passed, what was NOT verified). Trail `--phase pr` → `ci-green`.
+Run the **`forge:execute-agents`** loop against the plan. Per task, the executor spawns the role matching the task's `kind` — `code`→implementer, `test`→test-architect, `ui`→designer + design-reviewer, `infra`→devops — around the scoper/reviewer bookends, with the per-task gates. Orchestrator marks the ledger and consumes each report.
+
+## Ship (all shippable kinds)
+
+Run `forge:ship`: situation gate · conventions lint · rebase + verify · mechanical gates (`plandrift`, `testintent`, `depguard`, `acgate`) · full-branch `security` + `reviewer` subagents (criticals escalate) · open the PR with `Closes #<n>`, the AC checklist, and an **honest verification statement**. Trail `--phase pr` → `ci-green`.
 
 ## Stop — the human gate
 
-Report the PR link and the honest verification, then **stop**. The human reviews and merges the MR. The post-merge ritual (`forge:ship`'s receipt → log → move) runs after they merge, as usual.
+Report the PR link (or, for a spike, the ADR + follow-up ticket) and the honest verification, then **stop**. The human reviews and merges; the post-merge ritual runs after they merge.
 
 ## Escalation triggers (the only pauses)
 
-Critical security finding · denylist-blocked action genuinely needed · reviewer/implementer deadlock across re-spawns · same gate failing twice · planner `verdict: fail` · blast radius beyond the plan with no safe `scope.json` extension. `escalate.mjs --issue <n> --reason … --options …`, then stop. Resume via `escalate.mjs --check` after the human replies — the ledger + plan make it seamless.
+Critical security finding · denylist-blocked action genuinely needed · reviewer/implementer deadlock · same gate failing twice · planner `verdict: fail` · blast radius beyond the plan with no safe `scope.json` extension. `escalate.mjs`, then stop; resume via `escalate.mjs --check`.

--- a/plugin/skills/deliver/SKILL.md
+++ b/plugin/skills/deliver/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: deliver
+description: End-to-end plan → execute → ship for one triaged ticket, driven by subagents, with a single human gate — the PR review. Auto-plans, runs the execute-agents subagent loop, ships to a PR, and stops. Halts only on spec §7 safety escalations. Use when a ticket is ready to become a merge-ready PR without step-by-step human approval.
+---
+
+# forge:deliver
+
+One triaged ticket → a merge-ready PR, unattended, with **exactly one human gate: reviewing the PR**. The plan-approval and inline checkpoints of the normal pipeline are collapsed into that final review. This is the autonomous wrapper around `forge:plan` + `forge:execute-agents` + `forge:ship` — every phase runs on subagents; the main loop orchestrates and owns all state.
+
+## The one-gate contract
+
+- **The human is consulted once — at the PR.** Nothing between kickoff and PR asks for approval.
+- **The pipeline still HALTS on genuine blockers (spec §7), never on routine choices:** a critical security finding, a denylist-blocked action, a reviewer/implementer deadlock across re-spawns, or the same gate failing twice → `escalate.mjs`, then stop. These are safety valves, not approvals.
+- **Preconditions:** the ticket is already triaged (clear ask + acceptance). If it isn't, the planner returns `verdict: fail` — escalate rather than guess. `deliver` does not do discovery/spec work; run `forge:triage`/`forge:brainstorm` first.
+- **Orchestrator owns state, subagents own work:** branch, ledger, `scope.json`, gates, trail, and every escalation decision stay with the main loop; subagents return their terminal JSON report and nothing more.
+
+## Phase 1 — Plan (subagent)
+
+1. Spawn `planner` (Task tool, `subagent_type: planner`) with a brief: the ticket ref + body, any linked spec/design/ADR. It returns an ordered task plan — each task with a **Files:** list, **AC-IDs** (`AC-<ticket>.<n>`), and a test plan — plus findings (risks/open questions).
+2. `verdict: fail` (unplannable without a human decision) → escalate, stop.
+3. Otherwise the **orchestrator** writes the plan to `docs/plans/<date>-<slug>.md` and commits it to main (no plan-approval gate — this is the collapsed step). Trail `--phase plan`.
+
+## Phase 2 — Execute (subagent loop)
+
+Run the **`forge:execute-agents`** loop against that plan: branch, ledger, and per task `scoper → test-architect → implementer → reviewer` spawned as subagents, with the per-task gates. The orchestrator marks the ledger and consumes each report. All of that skill's rules apply here unchanged.
+
+## Phase 3 — Ship (gates + subagents → PR)
+
+Run `forge:ship`:
+1. Situation gate, conventions lint, rebase + verify green.
+2. Mechanical gates: `plandrift.mjs --plan <plan>`, `testintent.mjs`, `depguard.mjs`, and the AC gate (`vitest --reporter=json` → `acgate.mjs --plan <plan> --ticket <n>`).
+3. Full-branch `security` + `reviewer` subagents; criticals escalate (that's a §7 halt).
+4. Open the PR: `Closes #<n>`, commits→issues map, AC checklist, and an **honest verification statement** (what ran, what passed, what was NOT verified). Trail `--phase pr` → `ci-green`.
+
+## Stop — the human gate
+
+Report the PR link and the honest verification, then **stop**. The human reviews and merges the MR. The post-merge ritual (`forge:ship`'s receipt → log → move) runs after they merge, as usual.
+
+## Escalation triggers (the only pauses)
+
+Critical security finding · denylist-blocked action genuinely needed · reviewer/implementer deadlock across re-spawns · same gate failing twice · planner `verdict: fail` · blast radius beyond the plan with no safe `scope.json` extension. `escalate.mjs --issue <n> --reason … --options …`, then stop. Resume via `escalate.mjs --check` after the human replies — the ledger + plan make it seamless.

--- a/plugin/skills/execute-agents/SKILL.md
+++ b/plugin/skills/execute-agents/SKILL.md
@@ -23,7 +23,7 @@ For each task, spawn in order and act on each report before the next:
 
 1. **Scope** — spawn `scoper` (read-only) with a brief: ticket ref, the task's declared Files list, the plan section. It returns the touched surface + blast radius. Legitimate extra surface → the orchestrator writes `.forge/scope.json` (never the subagent, never silently).
 2. **Failing tests first** — spawn `test-architect` with a brief: the task's AC ids + test plan. It writes AC-ID-titled tests and confirms each fails for the expected reason. Bug fixes: regression test first, no exceptions. The orchestrator verifies red before proceeding.
-3. **Implement** — spawn `implementer` with a brief: the failing tests, the task's Files list, repo conventions. It makes the tests pass with the smallest correct change and nothing beyond the task. Orchestrator runs the scoped tests + full verify green.
+3. **Implement** — spawn the role matching the task's `kind` (from the planner's typed plan): `code`→`implementer`, `ui`→`designer` (then a `design-reviewer` pass in step 4), `infra`→`devops`, `test`→the `test-architect` from step 2 carries it. Brief: the failing tests, the task's Files list, repo conventions. It makes the tests pass with the smallest correct change and nothing beyond the task. Orchestrator runs the scoped tests + full verify green.
 4. **Per-task review** — spawn `reviewer` (and `design-reviewer` on UI tasks when `features.designReview`) on the task diff. Findings come back severity-tagged; the orchestrator fixes them (a fresh `implementer` spawn) or tickets them **before** marking the task done.
 5. New dependency introduced? Run the dep guard now, not at ship: `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/depguard.mjs"`.
 

--- a/tests/backends/cards.test.mjs
+++ b/tests/backends/cards.test.mjs
@@ -4,7 +4,7 @@ import { join, basename } from 'node:path';
 import { CARDS_DIR, AGENTS_DIR, compileCard, ROLES, MODELS } from '../../plugin/scripts/backends/compile.mjs';
 
 describe('role cards (AC-4.1)', () => {
-  it('all 11 roles have a card and only those', async () => {
+  it('all 12 roles have a card and only those', async () => {
     const cards = (await readdir(CARDS_DIR)).filter((f) => f.endsWith('.md')).map((f) => basename(f, '.md'));
     expect(cards.sort()).toEqual([...ROLES].sort());
   });

--- a/tests/skills/deliver.test.mjs
+++ b/tests/skills/deliver.test.mjs
@@ -18,6 +18,34 @@ describe('forge:deliver skill (AC-121, #121)', () => {
     expect(s).toMatch(/security/i);                         // security-critical is a halt
   });
 
+  it('AC-121.3: is kind-aware — classifies the ticket and routes per kind (#121)', async () => {
+    const s = await read('plugin/skills/deliver/SKILL.md');
+    expect(s).toMatch(/Classify/i);
+    for (const kind of ['spike', 'bug', 'ui', 'feature', 'test', 'chore']) {
+      expect(s, `route missing kind ${kind}`).toContain(kind);
+    }
+    // spike special-cases: ADR + follow-up ticket, no code PR
+    expect(s).toMatch(/does not ship code|no code PR/i);
+    expect(s).toMatch(/ADR/);
+    expect(s).toMatch(/board\/create\.mjs|follow-up/i);
+    // ui: auto-pick a variant, single gate preserved (no human variant pick)
+    expect(s).toMatch(/auto-select|auto-pick/i);
+    expect(s).toMatch(/visual spec/i);
+    // bug: reproduce / regression test first
+    expect(s).toMatch(/reproduce|regression/i);
+  });
+
+  it('AC-121.4: the planner classifies + types tasks; execute-agents selects role by task kind (#121)', async () => {
+    const card = await read('plugin/cards/planner.md');
+    expect(card).toMatch(/Classify the ticket kind/i);
+    expect(card).toMatch(/spike.*bug.*ui.*feature.*test.*chore|kind/i);
+    expect(card).toMatch(/Type each task|code.*test.*ui.*infra/i);
+    const ea = await read('plugin/skills/execute-agents/SKILL.md');
+    expect(ea).toMatch(/matching the task's `kind`|task's `kind`/);
+    expect(ea).toMatch(/designer/);
+    expect(ea).toMatch(/devops/);
+  });
+
   it('AC-121.2: planner is a compiled, read-only role pinned to a model', async () => {
     const { ROLES, MODELS } = await import('../../plugin/scripts/backends/compile.mjs');
     expect(ROLES).toContain('planner');

--- a/tests/skills/deliver.test.mjs
+++ b/tests/skills/deliver.test.mjs
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => readFile(join(root, rel), 'utf8');
+
+describe('forge:deliver skill (AC-121, #121)', () => {
+  it('AC-121.1: chains plan → execute-agents → ship with a single human gate at the PR', async () => {
+    const s = await read('plugin/skills/deliver/SKILL.md');
+    expect(s).toMatch(/^name:\s*deliver$/m);
+    expect(s).toMatch(/one[- ]gate|single human gate/i);   // one human touchpoint
+    expect(s).toMatch(/planner/);                           // plan phase = the new role
+    expect(s).toMatch(/execute-agents/);                    // execute phase
+    expect(s).toMatch(/forge:ship|ship/i);                  // ship phase
+    expect(s).toMatch(/escalate\.mjs/);                     // still halts on §7 blockers
+    expect(s).toMatch(/security/i);                         // security-critical is a halt
+  });
+
+  it('AC-121.2: planner is a compiled, read-only role pinned to a model', async () => {
+    const { ROLES, MODELS } = await import('../../plugin/scripts/backends/compile.mjs');
+    expect(ROLES).toContain('planner');
+    expect(MODELS.planner).toBe('sonnet');
+    const agent = await read('plugin/agents/planner.md');
+    expect(agent).toMatch(/^model: sonnet$/m);
+    expect(agent).toMatch(/^tools: Read, Grep, Glob$/m);
+  });
+});


### PR DESCRIPTION
Owner request: a new orchestration — **plan → execute → ship with subagents, the human gate only the MR review**. Closes #121.

Decisions taken: **runs unattended to the PR but halts on spec §7 safety escalations**; **a dedicated `planner` role**.

## What's added
### `planner` role (the 12th)
- `plugin/cards/planner.md` + compiled `plugin/agents/planner.md`; `MODELS.planner = sonnet`, read-only tools (`Read, Grep, Glob`).
- It drafts an ordered task plan (Files + AC-IDs + test plan) and returns it; the orchestrator writes + commits. Read-only, so it never branches or edits code.

### `forge:deliver` skill
One triaged ticket → merge-ready PR, unattended, **one human gate — the PR**:
1. **Plan** — spawn `planner`; orchestrator writes `docs/plans/…` + commits (the collapsed plan-approval step). `verdict: fail` → escalate.
2. **Execute** — the `forge:execute-agents` subagent loop (scoper → test-architect → implementer → reviewer per task).
3. **Ship** — gate ladder + `security`/`reviewer` subagents → PR with AC checklist + honest verification, then **stop**.
- Orchestrator owns ledger/gates/trail/escalations; subagents return reports only.
- Halts on: security-critical, denylist-blocked action, reviewer/implementer deadlock, same gate failing twice, planner `verdict: fail`. Those are the only pauses.

Handbook updated (deliver = autonomous variant of steps 5→7).

## Verification
- `npx vitest run` → **255 passed** (+2: AC-121.1 phase-chain + single gate + §7 halts; AC-121.2 planner compiled/sonnet/read-only); card freshness gate green.
- `doctor` healthy.
- Builds on this session's arc: execute-agents (#118) gave the execute loop; deliver wraps plan + ship around it with the single-gate policy you chose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
