### PR TITLE
feat(gates): docsync gate + autopilot context/cost bounding (#136, #137)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,15 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [SP11 — Maintain](plans/2026-07-17-sp11-maintain.md) — tasks T1–T5 for epic #14: outdated scan, patch/minor batch plan, majors bundled, CVE triage with SLA.
 - [Local web console](plans/2026-07-17-local-web-console.md) — tasks T1–T4 for #37: localhost serve, state + decide APIs, self-contained page.
 - [Console UI v2](plans/2026-07-17-console-ui-v2.md) — tasks T1–T5 for #39: decision-flow defect fixes, a11y floor, identity variants + owner pick.
+- [C1 — Control queue](plans/2026-07-18-c1-control-queue.md) — control queue + machine registry + CLI (forge-control epic; see the forge-control spec).
+- [C2 — Control runner](plans/2026-07-19-c2-control-runner.md) — the forge-control runner that spawns + supervises headless sessions.
+- [C3 — Console control tab](plans/2026-07-19-c3-console-control-tab.md) — the console's control tab: sessions, queue, command audit.
+- [C4 — situationgate paused flag](plans/2026-07-19-c4-situationgate-paused.md) — situationgate reads the machine-level paused flag (global kill switch).
+- [C5 — Dogfood end-to-end](plans/2026-07-19-c5-dogfood-end-to-end.md) — one real ticket end-to-end through the control queue.
+- [C6 — Trace + conformance](plans/2026-07-19-c6-trace-conformance.md) — agent-work trace + structure-conformance badge.
+- [C7 — Alerts](plans/2026-07-19-c7-alerts.md) — alerts on session/queue events.
+- [C8 — Quota panel](plans/2026-07-19-c8-quota-panel.md) — Claude Code quota panel in the console.
+- [Batch close](plans/2026-07-20-batch-close.md) — tasks for #123: comma-separated `--issue` in `board/close.mjs`.
 
 ## Design specs
 
@@ -35,6 +44,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [ADR-0001 — Status field options](decisions/0001-status-field-options.md) — built-in Status options are GraphQL-mutable but replacement mints new IDs; init replaces on fresh (empty) projects only, maps-as-is on live boards.
 - [ADR-0002 — Console/control distribution](decisions/0002-console-control-distribution.md) — *(superseded by ADR-0003)* the console + control plane ship as repo tooling run from a checkout, not in the packaged plugin (#91).
 - [ADR-0003 — Remove forge-control + console](decisions/0003-remove-control-console.md) — the local control plane + console are removed (unused for a solo interactive workflow; token/scope reduction). Preserved in the v0.5.0 tag; the pipeline (skills/board/gates/care) is unaffected (#95).
+- [ADR-0004 — Remove the multi-backend plane](decisions/0004-remove-multi-backend-plane.md) — the CLI role-swap / multi-backend plane (Plane B) is removed as unwired dead weight; role subagents stay Claude-native. Preserved in the v0.5.0 tag (#99).
 
 ## Guides
 
@@ -43,3 +53,8 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [Troubleshooting](guides/troubleshooting.md) — known issues: update-not-visible ladder, statusline wiring overwrites, board drift, hooks, environment.
 - [Rollback runbook](guides/rollback-runbook.md) — find the previous digest, redeploy it (one command), verify, record; forward-only-migration exception.
 - [Data-recovery runbook](guides/data-recovery-runbook.md) — restore → verify → postmortem; never debug against the only copy.
+
+## Feedback
+
+- [iomanage feedback 0.1.0→0.3.0](feedback/iomanage-feedback-forge-0.3.0.md) — observed usage feedback across the early versions.
+- [iomanage feedback ~0.5.0](feedback/iomanage-feedback-forge-0.5.0.md) — session feedback on forge ~0.5.0.

--- a/docs/guides/handbook.md
+++ b/docs/guides/handbook.md
@@ -72,6 +72,7 @@ The normal path, with your touch-points marked **[you]**:
 | testintent | weakened pre-existing assertions | reviewer sign-off in the PR body, or revert |
 | depguard | new deps exist, are ≥90d old, ≥500 downloads | remove or escalate |
 | acgate | every AC-ID in a passing test (runner JSON only) | write the missing test |
+| docsync | every doc is in the route index; a new skill is in the handbook | update `docs/README.md` / `docs/guides/handbook.md` |
 | security/review passes | role-card review of the diff | fix findings; criticals escalate |
 | CI green | never ask for merge on red | fix, trail `gate-fail` with cause |
 

--- a/docs/specs/2026-07-21-forge-autopilot.md
+++ b/docs/specs/2026-07-21-forge-autopilot.md
@@ -105,3 +105,13 @@ v1 is sequential by owner choice. The loop is factored so a **bounded worktree p
 - **AC-5 (files new work):** a need surfaced mid-delivery becomes a linked, trail-noted ticket via `board/create.mjs` and re-enters the queue.
 - **AC-6 (safety):** honours the global pause / situation gate; the loop backstop prevents runaway; the run ledger makes an interrupted run resumable.
 - **AC-7 (trail):** every lifecycle moment is trail-commented on the driving ticket (started · delivered · merged · escalated · filed), and the run is summarised on the delivery-log issue.
+
+## 11. Cost & context on long runs (#137)
+
+A long run must not blow the orchestrator's context window or let cost grow with run length. The design bounds both:
+
+- **Delegate, don't inline.** Each ticket's `forge:deliver` runs as its **own spawned agent** with a fresh context that is discarded when the ticket finishes. The heavy tokens — reading code, writing code, review passes — live and die inside that per-ticket context and its own sub-subagents; they never accumulate in the outer loop.
+- **The outer loop holds only file-backed state.** Between tickets the autopilot loop retains just `.forge/autopilot/run.json` + git state + a one-line outcome per ticket. Its growth is **~O(1) per ticket**, not O(work), so a 5-ticket run and a 50-ticket run have about the same loop overhead.
+- **Checkpoint + reset is free.** Every ticket is checkpointed to `run.json`; the resume protocol (§ resume) reconstructs from disk, so the orchestrator can be compacted or fully restarted between tickets at near-zero reload cost. (This session is the proof: it compacted at 67% and continued because state lived on the board + files, not the transcript.)
+- **Cheap where it can be.** Selection (`select.mjs`) and the ledger are plain scripts — **zero model cost**. Model tiering already applies inside delivery (haiku for lookup, sonnet default, opus only for second-opinion).
+- **What's intrinsic vs. overhead.** Per-ticket *delivery* cost is intrinsic — it's the actual engineering and can't be optimised away. What autopilot keeps ~constant is the *loop overhead*. (The host OS — Windows included — has no bearing on tokens, context, or cost; only PATH/shell handling is platform-specific.)

--- a/plugin/scripts/gates/docsync.mjs
+++ b/plugin/scripts/gates/docsync.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Doc-sync gate (#136): keep the repo's docs in step with what ships. Two
+ * mechanical, fail-closed checks run at ship — so manual `ship`, `forge:deliver`,
+ * and `forge:autopilot` all inherit them:
+ *   1. every doc under docs/ is listed in the docs/README.md route index;
+ *   2. a newly-added skill is mentioned in the handbook.
+ * (Releases stay current on their own — release.mjs derives the CHANGELOG from
+ * conventional commits. Wiki publish is a separate post-release step.)
+ */
+import { readFile, readdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run } from '../lib/exec.mjs';
+
+export const ROUTE_INDEX = 'docs/README.md';
+export const HANDBOOK = 'docs/guides/handbook.md';
+
+/** Relative-to-docs/ .md links referenced in the route index (skips http + anchors). */
+export function parseRouteLinks(indexText) {
+  const links = new Set();
+  for (const m of (indexText ?? '').matchAll(/\]\(([^)]+?\.md)(?:#[^)]*)?\)/g)) {
+    const href = m[1].trim();
+    if (/^https?:/i.test(href)) continue;
+    links.add(href.replace(/^\.\//, '').replaceAll('\\', '/'));
+  }
+  return links;
+}
+
+/** Docs present on disk but absent from the route index (README.md excludes itself). */
+export function routeIndexGaps(docFiles, linkedSet) {
+  return docFiles.filter((f) => f !== 'README.md' && !linkedSet.has(f)).sort();
+}
+
+/** Skill dir-names for added plugin/skills/<name>/SKILL.md paths. */
+export function addedSkills(addedFiles) {
+  const names = [];
+  for (const f of addedFiles) {
+    const m = /^plugin\/skills\/([^/]+)\/SKILL\.md$/.exec(f.replaceAll('\\', '/'));
+    if (m) names.push(m[1]);
+  }
+  return [...new Set(names)];
+}
+
+/** Added skills whose name never appears in the handbook. */
+export function skillHandbookGaps(skillNames, handbookText) {
+  const text = handbookText ?? '';
+  return skillNames.filter((n) => !text.includes(n)).sort();
+}
+
+/** Recursively list .md files under docs/, relative to docs/ (posix slashes). */
+async function listDocFiles(docsDir) {
+  let entries;
+  try { entries = await readdir(docsDir, { recursive: true, withFileTypes: true }); }
+  catch { return []; }
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith('.md'))
+    .map((e) => join(e.parentPath ?? e.path, e.name))
+    .map((p) => p.slice(docsDir.length + 1).replaceAll('\\', '/'));
+}
+
+export async function runDocSync({ cwd, base = 'main', execFn = run, log = console.log }) {
+  const docsDir = resolve(cwd, 'docs');
+  const indexText = await readFile(join(docsDir, 'README.md'), 'utf8').catch(() => null);
+  if (indexText === null) {
+    log('doc-sync: no docs/README.md route index — skipping (nothing to enforce)');
+    return { ok: true, routeGaps: [], skillGaps: [], skipped: true };
+  }
+  const docFiles = await listDocFiles(docsDir);
+  const routeGaps = routeIndexGaps(docFiles, parseRouteLinks(indexText));
+
+  const diff = await execFn('git', ['-C', cwd, 'diff', '--name-only', '--diff-filter=A', `${base}...HEAD`]);
+  if (!diff.ok) return { ok: false, error: `git diff failed: ${diff.stderr}` };
+  const added = diff.stdout.split(/\r?\n/).filter(Boolean);
+  const handbookText = await readFile(resolve(cwd, HANDBOOK), 'utf8').catch(() => null);
+  const skillGaps = skillHandbookGaps(addedSkills(added), handbookText);
+
+  for (const g of routeGaps) log(`✗ docs/${g} is not linked in ${ROUTE_INDEX}`);
+  for (const s of skillGaps) log(`✗ new skill '${s}' is not mentioned in ${HANDBOOK}`);
+  const ok = routeGaps.length === 0 && skillGaps.length === 0;
+  if (ok) log(`doc-sync: clean (${docFiles.length} docs indexed${skillGaps.length === 0 ? '' : ''})`);
+  else log(`doc-sync: ${routeGaps.length} unindexed doc(s), ${skillGaps.length} undocumented skill(s) — update the route index / handbook before shipping`);
+  return { ok, routeGaps, skillGaps };
+}
+
+export function parseArgs(argv) {
+  const a = { base: 'main' };
+  for (let i = 0; i < argv.length; i++) if (argv[i] === '--base') a.base = argv[++i];
+  return a;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2));
+  runDocSync({ cwd: process.cwd(), base: args.base }).then((res) => {
+    if (res.error) console.error(res.error);
+    process.exit(res.ok ? 0 : 1);
+  });
+}

--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -15,6 +15,7 @@ Spec: `docs/specs/2026-07-21-forge-autopilot.md`.
 - **The only pauses are real escalations.** Product broken with no safe fix · a design/behaviour decision that isn't the engine's to make · an under-specified ticket · critical security · plus deliver's existing §7 triggers. Everything routine — role choice, UI variant, which regression test, filing a follow-up — autopilot decides and proceeds.
 - **One ticket at a time (v1).** Finish and merge one before starting the next — no worktree machinery, no cross-ticket conflicts. (Parallel via a bounded worktree pool is designed-for but deferred; see spec §9.)
 - **The loop owns the run; deliver owns each ticket.** Autopilot owns the run ledger and the stop condition; each ticket's branch/ledger/gates/trail stay inside `forge:deliver`.
+- **Each ticket is delivered in a discardable context.** `forge:deliver` for a ticket runs as its **own spawned agent**; its heavy tokens (reading/writing/reviewing code) die with that context. The outer loop keeps only `run.json` + git + a one-line outcome per ticket — so loop overhead stays ~O(1) per ticket no matter how long the run (spec §11).
 
 ## The loop
 
@@ -99,6 +100,15 @@ The loop is prose the orchestrator runs, but its mechanical decisions are real, 
 - `newwork.mjs` — `fileWork(ctx,{title,kind,from})`: files a linked follow-up (bug/spike/item) mid-run.
 
 The orchestrator holds the ship/gate/reviewer/security verdicts and passes them to the merge bar; the scripts never spawn subagents or drive the loop themselves.
+
+## Cost & context on long runs (spec §11)
+
+A long run stays bounded by construction — not by luck:
+
+- **Delegate, don't inline.** Deliver each ticket as a spawned agent; its context (and its own subagents' contexts) is discarded when the ticket ends. The outer loop never ingests code — only the terminal outcome.
+- **Checkpoint + reset is free.** Every ticket is written to `run.json`; the resume protocol reconstructs from disk, so the orchestrator can be compacted or restarted between tickets at near-zero reload cost.
+- **Cheap where it can be.** `select.mjs` + the ledger are plain scripts (zero model cost); model tiering already applies inside delivery (haiku lookup / sonnet default / opus only for second-opinion).
+- **Intrinsic vs. overhead.** Per-ticket delivery cost is the real work and can't be optimised away; what autopilot keeps ~constant is the *loop overhead*. The host OS is irrelevant to cost/context — only PATH/shell handling is platform-specific.
 
 ## Resume protocol
 

--- a/plugin/skills/execute-agents/SKILL.md
+++ b/plugin/skills/execute-agents/SKILL.md
@@ -36,6 +36,7 @@ Independent read-only briefs (e.g. scoping several tasks up front) may be spawne
    - `gates/plandrift.mjs --plan <plan>` — off-plan files ⇒ escalate or extend `scope.json` with a reviewer-visible note.
    - `gates/testintent.mjs` — weakened existing assertions ⇒ reviewer sign-off in the PR or revert.
    - `vitest run --reporter=json --outputFile=.forge/results.json` then `gates/acgate.mjs --plan <plan> --ticket <n> --results .forge/results.json`.
+   - `gates/docsync.mjs` — docs kept in step with what ships: an unindexed doc or an undocumented new skill ⇒ fix the route index / handbook before shipping.
 3. Hand to `forge:ship`.
 
 ## Report contract (what the orchestrator relies on)

--- a/plugin/skills/ship/SKILL.md
+++ b/plugin/skills/ship/SKILL.md
@@ -18,6 +18,7 @@ Branch → PR with gates, then the post-merge ritual. Since SP5 the core gates a
    - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/testintent.mjs"` — weakened existing assertions ⇒ explicit reviewer sign-off in the PR body, or revert
    - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/depguard.mjs"` — new-dependency violations ⇒ remove or escalate
    - **AC gate**: `vitest run --reporter=json --outputFile=.forge/results.json` then `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/acgate.mjs" --plan <plan> --ticket <n> --results .forge/results.json` — every AC id in a passing test, machine evidence only
+   - `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/docsync.mjs"` — a doc that isn't in the `docs/README.md` route index, or a newly-added skill not mentioned in `docs/guides/handbook.md` ⇒ update the index/handbook before shipping (keeps docs in step with what ships)
 6. **Security pass** (`security` role card on the full branch diff): findings journaled; criticals escalate.
 7. **Review pass** (`reviewer` role card; `design-reviewer` for UI when `features.designReview`).
 8. **Honest verification statement** for the PR body: what ran, what passed, what was NOT verified. Never overstate.

--- a/tests/gates/docsync.test.mjs
+++ b/tests/gates/docsync.test.mjs
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parseRouteLinks, routeIndexGaps, addedSkills, skillHandbookGaps, runDocSync,
+} from '../../plugin/scripts/gates/docsync.mjs';
+
+describe('doc-sync gate (#136)', () => {
+  it('parseRouteLinks extracts relative .md links, skipping http + anchors', () => {
+    const idx = '- [A](specs/a.md) x [B](./guides/b.md#top) y [ext](https://x.com/z.md) z [C](decisions/c.md)';
+    const links = parseRouteLinks(idx);
+    expect([...links].sort()).toEqual(['decisions/c.md', 'guides/b.md', 'specs/a.md']);
+    expect(links.has('z.md')).toBe(false); // the http link is not indexed
+  });
+
+  it('routeIndexGaps flags unindexed docs and never flags README.md itself', () => {
+    const docs = ['README.md', 'specs/a.md', 'specs/b.md', 'guides/h.md'];
+    const linked = new Set(['specs/a.md', 'guides/h.md']);
+    expect(routeIndexGaps(docs, linked)).toEqual(['specs/b.md']);
+  });
+
+  it('addedSkills pulls skill names from added SKILL.md paths only', () => {
+    const added = [
+      'plugin/skills/autopilot/SKILL.md',
+      'plugin/skills/deliver/SKILL.md',
+      'plugin/scripts/gates/docsync.mjs', // not a skill
+      'plugin/skills/autopilot/notes.md',  // not a SKILL.md
+    ];
+    expect(addedSkills(added)).toEqual(['autopilot', 'deliver']);
+  });
+
+  it('skillHandbookGaps flags added skills the handbook never mentions', () => {
+    const handbook = 'The forge:deliver skill runs plan→ship...';
+    expect(skillHandbookGaps(['deliver', 'autopilot'], handbook)).toEqual(['autopilot']);
+    expect(skillHandbookGaps(['deliver'], handbook)).toEqual([]);
+  });
+
+  it('runDocSync is RED on an unindexed doc + an undocumented new skill, GREEN once fixed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-docsync-'));
+    await mkdir(join(cwd, 'docs', 'specs'), { recursive: true });
+    await mkdir(join(cwd, 'docs', 'guides'), { recursive: true });
+    await writeFile(join(cwd, 'docs', 'specs', 'a.md'), '# A');
+    await writeFile(join(cwd, 'docs', 'specs', 'b.md'), '# B'); // will be unindexed at first
+    await writeFile(join(cwd, 'docs', 'guides', 'handbook.md'), 'forge:deliver exists.');
+
+    // git diff --diff-filter=A returns a newly-added skill
+    const execFn = async () => ({ ok: true, stdout: 'plugin/skills/newskill/SKILL.md\n', stderr: '' });
+
+    // route index links only a.md; handbook lacks 'newskill' → two gaps
+    await writeFile(join(cwd, 'docs', 'README.md'), '# index\n- [A](specs/a.md)\n- [H](guides/handbook.md)\n');
+    const red = await runDocSync({ cwd, execFn, log: () => {} });
+    expect(red.ok).toBe(false);
+    expect(red.routeGaps).toContain('specs/b.md');
+    expect(red.skillGaps).toContain('newskill');
+
+    // fix both: index b.md, mention the skill in the handbook
+    await writeFile(join(cwd, 'docs', 'README.md'), '# index\n- [A](specs/a.md)\n- [B](specs/b.md)\n- [H](guides/handbook.md)\n');
+    await writeFile(join(cwd, 'docs', 'guides', 'handbook.md'), 'forge:deliver and forge:newskill exist.');
+    const green = await runDocSync({ cwd, execFn, log: () => {} });
+    expect(green.ok).toBe(true);
+    expect(green.routeGaps).toEqual([]);
+    expect(green.skillGaps).toEqual([]);
+  });
+
+  it('runDocSync skips cleanly when there is no route index (nothing to enforce)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-docsync-none-'));
+    const execFn = async () => ({ ok: true, stdout: '', stderr: '' });
+    const res = await runDocSync({ cwd, execFn, log: () => {} });
+    expect(res).toMatchObject({ ok: true, skipped: true });
+  });
+});

