### PR TITLE
feat(skills): quiet output discipline for orchestration runs (#158)

### DIFF
--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -9,6 +9,10 @@ Clear the board, unattended. Autopilot is **`forge:deliver` in a continuous loop
 
 Spec: `docs/specs/2026-07-21-forge-autopilot.md`.
 
+## Output discipline (quiet run)
+
+The trail, ledger (`run.json`), and journal are the record — don't re-narrate them in chat. Emit **at most one terse status line per ticket** (`#123 → merged · PR #145`, `#130 → escalated (needs decision)`), never a paragraph, preamble, or recap. The delivery subagents work silently in their own contexts — surface only each returned **outcome**, not its working. Reserve prose for what the human must act on: **escalations** (the decision + options) and the **final run report**.
+
 ## The contract (what changes, what doesn't)
 
 - **The human PR gate is gone.** In its place, a strict **automated merge bar** (below). This is the deliberate trust reversal — the quality guarantee rests entirely on the mechanical gates + adversarial subagents + CI.

--- a/plugin/skills/deliver/SKILL.md
+++ b/plugin/skills/deliver/SKILL.md
@@ -7,6 +7,10 @@ description: End-to-end delivery of one triaged ticket, driven by subagents, wit
 
 One triaged ticket → a merge-ready PR (or, for a spike, an ADR), unattended, with **exactly one human gate: reviewing the PR**. `deliver` is **kind-aware** — it doesn't assume plain implementation. It classifies the ticket and routes to the right flow, running every phase on subagents while the main loop orchestrates and owns all state.
 
+## Output discipline (quiet run)
+
+The trail, ledger, and journal are the record — don't re-narrate them in chat. Emit **at most one terse status line per phase** (`plan committed`, `PR #145 opened`, `merged`), never a paragraph, preamble, or recap. Don't announce a subagent spawn — spawn it, consume its JSON report, surface only its **verdict + one-line note**, not its working. Reserve prose for **escalations** (the decision + options) and the **final result** (the PR/ADR link + honest verification).
+
 ## The one-gate contract
 
 - **The human is consulted once — at the PR.** Nothing between kickoff and PR asks for approval.

--- a/plugin/skills/execute-agents/SKILL.md
+++ b/plugin/skills/execute-agents/SKILL.md
@@ -7,6 +7,10 @@ description: Like forge:execute, but each plan task is driven by real subagents 
 
 The subagent-fan-out variant of `forge:execute`. Same order-is-law loop and the same ledger — the difference is **who does the work**: every role step is a **Task-tool subagent spawn**, not inline main-loop work. Use this when you want each task's scope/test/implement/review done by a fresh-context specialist; use plain `forge:execute` when inline is enough.
 
+## Output discipline (quiet run)
+
+The ledger, trail, and journal are the record — don't re-narrate them in chat. Emit **at most one terse status line per task** (`T2 tests green`, `T3 reviewed`), never a paragraph, preamble, or recap. Don't announce a subagent spawn — spawn it, consume its JSON report, surface only its **verdict + one-line note**, not its working. Reserve prose for **escalations** (the decision + options) and the **final summary**.
+
 ## Division of labour (the rule that makes this worth it)
 
 - **The orchestrator (this main loop) owns state and never writes task code itself:** branch, `.forge/progress.md` ledger, `.forge/scope.json`, the gates, trail comments, the resume protocol, and every escalation decision.

--- a/plugin/skills/execute/SKILL.md
+++ b/plugin/skills/execute/SKILL.md
@@ -7,6 +7,10 @@ description: Plan → branch, task by task — scoper → failing tests → impl
 
 Plan → working branch. Order is law (spec §4 item 5); the ledger makes any session resumable.
 
+## Output discipline (quiet run)
+
+The ledger, trail, and journal are the record — don't re-narrate them in chat. Emit **at most one terse status line per task** (`T2 tests green`, `T3 done`), never a paragraph, preamble, or recap. Don't announce what a subagent will do — spawn it, consume its JSON report, surface only its **verdict + one-line note**, not its working. Reserve prose for what the human must act on: **escalations** (the decision + options) and the **final summary**.
+
 ## Setup
 
 1. Branch per git conventions: `<type>/<issue#>-<slug>` cut from up-to-date main.

--- a/tests/skills/output-discipline.test.mjs
+++ b/tests/skills/output-discipline.test.mjs
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => readFile(join(root, rel), 'utf8');
+
+describe('orchestration skills are quiet by contract (#158)', () => {
+  const skills = [
+    'plugin/skills/autopilot/SKILL.md',
+    'plugin/skills/deliver/SKILL.md',
+    'plugin/skills/execute/SKILL.md',
+    'plugin/skills/execute-agents/SKILL.md',
+  ];
+
+  it('each carries an Output discipline section: trail is the record, one status line, prose only for escalations + final', async () => {
+    for (const path of skills) {
+      const s = await read(path);
+      expect(s, `${path} missing Output discipline`).toMatch(/## Output discipline/);
+      expect(s, `${path} should name the record`).toMatch(/trail.*record|ledger.*record|record —/i);
+      expect(s, `${path} should cap per-unit output`).toMatch(/one terse status line|status line per/i);
+      expect(s, `${path} should forbid re-narration`).toMatch(/re-narrate|preamble|recap/i);
+      expect(s, `${path} should reserve prose for escalations + final`).toMatch(/escalations.*(final|report|summary|result)/is);
+      expect(s, `${path} should surface verdict/outcome not working`).toMatch(/verdict.*note|outcome, not|not its working/i);
+    }
+  });
+});


### PR DESCRIPTION
Closes #158

During autopilot/deliver/execute/execute-agents runs, the trail + ledger + journal already hold the record, so the chat narration is redundant token cost. Each skill now carries an **Output discipline** section: ≤1 terse status line per ticket/task, no preamble/recap/re-narration, surface a subagent's verdict/outcome (not its working), prose only for **escalations** + the **final report**.

322/322 green · validate ✔. Contract test asserts all four skills carry it.