### PR TITLE
feat(plugin): bin/forge dispatcher, autopilot monitors, theme + polish (#150, #151, #153)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,10 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [C8 — Quota panel](plans/2026-07-19-c8-quota-panel.md) — Claude Code quota panel in the console.
 - [Batch close](plans/2026-07-20-batch-close.md) — tasks for #123: comma-separated `--issue` in `board/close.mjs`.
 
+## Spikes
+
+- [Plugin capabilities](spikes/2026-07-21-plugin-capabilities.md) — research on the full Claude Code plugin surface vs. forge's usage; the tiered enhancement plan behind epic #148 (monitors, bin/, themes, LSP, manifest, `${CLAUDE_PLUGIN_DATA}`).
+
 ## Design specs
 
 - [Console — heat identity](design/2026-07-17-console.md) — visual spec for the local web console: situation-as-heat token system, states matrix, a11y contract.

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -47,6 +47,10 @@ Run it after init and any time something feels off. ✗ items block work and say
 | graph | `features.graph: true` + `npm i -D ts-morph` + `node <plugin>/scripts/graph/graphctl.mjs rebuild` | structural index: find_component / who_uses / blast_radius / reuse_candidates MCP tools (TypeScript repos only — grep-first is the permanent fallback otherwise) |
 | design review | `features.designReview: true` | design-reviewer validates UI work against visual specs |
 
+**Code intelligence (LSP, optional):** forge's graph MCP gives structural reuse/blast-radius answers; for real-time diagnostics and go-to-definition, install Anthropic's official LSP plugin for your language rather than one from forge — search `lsp` in the `/plugin` Discover tab (e.g. `typescript-lsp`, `pyright-lsp`, `rust-analyzer-lsp`). Install the language server binary first, then the plugin. forge deliberately doesn't bundle an LSP — the binary is yours to install.
+
+**Theme (optional):** `/theme` → **Forge (smithy)** for forge's ember-on-steel identity.
+
 ## 5. Working in it
 
 Everything is ticket-first: `/forge:ticket` for quick triage, then the lane skills (ideate → brainstorm → design → plan → execute → ship → release; hotfix/respond/maintain for care). `forge board status` (or the status line) is the one-glance catch-up. The owner merges every PR — agents never do.

--- a/docs/spikes/2026-07-21-plugin-capabilities.md
+++ b/docs/spikes/2026-07-21-plugin-capabilities.md
@@ -1,0 +1,52 @@
+# Spike — Claude Code plugin capabilities vs. forge, and an enhancement plan
+
+**Kind:** spike (research) · **Source:** code.claude.com/docs/en/{plugins, plugins-reference, plugin-marketplaces} · **Date:** 2026-07-21.
+
+Time-boxed read of the full plugin surface to answer: *what can a plugin do that forge doesn't yet, and what's worth adding?*
+
+## 1. The full capability surface (component types)
+
+| Component | Location | forge today | Notes |
+|---|---|---|---|
+| **skills/** | `skills/<name>/SKILL.md` | ✅ 18 skills | model- + user-invokable; `$ARGUMENTS`; `disable-model-invocation` for user-only |
+| **agents/** | `agents/*.md` | ✅ 12 compiled cards | model/tool pins |
+| **hooks/** | `hooks/hooks.json` | ✅ denylist + capture | Pre/PostToolUse |
+| **MCP** | `.mcp.json` / manifest | ✅ forge-graph | stdio graph RAG |
+| **commands/** | flat `.md` | — (uses skills) | legacy; skills preferred ✅ |
+| **LSP** | `.lsp.json` / `lspServers` | ❌ | real-time diagnostics + navigation; official `typescript-lsp` exists |
+| **monitors/** | `monitors/monitors.json` | ❌ | background watchers that push stdout lines to Claude as notifications; `when: always \| on-skill-invoke:<skill>`; interactive-only, unsandboxed |
+| **bin/** | `bin/` | ❌ | executables added to the Bash tool PATH while enabled |
+| **themes/** | `themes/*.json` (experimental) | ❌ | ship a `/theme`; `base` + sparse `overrides` |
+| **output-styles/** | `output-styles/` | ❌ | custom response styles |
+| **plugin settings.json** | root `settings.json` | ❌ | default settings on enable; only `agent` (activate a custom agent as main thread) + `subagentStatusLine` supported |
+| **channels** | manifest `channels[]` | ❌ | Telegram/Slack/Discord message injection, bound to an MCP server |
+
+## 2. Manifest + distribution features forge under-uses
+
+- **`plugin.json` is minimal** — only `name`, `version`, `description`, `author.name`, `mcpServers`. Missing discovery/validation metadata: `displayName`, `homepage`, `repository`, `license`, `keywords`, `$schema`.
+- **`claude plugin validate [--strict]`** exists and is run by the community review pipeline — forge does not run it in CI. `--strict` turns unrecognized/misspelled manifest fields into errors.
+- **`${CLAUDE_PLUGIN_DATA}`** — a persistent per-plugin dir (`~/.claude/plugins/data/<id>/`) that survives updates. Ideal for caches/generated state (e.g. the code-graph SQLite db) instead of rebuilding each update or writing into the version-pinned `${CLAUDE_PLUGIN_ROOT}` (which is wiped ~14 days after an update).
+- **`userConfig`** — enable-time prompts stored in user settings / keychain. forge's config lives in project `forge.json` (via init), so this is a weak fit except for a few user-level prefs.
+- **`defaultEnabled`, dependencies, release channels** — not needed for a single solo plugin today.
+
+## 3. Recommendations (tiered)
+
+### Tier 1 — clear wins (low effort, low risk)
+1. **Manifest completeness + `plugin validate --strict` in CI.** Fill `displayName`/`homepage`/`repository`/`license`/`keywords`/`$schema`; add a `claude plugin validate --strict` step to `verify.yml`. Catches manifest drift; improves marketplace listing.
+2. **`bin/forge` dispatcher on PATH.** A single `forge <area> <cmd>` entry point wrapping the `scripts/**` node CLIs, so skills' prose and manual use stop repeating `node "${CLAUDE_PLUGIN_ROOT}/scripts/.../x.mjs"`. *Honest caveat:* it still needs `node` resolvable — it shortens commands, it doesn't fix a missing node on PATH.
+
+### Tier 2 — strong fits (medium effort)
+3. **Monitors for autopilot.** A CI-status watcher so the auto-merge bar reacts to green instead of polling, and a watcher on `.forge/decisions/` so answered escalations surface immediately. Directly strengthens autopilot + escalate. (Interactive-only, unsandboxed — fine for a user-installed plugin.)
+4. **Persist the code-graph index in `${CLAUDE_PLUGIN_DATA}`.** Move the graph SQLite db / caches there so they survive plugin updates instead of rebuilding. (Spike: confirm where the db currently lives.)
+
+### Tier 3 — polish / brand (small)
+5. **`themes/forge.json`** — the smithy/ember identity as a selectable `/theme`.
+6. **`disable-model-invocation`** on user-only skills (`init`, `release`, `deploy-init`) so Claude doesn't auto-invoke them.
+7. **`settings.json` `subagentStatusLine`** — surface role-subagent status during fan-out.
+8. **Recommend official `typescript-lsp`** in the install guide (don't bundle — the binary is the user's to install).
+
+### Not now (out of scope)
+`channels` (Slack/Telegram notifications), `output-styles`, bundling LSP servers, `userConfig` for board config (init/forge.json already owns it), `settings.json agent` (forge is many skills, not one main-thread agent).
+
+## 4. Suggested delivery order
+T1.1 (metadata+validate, trivial) → T1.2 (bin/forge, high leverage) → T2.3 (monitors, new autopilot power) → T2.4 (graph data dir) → T3 polish bundle.

--- a/plugin/bin/forge
+++ b/plugin/bin/forge
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# forge — one dispatcher for forge's node CLIs (#150). Added to the Bash tool
+# PATH while the plugin is enabled, so skills and manual use can run
+#   forge board create --title "…"
+# instead of  node "${CLAUDE_PLUGIN_ROOT}/scripts/board/create.mjs" …
+# Note: this shortens the command; it still needs `node` resolvable on PATH.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+S="$ROOT/scripts"
+
+usage() {
+  cat >&2 <<'USAGE'
+forge — dispatcher for forge's node CLIs
+  forge init|doctor|release [args…]
+  forge <area> <command> [args…]
+      areas: board, gate, autopilot, care, deploy, design, graph, learn, backends
+examples:
+  forge board create --title "…" --type item
+  forge gate docsync --base main
+  forge autopilot select --dry-run
+  forge release --dry-run
+USAGE
+}
+
+[ $# -eq 0 ] && { usage; exit 2; }
+area="$1"; shift
+
+case "$area" in
+  -h|--help|help) usage; exit 0 ;;
+  init|doctor)    target="$S/$area.mjs" ;;
+  release)        target="$S/release/release.mjs" ;;
+  gate|gates)
+    [ $# -ge 1 ] || { echo "forge $area: missing <command>" >&2; usage; exit 2; }
+    sub="$1"; shift; target="$S/gates/$sub.mjs" ;;
+  board|autopilot|care|deploy|design|graph|learn|backends)
+    [ $# -ge 1 ] || { echo "forge $area: missing <command>" >&2; usage; exit 2; }
+    sub="$1"; shift; target="$S/$area/$sub.mjs" ;;
+  *) echo "forge: unknown area '$area'" >&2; usage; exit 2 ;;
+esac
+
+if [ ! -f "$target" ]; then echo "forge: no such command → $target" >&2; exit 2; fi
+
+# FORGE_DRY=1 prints the resolved invocation instead of running it (used in tests).
+if [ "${FORGE_DRY:-}" = "1" ]; then echo "node $target $*"; exit 0; fi
+exec node "$target" "$@"

--- a/plugin/commands/deploy-init.md
+++ b/plugin/commands/deploy-init.md
@@ -1,5 +1,6 @@
 ---
 description: Install the deploy scaffold — digest-pinned Dockerfile, compose, terraform skeleton, environment-branch workflows, smoke script — and wire forge.json
+disable-model-invocation: true
 ---
 
 Install the deploy layer into this repo (spec §10). Ask the user for the app name (default: repo name) and healthcheck path (default: `/healthz`) if not obvious, then run:

--- a/plugin/commands/init.md
+++ b/plugin/commands/init.md
@@ -1,5 +1,6 @@
 ---
 description: Bootstrap or adopt this repo's forge setup — GitHub Project, fields, delivery log, forge.json, gitignore, status line
+disable-model-invocation: true
 ---
 
 Bootstrap forge for this repository (adopt-or-create, idempotent — safe to re-run).

--- a/plugin/monitors/monitors.json
+++ b/plugin/monitors/monitors.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "forge-ci",
+    "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/monitors/ci-watch.mjs\"",
+    "description": "CI status on the current branch's PR (autopilot merge bar)",
+    "when": "on-skill-invoke:autopilot"
+  },
+  {
+    "name": "forge-decisions",
+    "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/monitors/decisions-watch.mjs\"",
+    "description": "Answered escalation decisions (.forge/decisions)",
+    "when": "on-skill-invoke:autopilot"
+  }
+]

--- a/plugin/scripts/monitors/ci-watch.mjs
+++ b/plugin/scripts/monitors/ci-watch.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * CI monitor (#151) — a background watcher (plugin monitors) that polls the
+ * current branch's PR checks and prints a line only when the rollup transitions,
+ * so autopilot's auto-merge bar reacts to green/red instead of polling inline.
+ * Each stdout line is delivered to Claude as a notification.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+
+const FAIL = new Set(['FAILURE', 'ERROR', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED', 'STARTUP_FAILURE']);
+const DONE = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
+
+/** Reduce a checks rollup to one of pass | fail | pending (fail-closed on unknowns). */
+export function rollupState(checks) {
+  const arr = checks ?? [];
+  if (arr.length === 0) return 'pending';
+  const st = (c) => c.conclusion ?? c.state ?? c.status ?? null;
+  if (arr.some((c) => FAIL.has(st(c)))) return 'fail';
+  if (arr.every((c) => DONE.has(st(c)))) return 'pass';
+  return 'pending';
+}
+
+/** Emit the new state only when it changed from the previous observation. */
+export function transition(prev, cur) {
+  return prev === cur ? null : cur;
+}
+
+export async function poll(gh, prev) {
+  const res = await gh(['pr', 'view', '--json', 'number,headRefName,statusCheckRollup'], { parseJson: true });
+  if (!res.ok) return { prev, line: null }; // no PR for this branch yet — stay quiet
+  const state = rollupState(res.json?.statusCheckRollup);
+  const changed = transition(prev, state);
+  if (!changed) return { prev: state, line: null };
+  return { prev: state, line: `CI ${state} on PR #${res.json.number} (${res.json.headRefName})` };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  const intervalMs = Number(process.env.FORGE_CI_INTERVAL_MS ?? 20000);
+  let prev = null;
+  const tick = async () => {
+    try { const r = await poll(gh, prev); prev = r.prev; if (r.line) console.log(r.line); }
+    catch { /* transient gh/network error — keep watching */ }
+    setTimeout(tick, intervalMs);
+  };
+  tick();
+}

--- a/plugin/scripts/monitors/decisions-watch.mjs
+++ b/plugin/scripts/monitors/decisions-watch.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Decisions monitor (#151) — a background watcher that polls .forge/decisions/
+ * and prints a line the moment an escalation the human answered flips to
+ * resolved, so autopilot surfaces the reply without being asked to check.
+ */
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { readdir } from 'node:fs/promises';
+import { readJson } from '../lib/jsonfile.mjs';
+
+/** Decisions that resolved since the last observation (by id). Pure + testable. */
+export function newlyResolved(prevResolvedIds, decisions) {
+  return decisions.filter((d) => d?.status === 'resolved' && d?.id && !prevResolvedIds.has(d.id));
+}
+
+export async function readDecisions(cwd) {
+  const dir = join(cwd, '.forge', 'decisions');
+  let files;
+  try { files = (await readdir(dir)).filter((f) => f.endsWith('.json')); }
+  catch { return []; }
+  const out = [];
+  for (const f of files) {
+    const d = await readJson(join(dir, f)).catch(() => null);
+    if (d) out.push(d);
+  }
+  return out;
+}
+
+export async function poll(cwd, seen) {
+  const decisions = await readDecisions(cwd);
+  const fresh = newlyResolved(seen, decisions);
+  for (const d of fresh) seen.add(d.id);
+  return fresh.map((d) => `Decision ${d.id} (#${d.issue}) resolved: ${String(d.answer ?? '').split(/\r?\n/)[0]}`);
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const cwd = process.cwd();
+  const intervalMs = Number(process.env.FORGE_DECISIONS_INTERVAL_MS ?? 15000);
+  const seen = new Set();
+  const tick = async () => {
+    try { for (const line of await poll(cwd, seen)) console.log(line); }
+    catch { /* transient fs error — keep watching */ }
+    setTimeout(tick, intervalMs);
+  };
+  tick();
+}

--- a/plugin/skills/release/SKILL.md
+++ b/plugin/skills/release/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: release
 description: Cut a named release — semver from conventional commits, CHANGELOG, annotated tag, GitHub Release, artifact naming. Use after merges when the owner wants a release, or before promoting deploy repos to production.
+disable-model-invocation: true
 ---
 
 # forge:release

--- a/plugin/themes/forge.json
+++ b/plugin/themes/forge.json
@@ -1,0 +1,9 @@
+{
+  "name": "Forge (smithy)",
+  "base": "dark",
+  "overrides": {
+    "claude": "#f0813f",
+    "error": "#e5484d",
+    "success": "#46a758"
+  }
+}

--- a/tests/bin/forge.test.mjs
+++ b/tests/bin/forge.test.mjs
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const bin = join(root, 'plugin', 'bin', 'forge');
+
+function bashAvailable() {
+  try { execFileSync('bash', ['-c', 'true'], { stdio: 'ignore' }); return true; } catch { return false; }
+}
+const HAS_BASH = bashAvailable();
+const dry = (args) => execFileSync('bash', [bin, ...args], { env: { ...process.env, FORGE_DRY: '1' }, encoding: 'utf8' }).trim();
+
+describe('forge dispatcher (#150)', () => {
+  it('is a bash script with a usage block and the FORGE_DRY hook', () => {
+    const s = readFileSync(bin, 'utf8');
+    expect(s.startsWith('#!/usr/bin/env bash')).toBe(true);
+    expect(s).toMatch(/FORGE_DRY/);
+    expect(s).toMatch(/areas: board/);
+  });
+
+  it.runIf(HAS_BASH)('resolves two-level areas to scripts/<area>/<cmd>.mjs', () => {
+    expect(dry(['board', 'create', '--title', 'x'])).toMatch(/scripts\/board\/create\.mjs --title x$/);
+    expect(dry(['gate', 'docsync', '--base', 'main'])).toMatch(/scripts\/gates\/docsync\.mjs --base main$/);
+    expect(dry(['autopilot', 'select', '--dry-run'])).toMatch(/scripts\/autopilot\/select\.mjs --dry-run$/);
+  });
+
+  it.runIf(HAS_BASH)('resolves single-level init/doctor/release', () => {
+    expect(dry(['init', '--project', '8'])).toMatch(/scripts\/init\.mjs --project 8$/);
+    expect(dry(['doctor'])).toMatch(/scripts\/doctor\.mjs$/);
+    expect(dry(['release', '--dry-run'])).toMatch(/scripts\/release\/release\.mjs --dry-run$/);
+  });
+
+  it.runIf(HAS_BASH)('fails fast: no args, unknown area, missing command, missing script', () => {
+    expect(() => execFileSync('bash', [bin], { stdio: 'ignore' })).toThrow();               // no args
+    expect(() => execFileSync('bash', [bin, 'bogus'], { stdio: 'ignore' })).toThrow();       // unknown area
+    expect(() => execFileSync('bash', [bin, 'board'], { stdio: 'ignore' })).toThrow();       // missing command
+    expect(() => execFileSync('bash', [bin, 'board', 'nope'], { stdio: 'ignore' })).toThrow(); // missing script
+  });
+});

--- a/tests/monitors/monitors.test.mjs
+++ b/tests/monitors/monitors.test.mjs
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { rollupState, transition, poll as ciPoll } from '../../plugin/scripts/monitors/ci-watch.mjs';
+import { newlyResolved } from '../../plugin/scripts/monitors/decisions-watch.mjs';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('CI monitor (#151)', () => {
+  it('reduces a checks rollup to pass | fail | pending (fail-closed)', () => {
+    expect(rollupState([])).toBe('pending');
+    expect(rollupState([{ conclusion: 'SUCCESS' }, { conclusion: 'SKIPPED' }])).toBe('pass');
+    expect(rollupState([{ conclusion: 'SUCCESS' }, { conclusion: 'FAILURE' }])).toBe('fail');
+    expect(rollupState([{ conclusion: 'SUCCESS' }, { status: 'IN_PROGRESS', conclusion: null }])).toBe('pending');
+    expect(rollupState([{ state: 'ERROR' }])).toBe('fail');
+  });
+
+  it('emits only on a state change', () => {
+    expect(transition('pending', 'pending')).toBe(null);
+    expect(transition('pending', 'pass')).toBe('pass');
+    expect(transition(null, 'fail')).toBe('fail');
+  });
+
+  it('poll stays quiet with no PR, and reports the transition when checks land', async () => {
+    const quiet = await ciPoll(async () => ({ ok: false }), null);
+    expect(quiet.line).toBe(null);
+    const gh = async () => ({ ok: true, json: { number: 42, headRefName: 'feat/x', statusCheckRollup: [{ conclusion: 'SUCCESS' }] } });
+    const first = await ciPoll(gh, null);
+    expect(first.line).toMatch(/CI pass on PR #42 \(feat\/x\)/);
+    const second = await ciPoll(gh, first.prev); // unchanged → silent
+    expect(second.line).toBe(null);
+  });
+});
+
+describe('decisions monitor (#151)', () => {
+  it('emits a resolved decision once, never a pending one', () => {
+    const seen = new Set();
+    const decisions = [
+      { id: 'a', issue: 1, status: 'pending' },
+      { id: 'b', issue: 2, status: 'resolved', answer: 'option 2\nmore' },
+    ];
+    const fresh = newlyResolved(seen, decisions);
+    expect(fresh.map((d) => d.id)).toEqual(['b']);
+    fresh.forEach((d) => seen.add(d.id));
+    expect(newlyResolved(seen, decisions)).toEqual([]); // already surfaced
+  });
+});
+
+describe('monitors manifest', () => {
+  it('declares the two autopilot watchers with when: on-skill-invoke:autopilot', async () => {
+    const arr = JSON.parse(await readFile(join(root, 'plugin', 'monitors', 'monitors.json'), 'utf8'));
+    expect(arr).toHaveLength(2);
+    for (const m of arr) {
+      expect(m.name && m.command && m.description).toBeTruthy();
+      expect(m.command).toContain('${CLAUDE_PLUGIN_ROOT}');
+      expect(m.when).toBe('on-skill-invoke:autopilot');
+    }
+    expect(arr.map((m) => m.name).sort()).toEqual(['forge-ci', 'forge-decisions']);
+  });
+});


### PR DESCRIPTION
Closes #150 · Closes #151 · Closes #153 · epic #148

## What
The additive plugin capabilities from the spike (the correctness fix #149 already merged; #152 closed as not-needed).

- **`bin/forge` dispatcher (#150)** — on the Bash-tool PATH: `forge board create …`, `forge gate docsync …`, `forge autopilot select …` instead of the long `node "${CLAUDE_PLUGIN_ROOT}/scripts/…"` form. `FORGE_DRY=1` prints the resolved invocation (how the tests check routing). *Honest:* shortens commands, still needs `node` on PATH.
- **Autopilot monitors (#151)** — `monitors/monitors.json` + two watchers that start `on-skill-invoke:autopilot`: `ci-watch` (prints CI rollup transitions on the branch PR, so the merge bar reacts to green/red) and `decisions-watch` (prints answered escalations from `.forge/decisions/`). Pure cores unit-tested; the loops are thin.
- **Polish (#153)** — `themes/forge.json` ("Forge (smithy)" `/theme`); `disable-model-invocation` on `init`/`deploy-init`/`release` so Claude won't auto-run operational skills; install-guide note pointing at the official LSP plugins (forge doesn't bundle LSP). `subagentStatusLine` deferred — its format isn't documented.

Also commits the spike findings doc + route-index entry.

## Verification
- `vitest run` — **317/317** (39 files; +9). `claude plugin validate ./plugin --strict` → ✔. `docsync --base main` → clean (42 docs).
- Monitors are interactive-only and unsandboxed (by design); they light up during an autopilot run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
