### PR TITLE
fix(agents): quote compiled descriptions — unquoted colons dropped all metadata (#149)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -35,3 +35,15 @@ jobs:
       - uses: docker://rhysd/actionlint@sha256:1d74bfc9fd1963af8f89a7c22afaaafd42f49aad711a09951d02cb996398f61d # 1.7.7
         with:
           args: -color
+
+  plugin-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      # #149: guard the plugin manifest + component frontmatter. Catches the
+      # unquoted-description YAML break that silently drops agent model/tool pins.
+      - run: npm install -g @anthropic-ai/claude-code
+      - run: claude plugin validate ./plugin --strict

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,10 +1,23 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "forge",
+  "displayName": "Forge",
   "version": "0.11.0",
   "description": "AI dev platform: pipeline skills, Claude-native agent roster, GitHub Projects board automation, learning loop, graph RAG",
   "author": {
     "name": "dngioi.dev"
   },
+  "homepage": "https://github.com/dngioidev/forge",
+  "repository": "https://github.com/dngioidev/forge",
+  "keywords": [
+    "ai",
+    "workflow",
+    "orchestration",
+    "github-projects",
+    "code-review",
+    "graph-rag",
+    "autopilot"
+  ],
   "mcpServers": {
     "forge-graph": {
       "command": "node",

--- a/plugin/agents/design-reviewer.md
+++ b/plugin/agents/design-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: design-reviewer
-description: Validate a UI implementation against its committed visual spec — token-only styling, the a11y contract, stories present, spec match. Sections, not vibes.
+description: "Validate a UI implementation against its committed visual spec — token-only styling, the a11y contract, stories present, spec match. Sections, not vibes."
 model: sonnet
 tools: Read, Grep, Glob, Bash
 ---

--- a/plugin/agents/designer.md
+++ b/plugin/agents/designer.md
@@ -1,6 +1,6 @@
 ---
 name: designer
-description: Generate token-grounded, a11y-first mockup variants for a UI ticket (`forge:design`). The human picks; the chosen variant graduates to the visual spec.
+description: "Generate token-grounded, a11y-first mockup variants for a UI ticket (`forge:design`). The human picks; the chosen variant graduates to the visual spec."
 model: sonnet
 ---
 

--- a/plugin/agents/devops.md
+++ b/plugin/agents/devops.md
@@ -1,6 +1,6 @@
 ---
 name: devops
-description: Own the deploy layer: Dockerfile/compose/Terraform, CI deploy jobs, infra diff review, `terraform plan`. Keep every repo production-deployable at all times (spec §10).
+description: "Own the deploy layer: Dockerfile/compose/Terraform, CI deploy jobs, infra diff review, `terraform plan`. Keep every repo production-deployable at all times (spec §10)."
 model: sonnet
 ---
 

--- a/plugin/agents/implementer.md
+++ b/plugin/agents/implementer.md
@@ -1,6 +1,6 @@
 ---
 name: implementer
-description: Make one plan task's failing tests pass — smallest correct change, repo conventions, nothing beyond the task.
+description: "Make one plan task's failing tests pass — smallest correct change, repo conventions, nothing beyond the task."
 model: sonnet
 ---
 

--- a/plugin/agents/investigator.md
+++ b/plugin/agents/investigator.md
@@ -1,6 +1,6 @@
 ---
 name: investigator
-description: Cheap read-only fan-out: locate code, trace call paths, answer "where does X happen" — fast, factual, no judgment calls.
+description: "Cheap read-only fan-out: locate code, trace call paths, answer \"where does X happen\" — fast, factual, no judgment calls."
 model: haiku
 tools: Read, Grep, Glob
 ---

--- a/plugin/agents/librarian.md
+++ b/plugin/agents/librarian.md
@@ -1,6 +1,6 @@
 ---
 name: librarian
-description: Answer "does X already exist?" before anything new is written — reuse-first lookup over the repo's components, helpers, and patterns.
+description: "Answer \"does X already exist?\" before anything new is written — reuse-first lookup over the repo's components, helpers, and patterns."
 model: haiku
 tools: Read, Grep, Glob
 ---

--- a/plugin/agents/planner.md
+++ b/plugin/agents/planner.md
@@ -1,6 +1,6 @@
 ---
 name: planner
-description: Classify a triaged ticket and turn it into an executable, typed plan: the ticket kind, then ordered tasks — each with its kind, Files list, AC-IDs, and test plan — the contract forge:deliver / forge:execute(-agents) work against.
+description: "Classify a triaged ticket and turn it into an executable, typed plan: the ticket kind, then ordered tasks — each with its kind, Files list, AC-IDs, and test plan — the contract forge:deliver / forge:execute(-agents) work against."
 model: sonnet
 tools: Read, Grep, Glob
 ---

--- a/plugin/agents/reviewer.md
+++ b/plugin/agents/reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: Find what's wrong with a diff — correctness first, then simplification and efficiency — with severity-tagged, actionable findings.
+description: "Find what's wrong with a diff — correctness first, then simplification and efficiency — with severity-tagged, actionable findings."
 model: sonnet
 tools: Read, Grep, Glob, Bash
 ---

--- a/plugin/agents/scoper.md
+++ b/plugin/agents/scoper.md
@@ -1,6 +1,6 @@
 ---
 name: scoper
-description: Ticket impact analysis before work starts: which components/files are touched, which tests must run, how far the blast radius reaches.
+description: "Ticket impact analysis before work starts: which components/files are touched, which tests must run, how far the blast radius reaches."
 model: sonnet
 tools: Read, Grep, Glob
 ---

--- a/plugin/agents/second-opinion.md
+++ b/plugin/agents/second-opinion.md
@@ -1,6 +1,6 @@
 ---
 name: second-opinion
-description: Independent second-pass critique of a spec, plan, or diff — a different model's eyes, on demand. Advisory only, never a merge gate.
+description: "Independent second-pass critique of a spec, plan, or diff — a different model's eyes, on demand. Advisory only, never a merge gate."
 model: opus
 tools: Read, Grep, Glob
 ---

--- a/plugin/agents/security.md
+++ b/plugin/agents/security.md
@@ -1,6 +1,6 @@
 ---
 name: security
-description: Adversarial pass over a branch: assume the diff is hostile until proven otherwise. Injection, secrets, supply chain, CI/hook attack surface.
+description: "Adversarial pass over a branch: assume the diff is hostile until proven otherwise. Injection, secrets, supply chain, CI/hook attack surface."
 model: sonnet
 tools: Read, Grep, Glob, Bash
 ---

--- a/plugin/agents/test-architect.md
+++ b/plugin/agents/test-architect.md
@@ -1,6 +1,6 @@
 ---
 name: test-architect
-description: Turn acceptance criteria into a test plan and failing tests — before implementation exists. Own test *intent*; the AC gate verifies it mechanically at ship.
+description: "Turn acceptance criteria into a test plan and failing tests — before implementation exists. Own test *intent*; the AC gate verifies it mechanically at ship."
 model: sonnet
 ---
 

--- a/plugin/scripts/backends/compile.mjs
+++ b/plugin/scripts/backends/compile.mjs
@@ -59,7 +59,12 @@ export function compileCard(role, cardBody) {
   const description = (missionMatch?.[1] ?? role).trim();
   const model = MODELS[role] ? `\nmodel: ${MODELS[role]}` : '';
   const tools = TOOLS[role] ? `\ntools: ${TOOLS[role]}` : '';
-  return `---\nname: ${role}\ndescription: ${description}${model}${tools}\n---\n\n<!-- generated from plugin/cards/${role}.md by scripts/backends/compile.mjs — edit the card, not this file -->\n\n${cardBody}`;
+  // #149: quote the description. A Mission line with a colon-space (e.g. "deploy
+  // layer: Dockerfile") is invalid unquoted YAML — the whole frontmatter fails to
+  // parse and the agent loads with EMPTY metadata (model/tools pins silently
+  // dropped). JSON.stringify yields a valid YAML double-quoted scalar.
+  const desc = JSON.stringify(description);
+  return `---\nname: ${role}\ndescription: ${desc}${model}${tools}\n---\n\n<!-- generated from plugin/cards/${role}.md by scripts/backends/compile.mjs — edit the card, not this file -->\n\n${cardBody}`;
 }
 
 export async function compileAll({ cardsDir = CARDS_DIR, agentsDir = AGENTS_DIR } = {}) {

--- a/tests/backends/cards.test.mjs
+++ b/tests/backends/cards.test.mjs
@@ -28,6 +28,19 @@ describe('role cards (AC-4.1)', () => {
     }
   });
 
+  it('AC-149.1: every compiled agent has a QUOTED description — unquoted colons break YAML and drop all metadata (#149)', async () => {
+    // A Mission line like "deploy layer: Dockerfile" is invalid unquoted YAML;
+    // the frontmatter fails to parse and the agent loads with no model/tools pin.
+    for (const role of ROLES) {
+      const agent = await readFile(join(AGENTS_DIR, `${role}.md`), 'utf8');
+      const desc = /^description: (.*)$/m.exec(agent);
+      expect(desc, `${role} agent has no description line`).toBeTruthy();
+      expect(desc[1].startsWith('"') && desc[1].endsWith('"'), `${role} description must be a quoted YAML scalar, got: ${desc[1]}`).toBe(true);
+      // and it must round-trip as a JSON string (valid double-quoted YAML scalar)
+      expect(() => JSON.parse(desc[1]), `${role} description is not a parseable quoted scalar`).not.toThrow();
+    }
+  });
+
   it('compiled agents are in sync with their cards (freshness gate)', async () => {
     for (const role of ROLES) {
       const card = await readFile(join(CARDS_DIR, `${role}.md`), 'utf8');


### PR DESCRIPTION
Closes #149

## The bug (found by the ticket's own tool)
Adding `claude plugin validate --strict` immediately failed on **5 agent cards** — devops, investigator, planner, scoper, security. Each has a colon-space in its Mission line (`Own the deploy layer: Dockerfile…`), which is **invalid unquoted YAML**. Claude's loader couldn't parse the frontmatter and loaded those agents **with empty metadata — their `model:` pins and `tools:` allowlists were silently dropped at runtime.** The existing freshness test only regex-matched the text, so it never caught it.

## Fix
- `compile.mjs` emits `description: "<JSON-quoted>"` — a valid YAML double-quoted scalar. Recompiled all 12 agents.
- **Regression test (AC-149.1):** every compiled agent description must be a quoted, parseable scalar — this bug can't come back silently.
- **CI guard:** new `plugin-validate` job runs `claude plugin validate ./plugin --strict`.
- **Manifest metadata:** `$schema`, `displayName`, `homepage`, `repository`, `keywords` (no `license` — there's no LICENSE file, so I didn't claim one).

## Verification
- `claude plugin validate ./plugin --strict` → **✔ Validation passed** (was ✘ 5 errors).
- `vitest run` — **308/308** (37 files; +1 regression test).

Part of epic #148 (plugin-capability enhancements). This is the highest-value item — it fixes a live correctness bug, not just ergonomics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
