### PR TITLE
feat(board): fulfill missing ticket fields — area (fix --area), labels, milestone (#146)

### DIFF
--- a/plugin/scripts/autopilot/select.mjs
+++ b/plugin/scripts/autopilot/select.mjs
@@ -77,6 +77,7 @@ export function normalize(ctx, item) {
     status: ctx.itemFieldKey(item, 'status'),
     priority: ctx.itemFieldKey(item, 'priority'),
     type: ctx.itemFieldKey(item, 'type'),
+    area: ctx.itemFieldKey(item, 'area'), // #146: null when the board has no Area field
   };
 }
 
@@ -86,6 +87,7 @@ if (isMain) {
   makeBoardCtx({ gh, cwd: process.cwd() }).then(async (ctx) => {
     if (!ctx.ok) { console.error(ctx.error); process.exit(1); }
     const area = process.argv.includes('--area') ? process.argv[process.argv.indexOf('--area') + 1] : null;
+    if (area && !ctx.fields.area) console.warn(`autopilot: --area ${area} given but this board has no Area field — forge:init maps one when the project has an "Area" single-select; nothing will match until then.`);
     const shape = process.argv.includes('--shape'); // crazy mode
     const list = await ctx.listItems();
     if (!list.ok) { console.error(list.error); process.exit(1); }

--- a/plugin/scripts/board/create.mjs
+++ b/plugin/scripts/board/create.mjs
@@ -12,10 +12,10 @@ import { getIssueNode, addSubIssue } from '../lib/issues.mjs';
 
 /** Defaults applied to a single ticket spec (flags or a --from JSON entry). */
 export function withDefaults(spec = {}) {
-  return { title: null, body: '', type: 'item', priority: 'p1', size: 'm', status: 'backlog', phase: null, parent: null, assignee: null, ...spec };
+  return { title: null, body: '', type: 'item', priority: 'p1', size: 'm', status: 'backlog', phase: null, area: null, parent: null, assignee: null, labels: [], milestone: null, ...spec };
 }
 
-const KNOWN_FLAGS = '--title --body --body-file --type --priority --size --status --phase --parent --assignee --from';
+const KNOWN_FLAGS = '--title --body --body-file --type --priority --size --status --phase --area --parent --assignee --label --milestone --from';
 
 export function parseArgs(argv) {
   const a = withDefaults();
@@ -32,8 +32,11 @@ export function parseArgs(argv) {
     else if (k === '--size') a.size = argv[++i];
     else if (k === '--status') a.status = argv[++i];
     else if (k === '--phase') a.phase = argv[++i];
+    else if (k === '--area') a.area = argv[++i];
     else if (k === '--parent') a.parent = Number(argv[++i]);
     else if (k === '--assignee') a.assignee = argv[++i];
+    else if (k === '--label') a.labels.push(argv[++i]);
+    else if (k === '--milestone') a.milestone = argv[++i];
     else if (k === '--from') a.from = argv[++i];
     else a.unknownFlags.push(k); // #104: never silently drop — a swallowed --body-file made empty-body tickets
   }
@@ -83,6 +86,12 @@ export async function runCreate(ctx, args, log = console.log) {
     const r = ctx.resolveOption('phase', args.phase);
     if (!r.ok) return { ok: false, error: r.error };
   }
+  // #146: optional Area, same rule — only when the consumer configured an Area field
+  if (args.area != null) {
+    if (!ctx.fields.area) return { ok: false, error: '--area given but no Area field is configured — forge:init maps it when the project has an "Area" single-select' };
+    const r = ctx.resolveOption('area', args.area);
+    if (!r.ok) return { ok: false, error: r.error };
+  }
 
   // 1. issue: find by exact title first (never duplicate)
   const found = await ctx.gh(
@@ -103,6 +112,17 @@ export async function runCreate(ctx, args, log = console.log) {
     const num = Number((/\/issues\/(\d+)/.exec(url) ?? [])[1]);
     issue = { number: num, url };
     log(`issue: created #${num}`);
+  }
+
+  // 1b. #146: labels + milestone via one idempotent edit (works for both the
+  // just-created and the resumed issue; --add-label + --milestone are idempotent).
+  if ((args.labels && args.labels.length) || args.milestone) {
+    const editArgs = ['issue', 'edit', String(issue.number)];
+    for (const l of args.labels ?? []) editArgs.push('--add-label', l);
+    if (args.milestone) editArgs.push('--milestone', args.milestone);
+    const edited = await ctx.gh(editArgs);
+    if (!edited.ok) return { ok: false, error: edited.stderr || 'issue edit (labels/milestone) failed — do the label/milestone exist in the repo?' };
+    log(`meta: ${[args.labels?.length ? `label ${args.labels.join(',')}` : null, args.milestone ? `milestone ${args.milestone}` : null].filter(Boolean).join(' · ')}`);
   }
 
   // 2. parent sub-issue link (skip when already parented)
@@ -139,6 +159,7 @@ export async function runCreate(ctx, args, log = console.log) {
   // 4. fields — set only what differs (resume-friendly)
   const fieldSets = [['type', args.type], ['priority', args.priority], ['size', args.size], ['status', args.status]];
   if (args.phase != null) fieldSets.push(['phase', args.phase]);
+  if (args.area != null) fieldSets.push(['area', args.area]);
   for (const [fieldKey, wanted] of fieldSets) {
     const current = existing.item ? ctx.itemFieldKey(existing.item, fieldKey) : null;
     if (current === wanted) continue;

--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -136,6 +136,13 @@ export async function runInit(ctx) {
     fields.phase = toConfigField(pf.fields['phase']);
     say('fields: mapped optional Phase field');
   }
+  // #146: map an optional consumer-defined Area single-select when present, so
+  // create --area and autopilot --area work. Areas are the consumer's own
+  // (frontend/api/…), so forge maps but never invents them.
+  if (pf.fields['area']) {
+    fields.area = toConfigField(pf.fields['area']);
+    say('fields: mapped optional Area field');
+  }
   const board = {
     projectNumber: project.number,
     projectId: project.id,

--- a/plugin/scripts/lib/config.mjs
+++ b/plugin/scripts/lib/config.mjs
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 export const CONFIG_RELPATH = join('.claude', 'forge.json');
 
 const FIELD_KEYS = ['status', 'priority', 'size', 'type'];
-const OPTIONAL_FIELD_KEYS = ['phase']; // #114: consumer-defined single-selects, mapped by init when the project has them
+const OPTIONAL_FIELD_KEYS = ['phase', 'area']; // #114/#146: consumer-defined single-selects, mapped by init when the project has them
 
 /**
  * Structural validation of .claude/forge.json — plain checks, no schema

--- a/tests/autopilot/engine.test.mjs
+++ b/tests/autopilot/engine.test.mjs
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { selectNext, actionFor, actionableQueue } from '../../plugin/scripts/autopilot/select.mjs';
+import { selectNext, actionFor, actionableQueue, normalize } from '../../plugin/scripts/autopilot/select.mjs';
 import { evaluateMergeBar, autoMergeEnabled, ciGreen, runMerge, BAR_SIGNALS } from '../../plugin/scripts/autopilot/merge.mjs';
 import { applyOutcome, applyFiled, guardTripped, renderReport, freshRun, startRun, recordOutcome, RUN_RELPATH } from '../../plugin/scripts/autopilot/ledger.mjs';
 import { toType, fileWork, KIND_TO_TYPE } from '../../plugin/scripts/autopilot/newwork.mjs';
@@ -39,6 +39,14 @@ describe('autopilot selection (#128, AC-1/AC-2)', () => {
     const tickets = [{ ...t(1, 'ready'), area: 'ui' }, { ...t(2, 'ready'), area: 'api' }];
     expect(selectNext(tickets, { area: 'api' }).ticket.number).toBe(2);
     expect(actionableQueue(tickets).map((q) => q.ticket.number)).toEqual([1, 2]);
+  });
+
+  it('#146: normalize populates area so --area actually filters (was a no-op)', () => {
+    const ctx = { itemFieldKey: (item, key) => item[key] ?? null };
+    const item = { content: { number: 5, title: 't' }, status: 'ready', priority: 'p1', area: 'api' };
+    expect(normalize(ctx, item)).toMatchObject({ number: 5, status: 'ready', area: 'api' });
+    // no Area field on the board → area is null, not undefined
+    expect(normalize({ itemFieldKey: () => null }, { content: { number: 6 } }).area).toBe(null);
   });
 });
 

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -27,6 +27,7 @@ const CFG = {
       size: { id: 'PVTSSF_z', options: { xs: '1', s: '2', m: '3', l: '4', xl: '5' } },
       type: { id: 'PVTSSF_t', options: { epic: 'e', item: 'i', bug: 'g', test: 't' } },
       phase: { id: 'PVTSSF_ph', options: { alpha: 'ph1', beta: 'ph2' } }, // #114 optional Phase
+      area: { id: 'PVTSSF_ar', options: { frontend: 'ar1', api: 'ar2' } }, // #146 optional Area
     },
     deliveryLogIssue: 15,
   },
@@ -171,6 +172,55 @@ describe('create (AC-2.1)', () => {
     const res = await runCreate(ctx, createArgs(['--title', 'X', '--phase', 'alpha']), noop);
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/no Phase field is configured/);
+  });
+
+  it('AC-146.2: --area sets the configured Area field (#146)', async () => {
+    const { ctx, calls } = await ctxWith([
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: createdIssueUrl }],
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      [(j) => j.startsWith('api graphql') && j.includes('projectItems'), { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [] } } } } }) }],
+      ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--area', 'api']), noop);
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.includes('PVTSSF_ar') && c.includes('ar2'))).toBe(true); // Area set to api
+  });
+
+  it('AC-146.2: --area without a configured Area field errors clearly (#146)', async () => {
+    const ctx = { fields: {}, resolveOption: () => ({ ok: true }) }; // no area configured
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--area', 'api']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/no Area field is configured/);
+  });
+
+  it('AC-146.4/5: --label (repeatable) + --milestone reconcile via one idempotent issue edit (#146)', async () => {
+    const { ctx, calls } = await ctxWith([
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: createdIssueUrl }],
+      ['issue edit', { stdout: '' }],
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--label', 'bug', '--label', 'p0', '--milestone', 'v1']), noop);
+    expect(res.ok).toBe(true);
+    const edit = calls.find((c) => c.startsWith('issue edit'));
+    expect(edit).toContain('--add-label bug');
+    expect(edit).toContain('--add-label p0');
+    expect(edit).toContain('--milestone v1');
+  });
+
+  it('AC-146.4: a failed label/milestone edit surfaces clearly (missing label)', async () => {
+    const { ctx } = await ctxWith([
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: createdIssueUrl }],
+      ['issue edit', { ok: false, stderr: "could not add label: 'ghost' not found" }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'X', '--label', 'ghost']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/issue edit|not found/);
   });
 });
 

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -119,6 +119,32 @@ describe('runInit — fresh bootstrap (AC-1.2)', () => {
     expect(cfg.board.fields.phase).toEqual({ id: 'PVTSSF_ph', options: { alpha: 'ph1', beta: 'ph2' } });
   });
 
+  it('AC-146.1: maps an optional Area field into forge.json when the project has one (#146)', async () => {
+    const cwd = await tmpCwd();
+    const withArea = [...FRESH_FULL_FIELDS, { id: 'PVTSSF_ar', name: 'Area', options: [{ id: 'ar1', name: 'Frontend' }, { id: 'ar2', name: 'API' }] }];
+    let fieldsCall = 0;
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project create', { stdout: JSON.stringify({ id: 'PVT_new', number: 9, title: 'forge' }) }],
+      ['project link', { stdout: '' }],
+      [(j) => j.startsWith('api graphql') && j.includes('fields(first: 50)'), () => {
+        fieldsCall += 1;
+        return fieldsCall === 1
+          ? fieldsResponse(0, [{ id: 'PVTSSF_new1', name: 'Status', options: [{ id: 'a', name: 'Todo' }, { id: 'b', name: 'In Progress' }, { id: 'c', name: 'Done' }] }])
+          : fieldsResponse(0, withArea);
+      }],
+      [(j) => j.includes('updateProjectV2Field'), { stdout: JSON.stringify({ data: { updateProjectV2Field: { projectV2Field: { id: 'PVTSSF_new1', options: [] } } } }) }],
+      [(j) => j.includes('createProjectV2Field'), { stdout: JSON.stringify({ data: { createProjectV2Field: { projectV2Field: { id: 'PVTSSF_x', options: [] } } } }) }],
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/42\n' }],
+    ]);
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--create-project', 'forge', '--skip-doctor']) });
+    expect(res.ok).toBe(true);
+    const cfg = await readJson(join(cwd, '.claude', 'forge.json'));
+    expect(cfg.board.fields.area).toEqual({ id: 'PVTSSF_ar', options: { frontend: 'ar1', api: 'ar2' } });
+  });
+
   it('AC-B64.2: fresh create links the new board to the repo (#64)', async () => {
     const cwd = await tmpCwd();
     const { gh, calls } = fakeGh(freshRoutes());


### PR DESCRIPTION
Closes #146

## What
Reviewing the tickets created this session surfaced fields `create` never fills — and a **latent bug**: `autopilot --area` (and crazy-mode selection) filtered on `ticket.area`, but no Area field was ever mapped, set, or normalized, so the filter **silently matched nothing**.

| Field | Change |
|-------|--------|
| **Area** (bug) | `init` maps an optional `Area` single-select (Phase precedent — mapped, never invented); `create --area` sets it (validated); `select.mjs` `normalize()` populates `area`; the CLI **warns** if `--area` is used with no Area field |
| **Labels** | `create --label <l>` (repeatable) |
| **Milestone** | `create --milestone <m>` |

Labels + milestone apply via **one idempotent `gh issue edit`** (works on both create and resume); a missing label/milestone **fails clearly** (the #104 fail-fast ethos). Batch (`--from`) entries accept all three.

## AC
- [x] AC.1 init maps optional Area when present; `OPTIONAL_FIELD_KEYS` gains `area`
- [x] AC.2 `--area` sets it / errors clearly with no Area field
- [x] AC.3 `select.mjs` normalizes `area` (the bug fix) + CLI warns
- [x] AC.4 `--label` repeatable, idempotent
- [x] AC.5 `--milestone` set, idempotent
- [x] AC.6 batch accepts area/labels/milestone

## Verification
- `vitest run` — **307/307** (37 files; +6). `docsync --base main` — clean (41 docs).
- Note: on **this** board (#8) there's no Area field yet, so `--area` stays inert until you add one in the project UI and re-run `/forge:init` — at which point the wiring lights up. `--label`/`--milestone` require the label/milestone to exist in the repo (fail-fast otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
