### PR TITLE
feat(autopilot): executable engine — selection, merge bar, run ledger, filing (#127–#131)

### DIFF
--- a/plugin/scripts/autopilot/ledger.mjs
+++ b/plugin/scripts/autopilot/ledger.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * autopilot run ledger — the top-level state the loop owns (#129, spec §3/§8).
+ * One JSON file per repo: what the current run has merged / escalated / skipped
+ * / filed, so a fresh session resumes and the end-of-run report is exact.
+ * Per-ticket state stays inside forge:deliver — this is only the run.
+ */
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { readJson, writeJson } from '../lib/jsonfile.mjs';
+
+export const RUN_RELPATH = join('.forge', 'autopilot', 'run.json');
+export const OUTCOMES = ['merged', 'escalated', 'skipped', 'awaiting-human'];
+
+export function freshRun(startedAt = null) {
+  return { version: 1, startedAt, iterations: 0, outcomes: [], filed: [] };
+}
+
+export async function loadRun(cwd) {
+  return (await readJson(join(cwd, RUN_RELPATH))) ?? freshRun();
+}
+
+/**
+ * Pure state transition: record what happened to one ticket this iteration.
+ * Last write for an issue wins (a re-run of the same ticket supersedes), so
+ * the ledger is idempotent under resume. Bumps the iteration counter.
+ */
+export function applyOutcome(run, { issue, outcome, ref = null }) {
+  if (!OUTCOMES.includes(outcome)) throw new Error(`unknown outcome '${outcome}' — valid: ${OUTCOMES.join(', ')}`);
+  const outcomes = run.outcomes.filter((o) => o.issue !== issue);
+  outcomes.push({ issue, outcome, ref, at: new Date().toISOString() });
+  return { ...run, iterations: run.iterations + 1, outcomes };
+}
+
+/** Record a ticket the run filed mid-delivery (bug/spike/follow-up). */
+export function applyFiled(run, { issue, kind, from }) {
+  if (run.filed.some((f) => f.issue === issue)) return run;
+  return { ...run, filed: [...run.filed, { issue, kind, from }] };
+}
+
+/**
+ * Loop backstop (spec §8): a pathological file-a-ticket-per-iteration run must
+ * not loop forever. Once iterations exceed board size × factor, stop and escalate.
+ */
+export function guardTripped(run, boardSize, factor = 2) {
+  return run.iterations >= Math.max(1, boardSize) * factor;
+}
+
+export function renderReport(run) {
+  const by = (o) => run.outcomes.filter((x) => x.outcome === o);
+  const line = (o) => {
+    const items = by(o);
+    return items.length ? `  ${o}: ${items.map((x) => `#${x.issue}${x.ref ? ` (${x.ref})` : ''}`).join(', ')}` : null;
+  };
+  const parts = [
+    `autopilot run — ${run.iterations} iteration(s)`,
+    ...OUTCOMES.map(line).filter(Boolean),
+    run.filed.length ? `  filed: ${run.filed.map((f) => `#${f.issue} (${f.kind})`).join(', ')}` : null,
+  ].filter(Boolean);
+  if (parts.length === 1) parts.push('  (nothing actionable — board was already clear)');
+  return parts.join('\n');
+}
+
+// IO wrappers the loop calls.
+export async function recordOutcome(cwd, entry) {
+  const run = applyOutcome(await loadRun(cwd), entry);
+  await writeJson(join(cwd, RUN_RELPATH), run);
+  return run;
+}
+export async function recordFiled(cwd, entry) {
+  const run = applyFiled(await loadRun(cwd), entry);
+  await writeJson(join(cwd, RUN_RELPATH), run);
+  return run;
+}
+export async function startRun(cwd) {
+  const existing = await readJson(join(cwd, RUN_RELPATH));
+  if (existing?.startedAt) return existing; // resume — keep the original start
+  const run = freshRun(new Date().toISOString());
+  await writeJson(join(cwd, RUN_RELPATH), run);
+  return run;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const sub = process.argv[2];
+  if (sub === 'report') {
+    loadRun(process.cwd()).then((run) => console.log(renderReport(run)));
+  } else {
+    console.error('usage: ledger.mjs report');
+    process.exit(1);
+  }
+}

--- a/plugin/scripts/autopilot/merge.mjs
+++ b/plugin/scripts/autopilot/merge.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * autopilot auto-merge — the bar that replaces the human PR review (#127, spec §4).
+ * The trust reversal: a ticket merges only when EVERY signal is green. The bar is
+ * a pure function so the invariant "nothing merges on red" is mechanically tested;
+ * the live squash-merge is a thin gh call gated behind it.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+
+/** The five signals of the merge bar (spec §4). All must be true to merge. */
+export const BAR_SIGNALS = ['ship', 'gates', 'reviewer', 'security', 'ci'];
+
+/** Owner opt-out: default ON. `features.autopilotAutoMerge: false` parks at the PR. */
+export function autoMergeEnabled(config) {
+  return config?.features?.autopilotAutoMerge !== false;
+}
+
+/**
+ * Evaluate the bar. `signals` maps each of BAR_SIGNALS to a boolean; a missing
+ * signal counts as NOT green (fail-closed). `critical` (a critical security or
+ * review finding) forces an escalation regardless. Returns whether to merge,
+ * what it's blocked on, and whether the block is an escalation vs a fix-wave.
+ */
+export function evaluateMergeBar(signals = {}, { critical = false } = {}) {
+  const blockedOn = BAR_SIGNALS.filter((s) => signals[s] !== true);
+  if (critical) blockedOn.unshift('security:critical');
+  const merge = blockedOn.length === 0;
+  return { merge, blockedOn, escalate: critical };
+}
+
+/** Is the PR's CI fully green? Empty rollup counts as NOT green (fail-closed). */
+export async function ciGreen(gh, pr) {
+  const res = await gh(['pr', 'view', String(pr), '--json', 'statusCheckRollup'], { parseJson: true });
+  if (!res.ok) return { ok: false, green: false, error: res.stderr || 'pr view failed' };
+  const rollup = res.json?.statusCheckRollup ?? [];
+  if (rollup.length === 0) return { ok: true, green: false, reason: 'no checks reported yet' };
+  const bad = rollup.filter((c) => {
+    const state = c.conclusion ?? c.state; // CheckRun uses conclusion; StatusContext uses state
+    return state !== 'SUCCESS' && state !== 'NEUTRAL' && state !== 'SKIPPED';
+  });
+  return { ok: true, green: bad.length === 0, pending: bad.map((c) => c.name ?? c.context) };
+}
+
+/**
+ * Live merge, gated by the bar. `signals` carries the orchestrator's held
+ * verdicts (ship/gates/reviewer/security); CI is checked here. When auto-merge
+ * is disabled, park at the PR (awaiting-human) and let the loop continue.
+ */
+export async function runMerge(ctx, { issue, pr, signals = {}, critical = false }, log = console.log) {
+  if (!Number.isInteger(issue) || !Number.isInteger(pr)) return { ok: false, error: '--issue and --pr are required' };
+  if (!autoMergeEnabled(ctx.config)) {
+    log(`autopilot: features.autopilotAutoMerge=false — parking #${issue} at PR #${pr} (awaiting-human)`);
+    return { ok: true, merged: false, parked: true, outcome: 'awaiting-human' };
+  }
+  const ci = await ciGreen(ctx.gh, pr);
+  if (!ci.ok) return { ok: false, error: ci.error };
+  const bar = evaluateMergeBar({ ...signals, ci: ci.green }, { critical });
+  if (!bar.merge) {
+    log(`autopilot: merge bar RED for #${issue} — blocked on ${bar.blockedOn.join(', ')}${bar.escalate ? ' (escalate)' : ''}`);
+    return { ok: false, merged: false, blockedOn: bar.blockedOn, escalate: bar.escalate };
+  }
+  const merged = await ctx.gh(['pr', 'merge', String(pr), '--squash', '--delete-branch']);
+  if (!merged.ok) return { ok: false, error: merged.stderr || 'gh pr merge failed' };
+  log(`autopilot: merged #${issue} via PR #${pr} (squash)`);
+  return { ok: true, merged: true, outcome: 'merged' };
+}
+
+function parseArgs(argv) {
+  const a = { issue: null, pr: null, signals: {}, critical: false };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
+    else if (argv[i] === '--pr') a.pr = Number(argv[++i]);
+    else if (argv[i] === '--critical') a.critical = true;
+    else if (argv[i].startsWith('--') && BAR_SIGNALS.includes(argv[i].slice(2))) a.signals[argv[i].slice(2)] = true;
+  }
+  return a;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    // signals default false: the orchestrator passes --ship --gates --reviewer --security once it holds those verdicts.
+    const res = await runMerge(ctx, parseArgs(process.argv.slice(2)));
+    if (!res.ok && res.error) { console.error(`merge failed: ${res.error}`); process.exit(1); }
+    if (!res.merged && !res.parked) process.exit(2); // bar red — not an error, but not merged
+  });
+}

