### PR TITLE
feat(board): board/close.mjs accepts a comma-separated --issue list (#123)

### DIFF
--- a/docs/plans/2026-07-20-batch-close.md
+++ b/docs/plans/2026-07-20-batch-close.md
@@ -1,0 +1,34 @@
+# Plan — batch close for board/close.mjs (#123)
+
+**Kind:** feature · **Ticket:** #123 · Authored by the `planner` subagent (forge:deliver shakedown).
+
+Goal: `board/close.mjs` accepts a comma-separated `--issue` list and closes each with the shared `--reason`/`--note`, returning a per-issue summary — while a single `--issue` stays byte-for-byte back-compatible.
+
+## T1 — parse a list + `runCloseBatch` (kind: code)
+
+**Files:** plugin/scripts/board/close.mjs
+
+- `parseArgs`: parse `--issue` into a list (`a.issues`), splitting on `,` and trimming; `Number('12,13')` is `NaN` today, so this must change. Keep a single lone number working.
+- Add `export async function runCloseBatch(ctx, args, log)` that validates `args.reason` against `REASONS` **once, before any GitHub call** (fail-fast), then reuses the existing single-issue `runClose` per issue. `runClose` is unchanged and already idempotent.
+- Return `{ ok, closed, failed, results }` (the `runCreateBatch` precedent). `ok` only when every issue closed; continue past a per-issue failure.
+- **Back-compat:** a length-1 list routes to `runClose` directly so a lone `--issue 12` returns the unchanged single shape `{ ok, issue, reason, status }`, not a batch summary.
+- `isMain`: dispatch single vs batch, print the summary, nonzero exit on any failure.
+
+**AC-IDs:** AC-123.1, AC-123.2, AC-123.3
+
+**Test plan (write first):** AC-123.3 — `--issue 12,13 --reason bogus` → `ok:false`, `/--reason must be one of/`, and no `issue view`/`issue close`/`item-edit` call (assert via `ctxWith` `calls`). AC-123.2 — a lone `--issue 12` through the new entry returns the single-issue shape, not a `results` array.
+
+## T2 — batch happy-path + partial-failure tests (kind: test)
+
+**Files:** tests/board.test.mjs
+
+- Add `runCloseBatch` to the `close.mjs` import (board.test.mjs:11).
+- **AC-123.1** happy path: `--issue 12,13 --reason not-planned --note "…"` → `{ ok:true, closed:2, failed:0 }`, one `results` entry per issue, `issue close … not planned` for both, the `--note` reaches each trail body, idempotent on re-run.
+- **AC-123.1** partial failure: one issue's `issue view` fails → `{ ok:false, closed:1, failed:1 }`, `results` names which failed vs closed (continue-past-failure, per `runCreateBatch`).
+
+**AC-IDs:** AC-123.1
+
+## AC coverage
+- AC-123.1 → T1 (batch orchestration) + T2 (tests)
+- AC-123.2 → T1 (single-issue dispatch) + named test
+- AC-123.3 → T1 (validate reason before any gh call) + named test

--- a/plugin/scripts/board/close.mjs
+++ b/plugin/scripts/board/close.mjs
@@ -70,12 +70,53 @@ export async function runClose(ctx, args, log = console.log) {
   return { ok: true, issue: args.issue, reason: args.reason, status: spec.status };
 }
 
+/**
+ * Batch wrapper over runClose. `args.issue` may be a comma-separated string
+ * (`'12,13'`) or a single value. Validates `--reason` ONCE up front so a bad
+ * reason fails fast with no GitHub call. A single issue delegates to runClose
+ * and returns its shape verbatim; two or more loop per-issue, continuing past
+ * failures, and return a `{ ok, closed, failed, results }` summary.
+ */
+export async function runCloseBatch(ctx, args, log = console.log) {
+  if (!REASONS[args.reason]) {
+    return { ok: false, error: `--reason must be one of: ${Object.keys(REASONS).join(', ')}` };
+  }
+  // strict per-token parsing: split on ',', trim, require positive integers.
+  // no silent drops — an empty list or ANY bad token fails before any GitHub call
+  // (a lax parse would let '--issue abc' collapse to [] → a no-op reported as
+  // success, and empty/whitespace tokens would become issue 0 via Number('')).
+  const tokens = String(args.issue ?? '').split(',').map((s) => s.trim());
+  const bad = tokens.find((t) => !/^\d+$/.test(t));
+  if (bad !== undefined) {
+    return { ok: false, error: `--issue must be one or more positive integers, got '${bad}'` };
+  }
+  const issues = tokens.map((t) => Number(t));
+
+  if (issues.length === 1) return runClose(ctx, { ...args, issue: issues[0] }, log);
+
+  const results = [];
+  let closed = 0; let failed = 0;
+  for (const n of issues) {
+    const r = await runClose(ctx, { ...args, issue: n }, log);
+    if (r.ok) closed++; else { failed++; log(`  ✗ #${n}: ${r.error}`); }
+    results.push({ ...r, issue: n });
+  }
+  log(`batch: ${closed} closed, ${failed} failed of ${issues.length}`);
+  return { ok: failed === 0, closed, failed, results };
+}
+
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 if (isMain) {
   const gh = makeGh(run);
   makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
     if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
-    const res = await runClose(ctx, parseArgs(process.argv.slice(2)));
+    const raw = process.argv.slice(2);
+    // keep --issue usable for both single and batch: pull the raw string here so
+    // runCloseBatch can split on ',' (parseArgs coerces to a single Number).
+    const idx = raw.indexOf('--issue');
+    const args = parseArgs(raw);
+    if (idx !== -1 && raw[idx + 1] !== undefined) args.issue = raw[idx + 1];
+    const res = await runCloseBatch(ctx, args);
     if (!res.ok) { console.error(`close failed: ${res.error}`); process.exit(1); }
   });
 }

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -8,7 +8,7 @@ import { buildAddSubIssue, addSubIssue } from '../plugin/scripts/lib/issues.mjs'
 import { runReparent, parseArgs as reparentArgs } from '../plugin/scripts/board/reparent.mjs';
 import { runMove, parseArgs as moveArgs } from '../plugin/scripts/board/move.mjs';
 import { runComment, parseArgs as commentArgs } from '../plugin/scripts/board/comment.mjs';