--- a/tests/skills/autopilot.test.mjs
+++ b/tests/skills/autopilot.test.mjs
@@ -48,6 +48,19 @@ describe('forge:autopilot skill (AC-1, AC-4, #126)', () => {
     expect(s).toMatch(/parks? one ticket|continue.*next|does not stop the whole run/i);
   });
 
+  it('#137: documents context/cost bounding — spawned per-ticket delivery + O(1) outer loop', async () => {
+    const s = await read('plugin/skills/autopilot/SKILL.md');
+    expect(s).toMatch(/discardable context|spawned agent/i);
+    expect(s).toMatch(/own spawned agent|delivered in a discardable/i);
+    // outer loop keeps only file-backed state
+    expect(s).toMatch(/run\.json.*outcome|one-line outcome/i);
+    expect(s).toMatch(/O\(1\) per ticket/);
+    // a dedicated cost/context section, incl. the OS-irrelevant note
+    expect(s).toMatch(/Cost & context on long runs/);
+    expect(s).toMatch(/checkpoint|resume protocol reconstructs/i);
+    expect(s).toMatch(/host OS is irrelevant|OS.*irrelevant/i);
+  });
+
   it('AC-2 front door + AC-5 files new work + AC-6 safety are all specified', async () => {
     const s = await read('plugin/skills/autopilot/SKILL.md');
     // auto-triage front door, under-specified => escalate + skip


### PR DESCRIPTION
Closes #136 · Closes #137

## #136 — docsync gate (keep docs in step with what ships)
A mechanical, fail-closed ship gate (peer of `plandrift`/`acgate`/`depguard`):
1. every doc under `docs/` must be linked in the `docs/README.md` route index;
2. a newly-added skill must be mentioned in `docs/guides/handbook.md`.

Wired into `forge:ship` §5 + `execute-agents` whole-branch finish, so **manual ship, `forge:deliver`, and `forge:autopilot` all inherit it** — the fix lives once, in the shared ladder. Handbook gates table updated.

**Dogfood:** running the new gate against `main` immediately surfaced **12 pre-existing unindexed docs** (ADR-0004, the C1–C8 control plans, batch-close, two feedback docs). This PR indexes all of them — the tree is now clean (`doc-sync: clean (40 docs indexed)`), so the gate is honest for everyone going forward.

Releases stay current on their own (`release.mjs` derives the CHANGELOG from conventional commits); wiki publish is a deferred post-release step, not a gate.

## #137 — autopilot context + cost on long runs
Spec §11 + skill: each ticket's `forge:deliver` runs as its **own spawned agent** (discardable context); the outer loop retains only `run.json` + git + a one-line outcome, so loop overhead is **~O(1) per ticket** regardless of run length. Checkpoint+reset is free via the resume protocol; `select.mjs`/ledger are scripts (zero model cost); model tiering already applies inside delivery. (This is a design/prose contract asserted by the skill test — not a runtime-enforced invariant.)

## AC
- [x] #136 AC.1 unindexed doc fails; AC.2 undocumented new skill fails; AC.3 wired into the ship ladder + `tests/gates/docsync.test.mjs`.
- [x] #137 AC.1 outer loop holds only file-backed state; AC.2 discardable per-ticket context; AC.3 spec cost-model section + skill prose.

## Verification
- `vitest run` — **290/290 pass** (35 files); +6 docsync tests, +1 autopilot #137 contract test.
- `docsync.mjs --base main` — exit 0, 40 docs indexed (dogfooded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