--- a/plugin/scripts/autopilot/newwork.mjs
+++ b/plugin/scripts/autopilot/newwork.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * autopilot reactive filing — turn a need surfaced mid-delivery into a tracked,
+ * linked ticket instead of dropping it (#130, spec §7). Thin wrapper over
+ * board/create.mjs: it maps the delivery "kind" to a board type and links the
+ * new ticket to the driving ticket. The loop then picks it up in a later pass.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+import { runCreate } from '../board/create.mjs';
+
+// Delivery kinds → board type options (epic/item/bug/test). No 'spike' type — a
+// spike is tracked as an item whose body says "spike:" (deliver's spike route).
+export const KIND_TO_TYPE = { bug: 'bug', test: 'test', spike: 'item', feature: 'item', chore: 'item', item: 'item' };
+
+export function toType(kind) {
+  return KIND_TO_TYPE[kind] ?? 'item';
+}
+
+/**
+ * File one follow-up. `spec`: { title, body, kind, from (driving issue#),
+ * priority?, size? }. Returns the created issue number. `create` is injected
+ * for testing; defaults to the real board/create.mjs.
+ */
+export async function fileWork(ctx, spec, create = runCreate, log = console.log) {
+  if (!spec?.title) return { ok: false, error: 'title is required' };
+  const body = `${spec.body ?? ''}${spec.from ? `\n\n_Filed by forge:autopilot while delivering #${spec.from}._` : ''}`;
+  const res = await create(ctx, {
+    title: spec.title,
+    body,
+    type: toType(spec.kind),
+    priority: spec.priority ?? 'p2',
+    size: spec.size ?? 's',
+    status: 'backlog',
+    parent: spec.parent ?? null,
+    unknownFlags: [],
+  }, log);
+  if (!res.ok) return res;
+  return { ok: true, number: res.number, kind: spec.kind ?? 'item' };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const argv = process.argv.slice(2);
+    const get = (f) => (argv.includes(f) ? argv[argv.indexOf(f) + 1] : null);
+    const res = await fileWork(ctx, {
+      title: get('--title'), body: get('--body') ?? '', kind: get('--kind') ?? 'item',
+      from: get('--from') ? Number(get('--from')) : null, parent: get('--parent') ? Number(get('--parent')) : null,
+    });
+    if (!res.ok) { console.error(`file failed: ${res.error}`); process.exit(1); }
+    console.log(`filed #${res.number} (${res.kind})`);
+  });
+}