-import { runClose, parseArgs as closeArgs } from '../plugin/scripts/board/close.mjs';
+import { runClose, runCloseBatch, parseArgs as closeArgs } from '../plugin/scripts/board/close.mjs';
 import { runReceipt } from '../plugin/scripts/board/receipt.mjs';
 import { runLog } from '../plugin/scripts/board/log.mjs';
 import { runDigest, renderChildTable, computeFlowMetrics, renderFlow, cycleDays } from '../plugin/scripts/board/digest.mjs';
@@ -344,6 +344,116 @@ describe('close (AC-117)', () => {
     const res = await runClose(ctx, closeArgs(['--issue', '1', '--reason', 'bogus']), noop);
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/--reason must be one of/);
+  });
+});
+
+describe('batch close (AC-123)', () => {
+  // Per-issue trail comment routes, mirroring AC-117.1's commentRoutes but keyed
+  // by issue number so each issue keeps its own trail ledger (no cross-talk).
+  // list (GET, has `?`) → returns the current ledger; create (POST, has `-f`) →
+  // seeds a trail:closed marker so a re-run PATCHes rather than stacking.
+  const commentRoutes = (ref, num) => [
+    [(j) => j.includes(`/issues/${num}/comments?`), () => ({ stdout: JSON.stringify(ref.comments) })],
+    [(j) => j.includes(`/issues/${num}/comments`) && j.endsWith('/comments') === false && j.includes('-f'), () => { ref.comments = [{ id: num, body: '<!-- forge:trail:closed -->' }]; return { stdout: JSON.stringify({ id: num }) }; }],
+  ];
+
+  // runCloseBatch's parsed-args contract: `issue` is a comma-separated string
+  // (or a single number-as-string), plus the same `reason`/`note` runClose reads.
+  it('AC-123.1: --issue 12,13 closes each, one result per issue, note in every trail, idempotent', async () => {
+    const ref12 = { comments: [] };
+    const ref13 = { comments: [] };
+    const { ctx, calls } = await ctxWith([
+      ['issue view', { stdout: JSON.stringify({ state: 'OPEN' }) }],
+      ['issue close', { stdout: '' }],
+      [(j) => j.startsWith('project item-list'), itemList([
+        { id: 'ITEM_9', content: { number: 12 }, status: 'Done' },
+        { id: 'ITEM_10', content: { number: 13 }, status: 'Done' },
+      ])],
+      ['project item-edit', { stdout: '' }],
+      [(j) => j.startsWith('api -X PATCH'), { stdout: '{}' }], // re-run PATCHes the existing trail
+      ...commentRoutes(ref12, 12),
+      ...commentRoutes(ref13, 13),
+    ]);
+    const args = { issue: '12,13', reason: 'not-planned', note: 'superseded by ADR-0003' };
+    const res = await runCloseBatch(ctx, args, noop);
+
+    expect(res).toMatchObject({ ok: true, closed: 2, failed: 0 });
+    expect(Array.isArray(res.results)).toBe(true);
+    expect(res.results.length).toBe(2); // one entry per issue
+
+    // BOTH issues get a NOT_PLANNED GitHub close ("not planned")
+    expect(calls.filter((c) => c.startsWith('issue close') && c.includes('not planned')).length).toBe(2);
+    // the note reaches EACH issue's trail body (one create per issue)
+    expect(calls.filter((c) => c.includes('/issues/12/comments') && c.includes('superseded by ADR-0003')).length).toBe(1);
+    expect(calls.filter((c) => c.includes('/issues/13/comments') && c.includes('superseded by ADR-0003')).length).toBe(1);
+
+    // idempotent: re-running yields the same summary and does not stack trail
+    // comments (the marker exists now → PATCH, not a second POST to /issues/N/comments)
+    const res2 = await runCloseBatch(ctx, args, noop);
+    expect(res2).toMatchObject({ ok: true, closed: 2, failed: 0 });
+    expect(calls.filter((c) => c.includes('/issues/12/comments') && c.includes('-f')).length).toBe(1);
+    expect(calls.filter((c) => c.includes('/issues/13/comments') && c.includes('-f')).length).toBe(1);
+  });
+
+  it('AC-123.1: partial failure — one issue view fails → ok:false closed:1 failed:1, naming the failure', async () => {
+    const ref12 = { comments: [] };
+    const { ctx } = await ctxWith([
+      [(j) => j.startsWith('issue view 13'), { ok: false, stderr: 'issue view failed for #13' }], // must precede the generic route
+      ['issue view', { stdout: JSON.stringify({ state: 'OPEN' }) }],
+      ['issue close', { stdout: '' }],
+      [(j) => j.startsWith('project item-list'), itemList([
+        { id: 'ITEM_9', content: { number: 12 }, status: 'Done' },
+        { id: 'ITEM_10', content: { number: 13 }, status: 'Done' },
+      ])],
+      ['project item-edit', { stdout: '' }],
+      ...commentRoutes(ref12, 12),
+    ]);
+    const res = await runCloseBatch(ctx, { issue: '12,13', reason: 'not-planned' }, noop);
+
+    expect(res).toMatchObject({ ok: false, closed: 1, failed: 1 });
+    const r12 = res.results.find((r) => r.issue === 12);
+    const r13 = res.results.find((r) => r.issue === 13);
+    expect(r12).toMatchObject({ ok: true });   // the good one still closed
+    expect(r13).toMatchObject({ ok: false });  // results name which issue failed
+  });
+
+  it('AC-123.2: a single --issue 12 returns the unchanged single-issue shape, not a batch summary', async () => {
+    const ref12 = { comments: [] };
+    const { ctx } = await ctxWith([
+      ['issue view', { stdout: JSON.stringify({ state: 'OPEN' }) }],
+      ['issue close', { stdout: '' }],
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_9', content: { number: 12 }, status: 'Done' }])],
+      ['project item-edit', { stdout: '' }],
+      ...commentRoutes(ref12, 12),
+    ]);
+    const res = await runCloseBatch(ctx, { issue: '12', reason: 'not-planned' }, noop);
+
+    expect(res).toMatchObject({ ok: true, issue: 12, reason: 'not-planned', status: 'wontDo' });
+    expect(res.results).toBeUndefined(); // NOT a batch summary
+    expect('closed' in res).toBe(false);
+  });
+
+  it('AC-123.3: bogus --reason fails fast — no view/close/item-edit call is made', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runCloseBatch(ctx, { issue: '12,13', reason: 'bogus' }, noop);
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/--reason must be one of/);
+    expect(calls.some((c) => c.startsWith('issue view'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('issue close'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('project item-edit'))).toBe(false);
+  });
+
+  it('AC-123.4: non-numeric --issue fails fast — no view/close/item-edit call is made', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runCloseBatch(ctx, { issue: 'abc', reason: 'not-planned' }, noop);
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/--issue must be one or more positive integers/);
+    expect(res.error).toContain('abc'); // names the bad input
+    expect(calls.some((c) => c.startsWith('issue view'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('issue close'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('project item-edit'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
**forge:deliver live shakedown** — this PR was produced end-to-end by the `deliver` pipeline on a real ticket, subagents doing each phase, with this PR as the single human gate. Closes #123.

## What it does
`board/close.mjs` now accepts a comma-separated `--issue` list. `runCloseBatch` validates `--reason` once up front, then reuses the single-issue `runClose` per issue (idempotent), returning `{ ok, closed, failed, results }`; a single `--issue` stays back-compatible. Strict positive-integer parsing — empty/invalid `--issue` fails before any GitHub call.

## How deliver ran it (the shakedown)
- **Classify + plan** — `planner` subagent classified it **feature**, produced 2 typed tasks (code + test) with AC-IDs; plan committed.
- **Execute** — `test-architect` wrote 4 failing AC-123 tests (confirmed red) → `implementer` made them pass.
- **Review** — `reviewer` + `security` subagents in parallel. **Security: pass** (argv arrays + numeric filter → no injection). **Reviewer: FAIL** on a real bug: all-invalid/empty `--issue` returned `{ok:true, closed:0}` — a no-op reported as success. A fix-wave `implementer` hardened parsing to strict `/^\d+$/` (fails before any gh call) + added AC-123.4. *The gate caught a genuine bug before it reached you — the point of the flow.*
- **Ship gates** (orchestrator-run): plandrift clean · testintent clean · depguard clean · **acgate: all 3 plan ACs covered by passing tests**.

## Honest verification
- `npx vitest run` → **all green** (262 tests: AC-123.1 batch + partial-failure, .2 single back-compat, .3 bad-reason fail-fast, .4 invalid-issue fail-fast; AC-117 intact).
- Gate ladder all clean; doctor healthy earlier.
- **Not verified:** no live multi-issue close was run against real GitHub issues (tests mock gh); the CLI `--issue 12,13` path is covered by unit tests, not an end-to-end gh call.
- Caveat: the `planner` role isn't in the installed 0.3.0 plugin cache yet, so the plan phase used a general agent primed with the committed planner card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011S1QNxSvSfGyibDiE1ru3x
