### PR TITLE
feat(agy): inline-output fix + shared core + ask helper + features.agy (#162)

### DIFF
--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -46,7 +46,7 @@ Run it after init and any time something feels off. ✗ items block work and say
 | deploy | `/forge:deploy-init` (sets `features.deploy`) | Dockerfile/compose/terraform scaffold, staging/production env-branch workflows, deploy-readiness gate, smoke script |
 | graph | `features.graph: true` + `npm i -D ts-morph` + `node <plugin>/scripts/graph/graphctl.mjs rebuild` | structural index: find_component / who_uses / blast_radius / reuse_candidates MCP tools (TypeScript repos only — grep-first is the permanent fallback otherwise) |
 | design review | `features.designReview: true` | design-reviewer validates UI work against visual specs |
-| Gemini second opinion | `features.geminiSecondOpinion: true` + `agy` (Antigravity) on PATH | opt-in cross-model review via `agy --print` (Gemini) — advisory, non-gating, zero Claude cost; optional `agy: { command, model }` config |
+| Gemini (agy) offload | `features.agy: true` + `agy` (Antigravity) on PATH | opt-in cross-model help via `agy --print` (Gemini), zero Claude cost — a **second opinion** (`scripts/review/agy-opinion.mjs`) and read-only **codebase Q&A** (`scripts/agy/ask.mjs`). Advisory, non-gating, read-only; optional `agy: { command, model }` config. (`features.geminiSecondOpinion` still accepted.) |
 
 **Code intelligence (LSP, optional):** forge's graph MCP gives structural reuse/blast-radius answers; for real-time diagnostics and go-to-definition, install Anthropic's official LSP plugin for your language rather than one from forge — search `lsp` in the `/plugin` Discover tab (e.g. `typescript-lsp`, `pyright-lsp`, `rust-analyzer-lsp`). Install the language server binary first, then the plugin. forge deliberately doesn't bundle an LSP — the binary is yours to install.
 

--- a/plugin/scripts/agy/ask.mjs
+++ b/plugin/scripts/agy/ask.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * agy ask (#162) — read-only codebase Q&A on Gemini, to offload cheap-but-frequent
+ * lookups (investigator/librarian-style "where does X happen?", "does Y already
+ * exist?") off Claude and onto the shared quota. Opt-in, advisory, read-only.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { loadConfig } from '../lib/config.mjs';
+import { runAgy, INLINE_RULE } from './core.mjs';
+
+/** A read-only, factual Q&A brief — locate/explain, don't judge or change anything. */
+export function buildAsk(question) {
+  return [
+    'You are a READ-ONLY code assistant working in this repository. Do NOT modify any files. Answer factually from the code; cite file paths and symbols.',
+    `Question: ${String(question ?? '').trim()}`,
+    'If the answer is not in the code, say "not found" rather than guessing.',
+    INLINE_RULE,
+  ].join('\n\n');
+}
+
+export async function runAgyAsk(config, { cwd, question } = {}, execFn) {
+  if (!question || !String(question).trim()) return { ok: false, error: 'a --question is required' };
+  const res = await runAgy(config, { prompt: buildAsk(question), cwd }, execFn);
+  if (!res.ok) return res;
+  return { ok: true, model: res.model, answer: res.output };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const argv = process.argv.slice(2);
+  const qi = argv.indexOf('--question');
+  const question = qi >= 0 ? argv[qi + 1] : argv.join(' ');
+  const cwd = process.cwd();
+  loadConfig(cwd).then(async (cfg) => {
+    const res = await runAgyAsk(cfg.config ?? {}, { cwd, question });
+    if (res.skipped) { console.error(res.reason + ' — set features.agy true in .claude/forge.json'); process.exit(2); }
+    if (!res.ok) { console.error(`agy ask failed: ${res.error}`); process.exit(1); }
+    console.log(`# Gemini (${res.model}) — read-only, advisory\n\n${res.answer}`);
+  });
+}

--- a/plugin/scripts/agy/core.mjs
+++ b/plugin/scripts/agy/core.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * agy / Antigravity shared core (#162). One headless-Gemini entry point behind
+ * an opt-in flag, used by purpose-built helpers (second opinion, ask). All agy
+ * work is ADVISORY and read-only (plan mode) — it never gates the pipeline and
+ * never edits the repo. This is not the removed multi-backend role-swap plane
+ * (ADR-0004): it's a set of flagged, non-gating tools that share unused quota.
+ */
+import { run } from '../lib/exec.mjs';
+
+export const DEFAULT_COMMAND = 'agy';
+export const DEFAULT_MODEL = 'gemini-3.1-pro-high';
+
+// The live test (#160) showed agy will write its answer to a file and print only
+// a summary — force the whole thing to stdout so callers actually get it.
+export const INLINE_RULE = 'Print your COMPLETE response inline in this reply. Do NOT write it to a file, a report, or the workspace — output everything directly here.';
+
+/** Opt-in. `features.agy` is the umbrella; `geminiSecondOpinion` stays for back-compat. */
+export function agyEnabled(config) {
+  return config?.features?.agy === true || config?.features?.geminiSecondOpinion === true;
+}
+export function agyCommand(config) { return config?.agy?.command ?? DEFAULT_COMMAND; }
+export function agyModel(config) { return config?.agy?.model ?? DEFAULT_MODEL; }
+
+/**
+ * Headless print, repo in scope, plan mode = read-only, skip prompts (else it
+ * hangs). No `--effort`: agy's model names already encode the tier (…-low/-high),
+ * and passing a conflicting effort is a hard error (found in the #160 live test).
+ */
+export function agyArgs({ prompt, cwd, model = DEFAULT_MODEL, mode = 'plan' }) {
+  return ['--print', prompt, '--add-dir', cwd, '--model', model, '--mode', mode, '--dangerously-skip-permissions'];
+}
+
+/**
+ * Run one agy pass. Fails SOFT — advisory work never throws or blocks; a missing
+ * `agy` or nonzero exit returns { ok:false } for the caller to note and move on.
+ * `execFn` injected for tests.
+ */
+export async function runAgy(config, { prompt, cwd, model, mode = 'plan' } = {}, execFn = run) {
+  if (!agyEnabled(config)) return { ok: false, skipped: true, reason: 'features.agy is off (opt-in)' };
+  const command = agyCommand(config);
+  const m = model ?? agyModel(config);
+  let res;
+  try { res = await execFn(command, agyArgs({ prompt, cwd, model: m, mode })); }
+  catch (e) { return { ok: false, error: `could not run ${command}: ${e.message}` }; }
+  if (!res.ok) return { ok: false, error: res.stderr?.trim() || `${command} --print failed (on PATH? try: ${command} --version)` };
+  return { ok: true, model: m, output: (res.stdout ?? '').trim() };
+}

--- a/plugin/scripts/review/agy-opinion.mjs
+++ b/plugin/scripts/review/agy-opinion.mjs
@@ -1,22 +1,16 @@
 #!/usr/bin/env node
 /**
- * Gemini second opinion via agy / Antigravity (#160). Opt-in, ADVISORY, never a
- * gate. `agy --print` runs a headless agentic pass on a genuinely different model
- * (Gemini) at zero Claude cost — a real independent reviewer for a diff/spec.
- * This does NOT reintroduce the removed multi-backend role-swap plane (ADR-0004):
- * it's one purpose-built, non-gating tool behind a feature flag.
+ * Gemini second opinion via agy / Antigravity (#160, #162). Opt-in, ADVISORY,
+ * never a gate — a genuinely different model's eyes on a diff/file at zero Claude
+ * cost. Built on the shared agy core.
  */
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { run } from '../lib/exec.mjs';
 import { loadConfig } from '../lib/config.mjs';
+import { runAgy, agyEnabled, agyArgs, INLINE_RULE, DEFAULT_MODEL, DEFAULT_COMMAND } from '../agy/core.mjs';
 
-export const DEFAULT_COMMAND = 'agy';
-export const DEFAULT_MODEL = 'gemini-3.1-pro-high';
-
-export function agyEnabled(config) {
-  return config?.features?.geminiSecondOpinion === true;
-}
+// Re-export for back-compat with existing importers.
+export { agyEnabled, agyArgs, DEFAULT_MODEL, DEFAULT_COMMAND };
 
 /** A skeptical, read-only, advisory review brief for the second model. */
 export function buildBrief({ ticket = null, acs = [], target = 'the diff on the current branch' } = {}) {
@@ -25,29 +19,14 @@ export function buildBrief({ ticket = null, acs = [], target = 'the diff on the 
     `Review ${target}${ticket ? ` for ticket #${ticket}` : ''}. Be skeptical. Look for correctness bugs first, then security, then design/simplification.`,
     acs.length ? `Check these acceptance criteria:\n${acs.map((a) => `- ${a}`).join('\n')}` : '',
     'Report concise, severity-tagged findings (critical | high | medium | low). If you find nothing real, say so plainly — "Unknown" or "no issues found" are valid answers.',
+    INLINE_RULE,
   ].filter(Boolean).join('\n\n');
 }
 
-/** The agy invocation: headless print, repo in scope, plan mode = read-only. */
-export function agyArgs({ prompt, cwd, model = DEFAULT_MODEL, effort = 'high' }) {
-  return ['--print', prompt, '--add-dir', cwd, '--model', model, '--effort', effort, '--mode', 'plan', '--dangerously-skip-permissions'];
-}
-
-/**
- * Run the second opinion. Fails SOFT — advisory work never throws or blocks the
- * pipeline; a missing `agy` or a nonzero exit returns { ok:false } for the caller
- * to note and move on. `execFn` is injected for tests.
- */
-export async function runAgyOpinion(config, { cwd, ticket = null, acs = [], target } = {}, execFn = run) {
-  if (!agyEnabled(config)) return { ok: false, skipped: true, reason: 'features.geminiSecondOpinion is off (opt-in)' };
-  const command = config?.agy?.command ?? DEFAULT_COMMAND;
-  const model = config?.agy?.model ?? DEFAULT_MODEL;
-  const prompt = buildBrief({ ticket, acs, target });
-  let res;
-  try { res = await execFn(command, agyArgs({ prompt, cwd, model })); }
-  catch (e) { return { ok: false, error: `could not run ${command}: ${e.message}` }; }
-  if (!res.ok) return { ok: false, error: res.stderr?.trim() || `${command} --print failed (is it on PATH? try: ${command} --version)` };
-  return { ok: true, model, critique: (res.stdout ?? '').trim() };
+export async function runAgyOpinion(config, { cwd, ticket = null, acs = [], target } = {}, execFn) {
+  const res = await runAgy(config, { prompt: buildBrief({ ticket, acs, target }), cwd }, execFn);
+  if (!res.ok) return res;
+  return { ok: true, model: res.model, critique: res.output };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
@@ -58,9 +37,8 @@ if (isMain) {
   const cwd = process.cwd();
   loadConfig(cwd).then(async (cfg) => {
     const res = await runAgyOpinion(cfg.config ?? {}, { cwd, ticket: get('--ticket'), acs, target: get('--target') ?? undefined });
-    if (res.skipped) { console.error(res.reason + ' — set it true in .claude/forge.json'); process.exit(2); }
+    if (res.skipped) { console.error(res.reason + ' — set features.agy true in .claude/forge.json'); process.exit(2); }
     if (!res.ok) { console.error(`second opinion failed: ${res.error}`); process.exit(1); }
-    console.log(`# Gemini second opinion (${res.model}) — advisory\n`);
-    console.log(res.critique);
+    console.log(`# Gemini second opinion (${res.model}) — advisory\n\n${res.critique}`);
   });
 }

--- a/plugin/skills/investigate/SKILL.md
+++ b/plugin/skills/investigate/SKILL.md
@@ -7,6 +7,8 @@ description: Unknown-cause bug → root cause + fix proposal on the ticket. Use 
 
 Debugging as a discipline, separate from building (spec §4 item 13). The deliverable is a **root cause + fix proposal on the ticket** — not a fix. The fix goes through execute (planned) or hotfix (urgent).
 
+**Optional Gemini offload (opt-in):** when `features.agy` is on, read-only "where does X happen / what calls Y" lookups can be offloaded to Gemini to save Claude quota — `node "${CLAUDE_PLUGIN_ROOT}/scripts/agy/ask.mjs" --question "…"`. Advisory + read-only; verify anything it claims against the code before acting.
+
 ## Steps
 
 1. **Ticket check**: the bug must have a ticket (triage first). Trail: `comment.mjs --phase started --body "investigating: <hypothesis>"`.

--- a/plugin/skills/spike/SKILL.md
+++ b/plugin/skills/spike/SKILL.md
@@ -7,6 +7,8 @@ description: Time-boxed research — throwaway exploration on a spike branch tha
 
 Finding out, not building (spec §4 item 12). Opposite rules from the Build lane, on purpose.
 
+**Optional Gemini offload (opt-in):** a spike is exploratory and non-gating, so when `features.agy` is on it's a natural place to spend the shared Gemini quota — `node "${CLAUDE_PLUGIN_ROOT}/scripts/agy/ask.mjs" --question "…"` for read-only codebase Q&A, or the second-opinion helper for a cross-model take. Advisory; the ADR still records *your* verified findings, not the model's raw output.
+
 ## Rules
 
 - **Time-boxed**: agree the box up front (default: half a day). When it expires, write up what you have — "inconclusive, here's what we learned" is a legitimate finding.

--- a/tests/agy/agy.test.mjs
+++ b/tests/agy/agy.test.mjs
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { agyEnabled, agyArgs, runAgy, INLINE_RULE, DEFAULT_MODEL } from '../../plugin/scripts/agy/core.mjs';
+import { buildAsk, runAgyAsk } from '../../plugin/scripts/agy/ask.mjs';
+import { buildBrief } from '../../plugin/scripts/review/agy-opinion.mjs';
+
+describe('agy shared core (#162)', () => {
+  it('AC.2: features.agy is the umbrella; geminiSecondOpinion still works', () => {
+    expect(agyEnabled({})).toBe(false);
+    expect(agyEnabled({ features: { agy: true } })).toBe(true);
+    expect(agyEnabled({ features: { geminiSecondOpinion: true } })).toBe(true); // back-compat
+  });
+
+  it('AC.1: every brief demands complete INLINE output (the live-test fix — no file)', () => {
+    expect(INLINE_RULE).toMatch(/Do NOT write it to a file/i);
+    expect(buildBrief({})).toContain(INLINE_RULE);
+    expect(buildAsk('where is X')).toContain(INLINE_RULE);
+  });
+
+  it('runAgy: skips when off (no exec), returns output when on, fails soft', async () => {
+    let called = false;
+    const off = await runAgy({}, { prompt: 'p', cwd: '/r' }, async () => { called = true; return { ok: true, stdout: 'x' }; });
+    expect(off).toMatchObject({ ok: false, skipped: true });
+    expect(called).toBe(false);
+
+    const on = { features: { agy: true } };
+    const good = await runAgy(on, { prompt: 'p', cwd: '/r' }, async (cmd, args) => {
+      expect(args).toContain('--print');
+      expect(args[args.indexOf('--mode') + 1]).toBe('plan'); // read-only
+      return { ok: true, stdout: 'answer' };
+    });
+    expect(good).toMatchObject({ ok: true, model: DEFAULT_MODEL, output: 'answer' });
+
+    expect((await runAgy(on, { prompt: 'p', cwd: '/r' }, async () => ({ ok: false, stderr: 'nope' }))).ok).toBe(false);
+    const threw = await runAgy(on, { prompt: 'p', cwd: '/r' }, async () => { throw new Error('ENOENT'); });
+    expect(threw).toMatchObject({ ok: false });
+    expect(threw.error).toMatch(/ENOENT/);
+  });
+
+  it('agyArgs is headless + read-only', () => {
+    const a = agyArgs({ prompt: 'P', cwd: '/r' });
+    expect(a).toContain('--print');
+    expect(a).toContain('--dangerously-skip-permissions');
+    expect(a[a.indexOf('--mode') + 1]).toBe('plan');
+  });
+});
+
+describe('agy ask — read-only codebase Q&A (#162, AC.3)', () => {
+  it('brief is read-only and factual, and carries the question', () => {
+    const b = buildAsk('where does the merge bar live?');
+    expect(b).toMatch(/READ-ONLY/i);
+    expect(b).toMatch(/Do NOT modify/i);
+    expect(b).toMatch(/where does the merge bar live\?/);
+    expect(b).toMatch(/not found.*rather than guessing/i);
+  });
+
+  it('requires a question, returns the answer via injected exec, skips when off', async () => {
+    const on = { features: { agy: true } };
+    expect((await runAgyAsk(on, { cwd: '/r', question: '' })).error).toMatch(/question is required/);
+    const ans = await runAgyAsk(on, { cwd: '/r', question: 'where is X' }, async () => ({ ok: true, stdout: 'in foo.mjs' }));
+    expect(ans).toMatchObject({ ok: true, answer: 'in foo.mjs' });
+    const off = await runAgyAsk({}, { cwd: '/r', question: 'where is X' }, async () => ({ ok: true, stdout: 'x' }));
+    expect(off).toMatchObject({ ok: false, skipped: true });
+  });
+});


### PR DESCRIPTION
Closes #162 · epic follow-up to #160

**Live test drove two real fixes:** agy wrote its findings to a file (brain dir) and printed only a summary → the brief now demands **complete inline output**; and `--effort` conflicts with tier-encoded model names (`…-high`) → dropped it. Re-tested live: gemini-3.5-flash-high answered **inline in 13s**, correctly.

**More quota-sharing uses:**
- Shared core `scripts/agy/core.mjs` — `features.agy` umbrella flag (geminiSecondOpinion still accepted), read-only plan mode, fails soft, non-gating.
- New `scripts/agy/ask.mjs` — read-only **codebase Q&A** on Gemini to offload investigator/librarian lookups off Claude. Wired opt-in into **investigate** + **spike** skills.
- `agy-opinion.mjs` refactored onto the core.

333/333 green · validate ✔ · docsync clean.