--- a/plugin/scripts/autopilot/select.mjs
+++ b/plugin/scripts/autopilot/select.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * autopilot select — "what's the next actionable ticket?" (#128, spec §5).
+ * Pure selection over normalized board tickets, so the order is testable in
+ * isolation from GitHub. The loop reads the board fresh each iteration and
+ * asks this for the next unit of work.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { makeBoardCtx } from '../lib/boardctx.mjs';
+
+// Tier: lower runs first. Resume-in-flight beats fresh work; ready beats backlog.
+const TIER = { inProgress: 0, inReview: 0, ready: 1, backlog: 2 };
+// Never selected — blocked has a pending decision; the rest are terminal.
+const SKIP = new Set(['blocked', 'done', 'wontDo']);
+const PRIORITY_RANK = { p0: 0, p1: 1, p2: 2 };
+
+/** status → what the loop should do with it. */
+export function actionFor(status) {
+  if (status === 'inProgress' || status === 'inReview') return 'resume';
+  if (status === 'ready') return 'deliver';
+  if (status === 'backlog') return 'triage'; // the auto-triage front door, then deliver
+  return null;
+}
+
+/**
+ * Pick the next actionable ticket. `tickets` are normalized:
+ * `{ number, title, status, priority, area? }`. Returns `{ ticket, action }`
+ * or `null` when nothing is actionable. Order: tier, then priority, then
+ * FIFO (issue number as a creation-order stand-in).
+ */
+export function selectNext(tickets, { area = null } = {}) {
+  const actionable = tickets
+    .filter((t) => !SKIP.has(t.status) && TIER[t.status] !== undefined)
+    .filter((t) => (area ? t.area === area : true))
+    .sort((a, b) =>
+      (TIER[a.status] - TIER[b.status]) ||
+      ((PRIORITY_RANK[a.priority] ?? 3) - (PRIORITY_RANK[b.priority] ?? 3)) ||
+      (a.number - b.number));
+  const ticket = actionable[0];
+  if (!ticket) return null;
+  return { ticket, action: actionFor(ticket.status) };
+}
+
+/** Everything the loop could still touch, in the order it will touch it. */
+export function actionableQueue(tickets, opts = {}) {
+  const q = [];
+  let pool = tickets;
+  // selectNext is stable enough to just re-rank the whole set once:
+  const ranked = [];
+  let pick;
+  const seen = new Set();
+  while ((pick = selectNext(pool.filter((t) => !seen.has(t.number)), opts))) {
+    ranked.push(pick);
+    seen.add(pick.ticket.number);
+  }
+  return ranked;
+}
+
+/** Map a raw board item (gh project item-list) to the normalized shape. */
+export function normalize(ctx, item) {
+  return {
+    number: item.content?.number ?? null,
+    title: item.content?.title ?? item.title ?? '',
+    status: ctx.itemFieldKey(item, 'status'),
+    priority: ctx.itemFieldKey(item, 'priority'),
+    type: ctx.itemFieldKey(item, 'type'),
+  };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
+    if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
+    const area = process.argv.includes('--area') ? process.argv[process.argv.indexOf('--area') + 1] : null;
+    const list = await ctx.listItems();
+    if (!list.ok) { console.error(list.error); process.exit(1); }
+    const tickets = list.items.map((i) => normalize(ctx, i)).filter((t) => t.number != null);
+    const next = selectNext(tickets, { area });
+    if (!next) { console.log('autopilot: no actionable ticket — board is clear'); process.exit(0); }
+    console.log(`next: #${next.ticket.number} [${next.ticket.status}/${next.ticket.priority ?? '—'}] → ${next.action} — ${next.ticket.title}`);
+    if (process.argv.includes('--dry-run')) {
+      const q = actionableQueue(tickets, { area });
+      console.log(`\nqueue (${q.length}):`);
+      for (const { ticket, action } of q) console.log(`  #${ticket.number} [${ticket.status}/${ticket.priority ?? '—'}] → ${action} — ${ticket.title}`);
+    }
+  });
+}

