### PR TITLE
feat(autopilot): skill loop, selection, escalation model + spec (#126)

### DIFF
--- a/docs/specs/2026-07-21-forge-autopilot.md
+++ b/docs/specs/2026-07-21-forge-autopilot.md
@@ -1,0 +1,107 @@
+# forge:autopilot — continuous autonomous board-clearing engine
+
+**Status: draft — awaiting owner approval.** Board: project #8. Target: next release. Code home: `plugin/skills/autopilot/SKILL.md` + a thin driver in `plugin/scripts/autopilot/`.
+
+## 1. What it is
+
+One command that **clears the whole board unattended**. It picks the next actionable ticket, makes it deliverable, delivers it, merges it, and moves to the next — continuously, until nothing actionable remains. It is `forge:deliver` in a loop with two additions: an **auto-triage front door** (so an untriaged ticket doesn't stall the run) and **auto-merge on green** (so the human is no longer the per-ticket gate). The human is consulted **only** when the product breaks or a decision the engine may not make comes up.
+
+Autopilot is not a new pipeline — it is an **orchestrator over the pipeline forge already has**. Every ticket still runs the real thing: planner classifies it, `execute-agents` fans the roles out, the mechanical gates and the adversarial `reviewer`/`security` subagents run. Autopilot only removes the *human* PR gate and adds the loop around it.
+
+## 2. The trust reversal (the one thing that changes)
+
+`deliver`'s contract is "exactly one human gate — the PR." Autopilot **removes that gate** and replaces it with an *automated* merge bar. This is deliberate and owner-chosen (this spec). The quality guarantee shifts entirely onto the mechanical gates + adversarial subagents + CI. Therefore the merge bar is strict and non-negotiable (§4).
+
+## 3. Orchestration — how it works, mechanically
+
+```
+[you] /forge:autopilot                         (optionally: --limit N, --area <a>, --dry-run)
+        ▼
+loop:  select next actionable ticket  ──────────────┐   selection order §5
+        ▼                                           │
+   triaged?  ── no ──▶  forge:triage the ticket      │   auto-triage front door
+        │                 (still under-specified? ⇒ ESCALATE, skip, continue)
+        ▼ yes                                        │
+   forge:deliver  (planner → execute-agents → ship)  │   the real pipeline, unchanged
+        ▼                                            │
+   merge bar §4  ── any red ──▶ fix wave / ESCALATE   │   never merge red
+        ▼ all green                                  │
+   auto-merge to main (squash, Closes #n)            │
+        ▼                                            │
+   post-merge ritual (move→done, delivery log, trail)│
+        ▼                                            │
+   surfaced a new need? board/create.mjs it ─────────┘   feeds back into the queue
+        ▼
+until: no actionable ticket left  ⇒  STOP + run report
+```
+
+- **One ticket at a time (v1).** Finish and merge one before starting the next — no worktree machinery, no cross-ticket conflicts. The loop is written so a **bounded worktree pool** can drop in later (§8) without touching the per-ticket flow.
+- **Continuous.** After each merge it re-reads the board (new tickets it filed, or ones you added mid-run, are picked up) and keeps going.
+- **Owns state at the top level.** The autopilot loop owns the run ledger (`.forge/autopilot/run.json`: queue, done, escalated, skipped) and the stop condition; each ticket's `deliver` owns its own branch/ledger/gates as today.
+
+## 4. The auto-merge bar (replaces the human PR review)
+
+A ticket merges **only when every one of these is green** — any red routes to a fix wave, and a second failure of the same gate escalates (never a merge on red):
+
+1. `ship` completed: situation gate · conventions lint · rebase + full `verify` green.
+2. All mechanical gates pass: `plandrift`, `testintent`, `depguard`, `acgate` (every AC checked).
+3. Full-branch `reviewer` **and** `security` subagents return `verdict: pass` with **zero critical/high** findings. A critical finding is always an escalation, never an auto-merge.
+4. CI on the PR is green (the PR is opened with `Closes #n` and the honest verification statement, exactly as `deliver` does; autopilot then waits for checks and merges — it does not merge before CI).
+5. Merge is **squash to main**; the branch is deleted; `Closes #n` closes the issue.
+
+If the repo's `features` disables auto-merge (an opt-out flag `features.autopilotAutoMerge: false`), autopilot stops at the open PR for that ticket and records it as *awaiting-human* instead of merging — the loop continues with other tickets. This keeps the safe-by-default door for consumers who adopt autopilot but not its merge policy.
+
+## 5. Selection — what "next actionable" means
+
+Priority-ordered, then FIFO within a priority:
+
+1. `inReview` / `inProgress` left mid-flight by a previous run → **resume first** (deliver's resume protocol).
+2. `ready` (triaged) tickets, `p0` → `p1` → `p2`.
+3. `backlog` tickets → **auto-triaged** first (front door), then delivered.
+4. Never: `blocked` (has a pending decision), `done`, `wontDo`, or anything with an unresolved escalation.
+
+`--area <a>` restricts selection to one area; `--limit N` stops after N merges; `--dry-run` prints the plan (selection + classification per ticket) and makes no changes.
+
+## 6. The human gates — the only pauses
+
+Autopilot halts **only** for these, via `escalate.mjs` (blocked + decision comment + pending file), then continues with the *next* ticket (one escalation does not stop the whole run — it parks that ticket and moves on):
+
+- **Product broken, no safe fix** — verify/CI red after a fix wave, or a change that breaks unrelated behaviour and the fix is beyond the plan's blast radius.
+- **Design deviation needs a decision** — the work can't be done as designed; the choice isn't the engine's to make (spec/ADR ambiguity, a product-behaviour fork).
+- **Under-specified ticket** — planner/triage returns `verdict: fail`; the ask or acceptance is unclear. Escalate, don't guess.
+- **Critical security finding.**
+- **Denylist-blocked action genuinely needed · reviewer↔implementer deadlock across re-spawns · the same gate failing twice.** (deliver's existing §7 triggers.)
+
+Everything else — routine role choices, UI variant selection, which regression test, a new follow-up ticket — autopilot decides and proceeds.
+
+## 7. It can open new work (tracking as it goes)
+
+When delivery surfaces a need, autopilot files it rather than dropping it — `board/create.mjs`, linked to the driving ticket, trail-noted:
+
+- a **bug** it found but that's out of the current ticket's scope,
+- a **spike** when a ticket turns out to need investigation before it can be built (deliver already does this for spike-kind; autopilot also does it *reactively*),
+- a **follow-up item** for deferred work.
+
+Filed tickets enter the queue and are picked up in a later iteration by §5 — so the board can *grow* during a run and still converge, as long as new work trends down.
+
+## 8. Stop conditions & safety rails
+
+- **Natural stop:** no actionable ticket remains (all `done`/`wontDo`/`blocked`) → print the run report (merged / escalated / skipped / newly-filed) and exit.
+- **`--limit N`:** stop after N merges.
+- **Kill switch:** honours the forge-control global pause (`.forge-control/paused`) and the per-repo situation gate (open incident / security hold) — autopilot spawns nothing while paused. A human clearing the pause is always manual.
+- **Interrupt:** Ctrl-C between tickets is clean (the run ledger is the resume point); mid-ticket, deliver's own resume protocol recovers.
+- **Loop backstop:** a max-iterations guard (default = board size × 2) prevents a pathological file-a-ticket-per-iteration runaway; hitting it escalates rather than looping forever.
+
+## 9. Future: parallel (deferred, designed-for)
+
+v1 is sequential by owner choice. The loop is factored so a **bounded worktree pool** (N tickets in flight, each in its own `git worktree`, chosen for non-overlapping blast radius via the scoper) can replace the single-ticket step without changing the merge bar, the escalation model, or the run ledger. Not built in v1.
+
+## 10. Acceptance criteria
+
+- **AC-1 (loop):** `/forge:autopilot` selects the next actionable ticket per §5, delivers it, and moves to the next — continuously until none remain, then prints a run report. Resumes a mid-flight ticket first.
+- **AC-2 (auto-triage front door):** a `backlog` ticket is triaged before delivery; one that stays under-specified is escalated and skipped, not guessed.
+- **AC-3 (auto-merge bar):** a ticket merges to main only when §4 items 1–5 are all green; any red routes to a fix wave; a repeated failure escalates; **nothing merges on red**. `features.autopilotAutoMerge: false` stops at the open PR instead.
+- **AC-4 (human gates only):** the run halts (`escalate.mjs`) only for the §6 conditions; each escalation parks one ticket and the loop continues with the next.
+- **AC-5 (files new work):** a need surfaced mid-delivery becomes a linked, trail-noted ticket via `board/create.mjs` and re-enters the queue.
+- **AC-6 (safety):** honours the global pause / situation gate; the loop backstop prevents runaway; the run ledger makes an interrupted run resumable.
+- **AC-7 (trail):** every lifecycle moment is trail-commented on the driving ticket (started · delivered · merged · escalated · filed), and the run is summarised on the delivery-log issue.

--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: autopilot
+description: Continuously clears the whole board unattended — picks the next actionable ticket, auto-triages it if needed, delivers it via forge:deliver, and auto-merges to main on green, one ticket at a time, until nothing actionable remains. The per-ticket human PR gate is replaced by a strict automated merge bar; the only pauses are genuine escalations (product broken, a decision that is the human's to make, critical security). Use to burn a triaged-or-triageable backlog down to empty hands-off.
+---
+
+# forge:autopilot
+
+Clear the board, unattended. Autopilot is **`forge:deliver` in a continuous loop** with two additions: an **auto-triage front door** (an untriaged ticket doesn't stall the run) and **auto-merge on green** (the human is no longer the per-ticket gate). It is an orchestrator *over* the pipeline forge already has — every ticket still runs the real thing (planner → `execute-agents` → mechanical gates → adversarial `reviewer`/`security`). Autopilot only removes the *human* PR gate and adds the loop.
+
+Spec: `docs/specs/2026-07-21-forge-autopilot.md`.
+
+## The contract (what changes, what doesn't)
+
+- **The human PR gate is gone.** In its place, a strict **automated merge bar** (below). This is the deliberate trust reversal — the quality guarantee rests entirely on the mechanical gates + adversarial subagents + CI.
+- **The only pauses are real escalations.** Product broken with no safe fix · a design/behaviour decision that isn't the engine's to make · an under-specified ticket · critical security · plus deliver's existing §7 triggers. Everything routine — role choice, UI variant, which regression test, filing a follow-up — autopilot decides and proceeds.
+- **One ticket at a time (v1).** Finish and merge one before starting the next — no worktree machinery, no cross-ticket conflicts. (Parallel via a bounded worktree pool is designed-for but deferred; see spec §9.)
+- **The loop owns the run; deliver owns each ticket.** Autopilot owns the run ledger and the stop condition; each ticket's branch/ledger/gates/trail stay inside `forge:deliver`.
+
+## The loop
+
+```
+select next actionable ticket (§ selection)
+  ├─ none left ────────────────────────────▶ STOP + run report
+  ▼
+triaged?  ── no ──▶ forge:triage
+                      └─ still under-specified (verdict: fail) ─▶ ESCALATE + skip, continue
+  ▼ yes
+forge:deliver  (planner → execute-agents → ship, up to the open PR)
+  ▼
+merge bar (§ auto-merge)  ── any red ──▶ fix wave; repeat failure ─▶ ESCALATE + park, continue
+  ▼ all green
+squash-merge to main · post-merge ritual · trail --phase merged
+  ▼
+surfaced new work? ─▶ board/create.mjs it (linked, trail-noted) — re-enters the queue
+  ▼
+loop
+```
+
+## Selection — "next actionable"
+
+Priority-ordered, FIFO within a priority. Read the board fresh each iteration (tickets you filed, or the owner added mid-run, get picked up):
+
+1. **Resume first** — an `inProgress`/`inReview` ticket left mid-flight by an earlier run (deliver's resume protocol continues it).
+2. `ready` (triaged), `p0` → `p1` → `p2`.
+3. `backlog` — **auto-triaged** first (the front door), then delivered.
+4. **Never selected:** `blocked` (has a pending decision), `done`, `wontDo`, or any ticket with an unresolved escalation.
+
+Flags: `--limit N` stop after N merges · `--area <a>` restrict to one area · `--dry-run` print the selection + per-ticket classification and change nothing.
+
+## Auto-triage front door
+
+A `backlog` ticket is run through `forge:triage` to become deliverable *before* `deliver` sees it. If it still can't be specified (planner or triage returns `verdict: fail` — the ask or acceptance is unclear), **escalate it and skip** — the loop moves to the next ticket. Autopilot never guesses a product decision to keep moving.
+
+## Auto-merge — the bar that replaces human review
+
+A ticket merges **only when every one of these is green**. Any red routes to a fix wave (a fresh `implementer` spawn inside deliver's flow); the *same* gate failing twice is an escalation. **Nothing merges on red — ever.**
+
+1. `forge:ship` completed clean: situation gate · conventions lint · rebase + full `verify` green.
+2. All mechanical gates pass: `plandrift` · `testintent` · `depguard` · `acgate` (every AC id in a passing test).
+3. Full-branch `reviewer` **and** `security` subagents return `verdict: pass` with **zero critical/high** findings. A critical is always an escalation, never a merge.
+4. **CI on the PR is green.** Open the PR as deliver does (`Closes #n`, AC checklist, honest verification), then wait for checks — never merge before CI.
+5. **Squash-merge to main**, delete the branch, `Closes #n` closes the issue.
+
+**Opt-out:** if `features.autopilotAutoMerge` is `false`, autopilot stops at the open PR for that ticket, records it as *awaiting-human*, and continues the loop with other tickets — the safe-by-default door for consumers who adopt autopilot but not its merge policy.
+
+## The human gates — the only pauses (spec §6)
+
+Halt via `escalate.mjs` (ticket → blocked + decision comment + pending file). An escalation **parks one ticket** and the loop continues with the next — a single blocked ticket does not stop the whole run.
+
+- **Product broken, no safe fix** — verify/CI red after a fix wave, or a change breaking unrelated behaviour with a fix beyond the plan's blast radius.
+- **Design deviation needs a decision** — the work can't be done as designed and the choice isn't the engine's (spec/ADR ambiguity, a product-behaviour fork).
+- **Under-specified ticket** — planner/triage `verdict: fail`.
+- **Critical security finding.**
+- **deliver's §7 triggers** — denylist-blocked action genuinely needed · reviewer↔implementer deadlock across re-spawns · the same gate failing twice.
+
+## Filing new work as it goes (spec §7)
+
+When delivery surfaces a need out of the current ticket's scope, file it rather than drop it — `board/create.mjs`, linked to the driving ticket, trail-noted: a **bug** found in passing, a **spike** when a ticket turns out to need investigation first, a **follow-up item** for deferred work. Filed tickets re-enter the queue and are picked up by a later iteration — the board may *grow* mid-run and still converge, as long as new work trends down.
+
+## Stop conditions & safety rails (spec §8)
+
+- **Natural stop:** no actionable ticket remains → print the run report (merged / escalated / skipped / newly-filed) and exit.
+- **`--limit N`:** stop after N merges.
+- **Kill switch:** honour the forge-control global pause (`.forge-control/paused`) and the per-repo situation gate (open incident / security hold) — spawn nothing while paused. Clearing a pause is always a human, never automated.
+- **Interrupt:** Ctrl-C between tickets is clean (the run ledger is the resume point); mid-ticket, deliver's own resume protocol recovers.
+- **Loop backstop:** a max-iterations guard (default = board size × 2) prevents a file-a-ticket-per-iteration runaway — hitting it escalates rather than looping forever.
+
+## Run ledger & report
+
+The loop owns `.forge/autopilot/run.json`: the queue, and per ticket `merged | escalated | skipped | filed` with the PR/decision ref. A fresh session reads it to resume. At stop, print the report: how many merged, which parked (with why), which skipped, what new tickets were filed — and summarise the run on the delivery-log issue.
+
+## Resume protocol
+
+Fresh session: read `.forge/autopilot/run.json` for run state → `escalate.mjs --check` to pick up any decisions the human answered → re-select per the selection order (which naturally resumes a mid-flight ticket first) → continue the loop.

--- a/tests/skills/autopilot.test.mjs
+++ b/tests/skills/autopilot.test.mjs
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => readFile(join(root, rel), 'utf8');
+
+describe('forge:autopilot skill (AC-1, AC-4, #126)', () => {
+  it('AC-1: is a continuous loop over deliver — select, deliver, advance, until none remain', async () => {
+    const s = await read('plugin/skills/autopilot/SKILL.md');
+    expect(s).toMatch(/^name:\s*autopilot$/m);
+    // built on the real pipeline, not a parallel one
+    expect(s).toMatch(/forge:deliver/);
+    expect(s).toMatch(/loop/i);
+    expect(s).toMatch(/select.*next actionable|next actionable/i);
+    // continuous until the board is empty, then a run report
+    expect(s).toMatch(/no actionable ticket remains|none left|until.*none/i);
+    expect(s).toMatch(/run report/i);
+    // one at a time in v1 (parallel is deferred)
+    expect(s).toMatch(/one ticket at a time/i);
+  });
+
+  it('AC-4: the human PR gate is replaced by a strict merge bar — nothing merges on red', async () => {
+    const s = await read('plugin/skills/autopilot/SKILL.md');
+    expect(s).toMatch(/auto-merge/i);
+    expect(s).toMatch(/squash-merge to main/i);
+    // the bar: ship green + mechanical gates + reviewer/security + CI green
+    for (const gate of ['plandrift', 'testintent', 'depguard', 'acgate']) {
+      expect(s, `merge bar missing ${gate}`).toContain(gate);
+    }
+    expect(s).toMatch(/reviewer/);
+    expect(s).toMatch(/security/);
+    expect(s).toMatch(/CI.*green|green.*CI/i);
+    // the invariant
+    expect(s).toMatch(/nothing merges on red|never merge.*red|merges on red.*ever/i);
+    // safe-by-default opt-out
+    expect(s).toMatch(/autopilotAutoMerge/);
+  });
+
+  it('AC-4: halts only on real escalations, and an escalation parks one ticket + continues', async () => {
+    const s = await read('plugin/skills/autopilot/SKILL.md');
+    expect(s).toMatch(/escalate\.mjs/);
+    // the owner's two headline gates
+    expect(s).toMatch(/product broken/i);
+    expect(s).toMatch(/decision.*(not|isn't) the engine|design deviation needs a decision/i);
+    // one escalation must not stop the whole run
+    expect(s).toMatch(/parks? one ticket|continue.*next|does not stop the whole run/i);
+  });
+
+  it('AC-2 front door + AC-5 files new work + AC-6 safety are all specified', async () => {
+    const s = await read('plugin/skills/autopilot/SKILL.md');
+    // auto-triage front door, under-specified => escalate + skip
+    expect(s).toMatch(/auto-triage|front door/i);
+    expect(s).toMatch(/forge:triage/);
+    expect(s).toMatch(/verdict: fail/);
+    // can open new bugs/spikes/items mid-run
+    expect(s).toMatch(/board\/create\.mjs/);
+    expect(s).toMatch(/bug/);
+    expect(s).toMatch(/spike/);
+    // safety rails: pause / kill switch, loop backstop, resumable run ledger
+    expect(s).toMatch(/paused|kill switch/i);
+    expect(s).toMatch(/backstop|max-iterations/i);
+    expect(s).toMatch(/run\.json|run ledger/i);
+  });
+});


### PR DESCRIPTION
Closes #126 · epic #125 · spec `docs/specs/2026-07-21-forge-autopilot.md`

## What
The first slice of **forge:autopilot** — the continuous board-clearing engine. This PR ships the **spec** and the **skill** (the loop, selection order, escalation model, stop conditions, run ledger/resume).

Autopilot is `forge:deliver` in a loop, plus an auto-triage front door and **auto-merge on green** — the per-ticket human PR gate is replaced by a strict automated merge bar. The only pauses are real escalations; each parks one ticket and the loop continues.

## Commits → issues
- `b71c5ca` feat(autopilot): skill loop, selection, escalation model + spec (#126)

## AC checklist (this slice)
- [x] **AC-1 (loop):** continuous select → deliver → advance until none remain, then a run report; resumes a mid-flight ticket first.
- [x] **AC-4 (human gates only):** halts only on the §6 escalations via `escalate.mjs`; an escalation parks one ticket, the loop continues. Merge bar specified: nothing merges on red; `features.autopilotAutoMerge:false` stops at the open PR.
- [x] AC-2/AC-5/AC-6 **specified** in the skill (front door, new-work filing, safety rails) — their *executable* pieces land in the sibling sub-issues #127–#131.

## Verification (honest)
- Ran: full `vitest run` — **266/266 pass** (33 files), including 4 new assertions in `tests/skills/autopilot.test.mjs`.
- This is a prose-skill deliverable implemented main-loop (not a subagent fan-out) and there is no committed plan doc, so the plan-based ship gates (`plandrift`/`acgate`) were **not** run — the skill-contract test is the mechanical check here. No new dependencies (`depguard` n/a).
- The auto-merge *driver*, run-ledger *code*, and triage-handoff *wiring* are **not** in this PR — they are #127/#129/#128. This slice is design + skill contract only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
