### PR TITLE
fix(autopilot): exclude umbrella types (program/epic) from selectNext

### DIFF
--- a/plugin/scripts/autopilot/select.mjs
+++ b/plugin/scripts/autopilot/select.mjs
@@ -15,6 +15,10 @@ import { isShaped } from './readiness.mjs';
 const TIER = { inProgress: 0, inReview: 0, ready: 1, backlog: 2 };
 // Never selected — blocked has a pending decision; the rest are terminal.
 const SKIP = new Set(['blocked', 'done', 'wontDo']);
+// Umbrella types (#175) are containers, not units of work — a program/epic
+// ticket is never itself deliverable, so it must never be selected regardless
+// of status. normalize() already captures `type`; this is the guard that uses it.
+const UMBRELLA_TYPES = new Set(['program', 'epic']);
 const PRIORITY_RANK = { p0: 0, p1: 1, p2: 2 };
 
 /**
@@ -44,6 +48,7 @@ export function actionFor(status, { shape = false, ready = null } = {}) {
 export function selectNext(tickets, { area = null, shape = false } = {}) {
   const actionable = tickets
     .filter((t) => !SKIP.has(t.status) && TIER[t.status] !== undefined)
+    .filter((t) => !UMBRELLA_TYPES.has(t.type)) // #175: umbrella items are containers, never deliverable
     .filter((t) => (area ? t.area === area : true))
     .sort((a, b) =>
       (TIER[a.status] - TIER[b.status]) ||

--- a/tests/autopilot/engine.test.mjs
+++ b/tests/autopilot/engine.test.mjs
@@ -51,6 +51,35 @@ describe('autopilot selection (#128, AC-1/AC-2)', () => {
   });
 });
 
+describe('umbrella-type exclusion (#175, AC1/AC2)', () => {
+  const u = (number, status, type) => ({ ...t(number, status), type });
+
+  it('AC1: a program/epic ticket is never selected, in any status', () => {
+    for (const status of ['inProgress', 'ready', 'backlog']) {
+      for (const type of ['program', 'epic']) {
+        expect(selectNext([u(1, status, type)])).toBeNull();
+      }
+    }
+  });
+
+  it('AC2: umbrella items are excluded across tiers while deliverable siblings remain', () => {
+    const tickets = [
+      u(1, 'inProgress', 'program'),
+      u(2, 'ready', 'epic'),
+      u(3, 'backlog', 'program'),
+      { ...t(4, 'ready'), type: 'bug' },
+    ];
+    // only the bug survives — despite the program sitting in the higher resume tier
+    expect(selectNext(tickets).ticket.number).toBe(4);
+    expect(actionableQueue(tickets).map((q) => q.ticket.number)).toEqual([4]);
+  });
+
+  it('a non-umbrella (or untyped) ticket is still selectable', () => {
+    expect(selectNext([{ ...t(1, 'ready'), type: 'feature' }]).ticket.number).toBe(1);
+    expect(selectNext([t(1, 'ready')]).ticket.number).toBe(1); // type undefined → not umbrella
+  });
+});
+
 describe('crazy-mode readiness routing (#142, AC-1)', () => {
   it('isShaped detects acceptance criteria (Acceptance section or AC-ids)', () => {
     expect(isShaped('## Acceptance\n- AC-1: does X')).toBe(true);


### PR DESCRIPTION
## Problem
`selectNext` (`plugin/scripts/autopilot/select.mjs`) filtered only on `SKIP` status and `TIER`, never on `type` — even though `normalize()` already captures `type`. A `type: program` ticket therefore mis-selected perpetually (routing as resume/triage) and epics routed to shape. Umbrella items are containers, not units of work, and must never be selected as deliverable. (iomanage real-usage feedback #1; was a local plugin-cache patch silently reverted by every `/plugin update`.)

## Fix
- Add `const UMBRELLA_TYPES = new Set(['program', 'epic'])`.
- Exclude it in the `selectNext` filter chain (`.filter((t) => !UMBRELLA_TYPES.has(t.type))`), so `actionableQueue` inherits the guard.

Minimal change — no selection-logic refactor beyond the guard.

## Acceptance criteria
- [x] **AC1**: a program or epic ticket in any status is never returned by `selectNext` / `actionableQueue`.
- [x] **AC2**: a test covers program + epic exclusion across inProgress/ready/backlog.

## Verification
- New tests in `tests/autopilot/engine.test.mjs` (`umbrella-type exclusion (#175, AC1/AC2)`): AC1 loops program/epic × inProgress/ready/backlog asserting `selectNext` is null; AC2 asserts umbrella items are dropped across tiers while a deliverable bug survives in both `selectNext` and `actionableQueue`; plus a guard that untyped/non-umbrella tickets stay selectable.
- `pnpm verify` green: 345 tests passing.
- forge:reviewer PASS (0 critical/high) — confirmed `'program'`/`'epic'` match the board's normalized option keys.
- forge:security PASS (0 critical/high) — narrowing filter, no injection/prototype-pollution surface (Set, hardcoded literals).

Closes #175