--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -89,6 +89,17 @@ When delivery surfaces a need out of the current ticket's scope, file it rather 
 
 The loop owns `.forge/autopilot/run.json`: the queue, and per ticket `merged | escalated | skipped | filed` with the PR/decision ref. A fresh session reads it to resume. At stop, print the report: how many merged, which parked (with why), which skipped, what new tickets were filed — and summarise the run on the delivery-log issue.
 
+## Driver scripts (the executable spine)
+
+The loop is prose the orchestrator runs, but its mechanical decisions are real, tested scripts under `${CLAUDE_PLUGIN_ROOT}/scripts/autopilot/`:
+
+- `select.mjs` — `selectNext(tickets)` / `--dry-run`: the selection order + the triage/deliver/resume decision (§ selection). Pure, so the order is testable.
+- `merge.mjs` — `evaluateMergeBar(signals)` + `runMerge(ctx,{issue,pr,signals})`: the auto-merge bar. Fail-closed — a missing signal is red; `features.autopilotAutoMerge:false` parks at the PR. This is where "nothing merges on red" lives.
+- `ledger.mjs` — the run ledger (`.forge/autopilot/run.json`): `applyOutcome`/`applyFiled`/`guardTripped`/`renderReport`, plus `ledger.mjs report`. The loop backstop and the resume point.
+- `newwork.mjs` — `fileWork(ctx,{title,kind,from})`: files a linked follow-up (bug/spike/item) mid-run.
+
+The orchestrator holds the ship/gate/reviewer/security verdicts and passes them to the merge bar; the scripts never spawn subagents or drive the loop themselves.
+
 ## Resume protocol
 
 Fresh session: read `.forge/autopilot/run.json` for run state → `escalate.mjs --check` to pick up any decisions the human answered → re-select per the selection order (which naturally resumes a mid-flight ticket first) → continue the loop.

--- a/tests/autopilot/engine.test.mjs
+++ b/tests/autopilot/engine.test.mjs
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { selectNext, actionFor, actionableQueue } from '../../plugin/scripts/autopilot/select.mjs';
+import { evaluateMergeBar, autoMergeEnabled, ciGreen, runMerge, BAR_SIGNALS } from '../../plugin/scripts/autopilot/merge.mjs';
+import { applyOutcome, applyFiled, guardTripped, renderReport, freshRun, startRun, recordOutcome, RUN_RELPATH } from '../../plugin/scripts/autopilot/ledger.mjs';
+import { toType, fileWork, KIND_TO_TYPE } from '../../plugin/scripts/autopilot/newwork.mjs';
+
+const t = (number, status, priority = 'p1') => ({ number, status, priority, title: `#${number}` });
+
+describe('autopilot selection (#128, AC-1/AC-2)', () => {
+  it('resume-in-flight beats ready beats backlog; within a tier, p0<p1<p2 then FIFO', () => {
+    const tickets = [
+      t(5, 'backlog', 'p0'), t(4, 'ready', 'p2'), t(3, 'ready', 'p0'),
+      t(2, 'inReview', 'p2'), t(1, 'done', 'p0'),
+    ];
+    // inReview (resume tier) wins despite low priority
+    expect(selectNext(tickets).ticket.number).toBe(2);
+    // drop the resume ticket → best ready by priority (p0 #3), not the backlog p0
+    expect(selectNext(tickets.filter((x) => x.number !== 2)).ticket.number).toBe(3);
+  });
+
+  it('maps status → action (resume/deliver/triage) and never selects terminal/blocked', () => {
+    expect(actionFor('inProgress')).toBe('resume');
+    expect(actionFor('inReview')).toBe('resume');
+    expect(actionFor('ready')).toBe('deliver');
+    expect(actionFor('backlog')).toBe('triage'); // the auto-triage front door
+    expect(selectNext([t(1, 'done'), t(2, 'wontDo'), t(3, 'blocked')])).toBeNull();
+  });
+
+  it('backlog is selectable but routed through triage first (AC-2 front door)', () => {
+    const pick = selectNext([t(9, 'backlog', 'p1')]);
+    expect(pick.action).toBe('triage');
+  });
+
+  it('area filter narrows the pool; queue is the full ordered plan', () => {
+    const tickets = [{ ...t(1, 'ready'), area: 'ui' }, { ...t(2, 'ready'), area: 'api' }];
+    expect(selectNext(tickets, { area: 'api' }).ticket.number).toBe(2);
+    expect(actionableQueue(tickets).map((q) => q.ticket.number)).toEqual([1, 2]);
+  });
+});
+
+describe('autopilot merge bar (#127, AC-3) — the trust reversal', () => {
+  const allGreen = { ship: true, gates: true, reviewer: true, security: true, ci: true };
+
+  it('merges only when every one of the five signals is green', () => {
+    expect(evaluateMergeBar(allGreen).merge).toBe(true);
+    expect(BAR_SIGNALS).toEqual(['ship', 'gates', 'reviewer', 'security', 'ci']);
+  });
+
+  it('NOTHING merges on red — any missing/false signal blocks (fail-closed)', () => {
+    for (const s of BAR_SIGNALS) {
+      const signals = { ...allGreen, [s]: false };
+      const bar = evaluateMergeBar(signals);
+      expect(bar.merge, `${s}=false should block the merge`).toBe(false);
+      expect(bar.blockedOn).toContain(s);
+    }
+    // a signal simply absent is also red, not assumed-green
+    expect(evaluateMergeBar({ ship: true }).merge).toBe(false);
+  });
+
+  it('a critical finding forces an escalation regardless of the other signals', () => {
+    const bar = evaluateMergeBar(allGreen, { critical: true });
+    expect(bar.merge).toBe(false);
+    expect(bar.escalate).toBe(true);
+    expect(bar.blockedOn).toContain('security:critical');
+  });
+
+  it('features.autopilotAutoMerge defaults ON, false parks at the PR', () => {
+    expect(autoMergeEnabled({})).toBe(true);
+    expect(autoMergeEnabled({ features: {} })).toBe(true);
+    expect(autoMergeEnabled({ features: { autopilotAutoMerge: false } })).toBe(false);
+  });
+
+  it('ciGreen is fail-closed: empty rollup is NOT green; a failure is NOT green', async () => {
+    const gh = (json) => async () => ({ ok: true, json });
+    expect((await ciGreen(gh({ statusCheckRollup: [] }))).green).toBe(false);
+    expect((await ciGreen(gh({ statusCheckRollup: [{ conclusion: 'SUCCESS' }, { conclusion: 'FAILURE', name: 'x' }] }))).green).toBe(false);
+    expect((await ciGreen(gh({ statusCheckRollup: [{ conclusion: 'SUCCESS' }, { conclusion: 'SKIPPED' }] }))).green).toBe(true);
+  });
+
+  it('runMerge: disabled → park; bar red → no merge call; all green → squash-merge', async () => {
+    const calls = [];
+    const gh = async (args) => {
+      calls.push(args.join(' '));
+      if (args[0] === 'pr' && args[1] === 'view') return { ok: true, json: { statusCheckRollup: [{ conclusion: 'SUCCESS' }] } };
+      return { ok: true };
+    };
+    // disabled
+    const parked = await runMerge({ config: { features: { autopilotAutoMerge: false } }, gh }, { issue: 1, pr: 9, signals: {} }, () => {});
+    expect(parked).toMatchObject({ merged: false, parked: true, outcome: 'awaiting-human' });
+    expect(calls.some((c) => c.startsWith('pr merge'))).toBe(false);
+    // enabled but a subagent verdict missing → red, no merge
+    const red = await runMerge({ config: {}, gh }, { issue: 1, pr: 9, signals: { ship: true, gates: true, reviewer: true /* security missing */ } }, () => {});
+    expect(red.merged).toBe(false);
+    expect(calls.some((c) => c.startsWith('pr merge'))).toBe(false);
+    // all verdicts + green CI → merge
+    const ok = await runMerge({ config: {}, gh }, { issue: 1, pr: 9, signals: { ship: true, gates: true, reviewer: true, security: true } }, () => {});
+    expect(ok).toMatchObject({ merged: true, outcome: 'merged' });
+    expect(calls).toContain('pr merge 9 --squash --delete-branch');
+  });
+});
+
+describe('autopilot run ledger (#129, AC-6)', () => {
+  it('records outcomes idempotently (last write per issue wins) and bumps iterations', () => {
+    let run = freshRun('2026-07-21T00:00:00Z');
+    run = applyOutcome(run, { issue: 1, outcome: 'merged', ref: 'PR#10' });
+    run = applyOutcome(run, { issue: 2, outcome: 'escalated' });
+    run = applyOutcome(run, { issue: 1, outcome: 'merged', ref: 'PR#10' }); // re-run same ticket
+    expect(run.outcomes.filter((o) => o.issue === 1)).toHaveLength(1);
+    expect(run.iterations).toBe(3);
+  });
+
+  it('tracks filed follow-ups without duplication', () => {
+    let run = applyFiled(freshRun(), { issue: 50, kind: 'bug', from: 12 });
+    run = applyFiled(run, { issue: 50, kind: 'bug', from: 12 });
+    expect(run.filed).toHaveLength(1);
+  });
+
+  it('loop backstop trips at board size × 2', () => {
+    const run = { ...freshRun(), iterations: 8 };
+    expect(guardTripped(run, 4)).toBe(true);   // 8 >= 4*2
+    expect(guardTripped({ ...freshRun(), iterations: 7 }, 4)).toBe(false);
+  });
+
+  it('renderReport summarises merged/escalated/filed', () => {
+    let run = freshRun();
+    run = applyOutcome(run, { issue: 1, outcome: 'merged', ref: 'PR#10' });
+    run = applyOutcome(run, { issue: 2, outcome: 'escalated' });
+    run = applyFiled(run, { issue: 3, kind: 'spike', from: 1 });
+    const out = renderReport(run);
+    expect(out).toMatch(/merged: #1/);
+    expect(out).toMatch(/escalated: #2/);
+    expect(out).toMatch(/filed: #3 \(spike\)/);
+  });
+
+  it('startRun + recordOutcome round-trip to disk and resume keeps the start time', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-autopilot-'));
+    const started = await startRun(cwd);
+    expect(started.startedAt).toBeTruthy();
+    await recordOutcome(cwd, { issue: 7, outcome: 'merged', ref: 'PR#7' });
+    const resumed = await startRun(cwd); // must NOT reset
+    expect(resumed.startedAt).toBe(started.startedAt);
+    const onDisk = JSON.parse(await readFile(join(cwd, RUN_RELPATH), 'utf8'));
+    expect(onDisk.outcomes).toHaveLength(1);
+  });
+});
+
+describe('autopilot reactive filing (#130, AC-5)', () => {
+  it('maps delivery kind → board type (spike→item, bug→bug, test→test)', () => {
+    expect(toType('bug')).toBe('bug');
+    expect(toType('spike')).toBe('item');
+    expect(toType('test')).toBe('test');
+    expect(toType('whatever')).toBe('item');
+    expect(KIND_TO_TYPE.feature).toBe('item');
+  });
+
+  it('fileWork creates a linked ticket, annotates the source, defaults to backlog', async () => {
+    const seen = [];
+    const create = async (_ctx, spec) => { seen.push(spec); return { ok: true, number: 200 }; };
+    const res = await fileWork({}, { title: 'race in queue', kind: 'bug', from: 12, parent: 125 }, create, () => {});
+    expect(res).toMatchObject({ ok: true, number: 200, kind: 'bug' });
+    expect(seen[0]).toMatchObject({ type: 'bug', status: 'backlog', parent: 125 });
+    expect(seen[0].body).toMatch(/while delivering #12/);
+  });
+});


### PR DESCRIPTION
Closes #127 · Closes #128 · Closes #129 · Closes #130 · Closes #131 · epic #125

## What
The runnable core behind the `forge:autopilot` skill — four small, dependency-free, pure-where-possible modules under `plugin/scripts/autopilot/`, plus their tests. Turns the design (merged in #132) into executable, tested code.

## Modules
| Module | Ticket | Role |
|--------|--------|------|
| `select.mjs` | #128 | `selectNext()` — selection order + triage/deliver/resume routing (auto-triage front door) |
| `merge.mjs` | #127 | `evaluateMergeBar()` + `runMerge()` — the auto-merge bar; fail-closed; `autopilotAutoMerge` opt-out |
| `ledger.mjs` | #129 | run ledger (`.forge/autopilot/run.json`) — outcomes, backstop, resume, report |
| `newwork.mjs` | #130 | `fileWork()` — files a linked bug/spike/follow-up mid-run |
| `tests/autopilot/engine.test.mjs` | #131 | 17 tests |

## AC checklist
- [x] **AC-2** front door — `select.mjs` routes `backlog` through triage; `actionFor` proven.
- [x] **AC-3** merge bar — `evaluateMergeBar` is fail-closed; **every** signal tested to block; critical escalates; `autopilotAutoMerge:false` parks. `runMerge` proven to never call `pr merge` on red.
- [x] **AC-5** filing — `fileWork` links to the driving ticket, maps kind→type, defaults to backlog.
- [x] **AC-6** safety — `guardTripped` (board size × 2), `startRun` resume keeps the original start, disk round-trip proven.

## Verification (honest)
- Ran: full `vitest run` — **283/283 pass** (34 files); the 17 new tests are in `tests/autopilot/engine.test.mjs`.
- The modules are unit-tested with injected `gh`/`create` doubles; they are **not** yet exercised against a live board end-to-end (the orchestrator wiring that calls them in sequence is the skill prose, verified by contract in #132's test, not an integration run). No new dependencies. `features.autopilotAutoMerge` needs no schema change — `validateConfig` already accepts arbitrary boolean features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
