### PR TITLE
fix(autopilot): delivery-subagent brief must watch CI to green in-run and merge same run

### DIFF
--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -28,8 +28,9 @@ select next actionable ticket (§ selection)
   ├─ none left ────────────────────────────▶ STOP + run report
   ▼
 SPAWN a delivery subagent (Task tool) for this ticket ─────────┐   § Orchestration
-  brief: deliver #N end-to-end (triage/shape → plan →          │   runs in its OWN context
-  execute → ship → open PR → wait CI → auto-merge on green),    │
+  brief: deliver #N end-to-end (triage/shape → plan → execute   │   runs in its OWN context
+  → ship → open PR → WATCH CI to green in-run                   │
+  (`gh pr checks <pr> --watch`) → auto-merge on green),         │
   return {issue, outcome, pr, notes}                            │
   ▼                                                             │
 main loop reads ONLY that terminal report ◀────────────────────┘
@@ -44,7 +45,9 @@ loop  (main context unchanged — ~O(1) per ticket)
 
 Per ticket, the main loop does exactly three things: **spawn**, **record**, **continue**.
 
-1. **Spawn a delivery subagent** with the Task tool — `subagent_type: general-purpose` (or a dedicated delivery agent if the roster has one). The brief is self-contained so the subagent needs no main-loop context: the ticket ref + body, the route (deliver, or shape-first under `--shape`), the merge bar (§ auto-merge), the escalation triggers (§ human gates), and this instruction — *do the whole ticket in your own context (branch, plan, implement, test, gates, ship, wait for CI, auto-merge on green, post-merge ritual); file follow-ups directly with `board/create.mjs`; escalate with `escalate.mjs`; then return a compact terminal report and nothing else.*
+1. **Spawn a delivery subagent** with the Task tool — `subagent_type: general-purpose` (or a dedicated delivery agent if the roster has one). The brief is self-contained so the subagent needs no main-loop context: the ticket ref + body, the route (deliver, or shape-first under `--shape`), the merge bar (§ auto-merge), the escalation triggers (§ human gates), and this instruction — *do the whole ticket in your own context (branch, plan, implement, test, gates, ship, open the PR, **watch CI to green in this same run with `gh pr checks <pr> --watch`**, auto-merge on green, post-merge ritual); file follow-ups directly with `board/create.mjs`; escalate with `escalate.mjs`; then return a compact terminal report and nothing else.*
+
+   **Forbidden — the return-then-resume stall:** the brief must NOT tell the subagent to open the PR and then return awaiting an external/background completion notification (e.g. "await the CI watcher's notification"). The subagent's context is discarded on return and **nothing re-invokes it when CI goes green** — that stalls the ticket until a manual resume. The background CI monitor notifies the **main loop**, not a returned subagent. The subagent must therefore watch CI to conclusion **in-run itself** (`gh pr checks <pr> --watch`) and merge within the **same invocation** — never return on the assumption it will be re-spawned on green.
 2. **Read only the terminal report** — `{issue, outcome: merged|escalated|awaiting-human|skipped, pr, notes}`. The main loop consumes that JSON, writes it to `run.json`, trails the ticket, and never re-reads the subagent's work.
 3. **Continue** to the next ticket. Because the delivery context is discarded, the main window is unchanged between tickets — a 5-ticket and a 50-ticket run cost the same orchestration overhead, and the run never compacts mid-loop.
 
@@ -88,7 +91,7 @@ A ticket merges **only when every one of these is green**. Any red routes to a f
 1. `forge:ship` completed clean: situation gate · conventions lint · rebase + full `verify` green.
 2. All mechanical gates pass: `plandrift` · `testintent` · `depguard` · `acgate` (every AC id in a passing test).
 3. Full-branch `reviewer` **and** `security` subagents return `verdict: pass` with **zero critical/high** findings. A critical is always an escalation, never a merge.
-4. **CI on the PR is green.** Open the PR as deliver does (`Closes #n`, AC checklist, honest verification), then wait for checks — never merge before CI.
+4. **CI on the PR is green.** Open the PR as deliver does (`Closes #n`, AC checklist, honest verification), then **watch CI to conclusion in the same run** with `gh pr checks <pr> --watch` — never merge before CI, and never return awaiting an external notification (the delivery subagent isn't re-invoked on green — § Orchestration).
 5. **Squash-merge to main**, delete the branch, `Closes #n` closes the issue.
 
 **Opt-out:** if `features.autopilotAutoMerge` is `false`, autopilot stops at the open PR for that ticket, records it as *awaiting-human*, and continues the loop with other tickets — the safe-by-default door for consumers who adopt autopilot but not its merge policy.

--- a/plugin/skills/deliver/SKILL.md
+++ b/plugin/skills/deliver/SKILL.md
@@ -36,7 +36,7 @@ Run the **`forge:execute-agents`** loop against the plan. Per task, the executor
 
 ## Ship (all shippable kinds)
 
-Run `forge:ship`: situation gate · conventions lint · rebase + verify · mechanical gates (`plandrift`, `testintent`, `depguard`, `acgate`) · full-branch `security` + `reviewer` subagents (criticals escalate) · open the PR with `Closes #<n>`, the AC checklist, and an **honest verification statement**. Trail `--phase pr` → `ci-green`.
+Run `forge:ship`: situation gate · conventions lint · rebase + verify · mechanical gates (`plandrift`, `testintent`, `depguard`, `acgate`) · full-branch `security` + `reviewer` subagents (criticals escalate) · open the PR with `Closes #<n>`, the AC checklist, and an **honest verification statement**. Then **watch CI to green in this same run** with `gh pr checks <pr> --watch` — do **not** open the PR and return awaiting a background/external completion notification: a returned subagent's context is discarded and nothing re-invokes it on green, so the ticket stalls until a manual resume. Trail `--phase pr` → `ci-green`.
 
 ## Stop — the human gate
 

--- a/tests/skills/autopilot.test.mjs
+++ b/tests/skills/autopilot.test.mjs
@@ -81,6 +81,18 @@ describe('forge:autopilot skill (AC-1, AC-4, #126)', () => {
     expect(s).toMatch(/host OS is irrelevant|OS.*irrelevant/i);
   });
 
+  it('#177: the delivery-subagent brief watches CI to green in-run and forbids the return-then-resume stall', async () => {
+    const s = await read('plugin/skills/autopilot/SKILL.md');
+    // AC1: brief instructs gh pr checks --watch to conclusion + merge in the same run
+    expect(s).toMatch(/gh pr checks <pr> --watch/);
+    expect(s).toMatch(/watch CI to green in.?run|watch CI to conclusion/i);
+    expect(s).toMatch(/same (run|invocation)/i);
+    // AC2: the open-PR-then-await-external-notification stall is explicitly forbidden
+    expect(s).toMatch(/Forbidden.*return-then-resume|return-then-resume stall/i);
+    expect(s).toMatch(/nothing re-invokes it when CI goes green|isn't re-invoked on green|never return.*re-spawned on green/i);
+    expect(s).toMatch(/await.*(external|background).*notification/i);
+  });
+
   it('AC-2 front door + AC-5 files new work + AC-6 safety are all specified', async () => {
     const s = await read('plugin/skills/autopilot/SKILL.md');
     // auto-triage front door, under-specified => escalate + skip

--- a/tests/skills/deliver.test.mjs
+++ b/tests/skills/deliver.test.mjs
@@ -46,6 +46,17 @@ describe('forge:deliver skill (AC-121, #121)', () => {
     expect(ea).toMatch(/devops/);
   });
 
+  it('#177: ship watches CI to green in-run and forbids the open-PR-then-return stall', async () => {
+    const s = await read('plugin/skills/deliver/SKILL.md');
+    // AC1: watch CI to green in the same run with gh pr checks --watch
+    expect(s).toMatch(/gh pr checks <pr> --watch/);
+    expect(s).toMatch(/watch CI to green in this same run|watch CI to conclusion/i);
+    // AC2: forbid opening the PR and returning to await an external notification
+    expect(s).toMatch(/do \*\*not\*\*|must not|forbid/i);
+    expect(s).toMatch(/await.*(background|external).*notification/i);
+    expect(s).toMatch(/nothing re-invokes it on green|context is discarded/i);
+  });
+
   it('AC-121.2: planner is a compiled, read-only role pinned to a model', async () => {
     const { ROLES, MODELS } = await import('../../plugin/scripts/backends/compile.mjs');
     expect(ROLES).toContain('planner');


### PR DESCRIPTION
Closes #177

## Problem
An autopilot delivery subagent that opens a PR and then plans to "await the background watcher's completion notification" **stalls**: the subagent's context is discarded on return and nothing re-invokes it when CI goes green (the background CI monitor notifies the **main loop**, not a returned subagent). Requires a manual resume.

## Fix
The delivery-subagent brief template now instructs the subagent to watch CI to green **in the same run** with `gh pr checks <pr> --watch` and merge within that invocation, and explicitly forbids the return-then-resume stall.

- `plugin/skills/autopilot/SKILL.md` — § Orchestration brief + loop diagram + merge-bar item 4; added a "Forbidden — the return-then-resume stall" callout.
- `plugin/skills/deliver/SKILL.md` — Ship phase watches CI to green in-run and forbids the open-PR-then-await-notification stall.
- Tests extended in `tests/skills/autopilot.test.mjs` and `tests/skills/deliver.test.mjs`.

## Acceptance criteria
- [x] **AC1**: brief tells the subagent to `gh pr checks <pr> --watch` to conclusion and merge in the same invocation (no return-then-resume on green).
- [x] **AC2**: the stall mode (open PR then await external notification) is explicitly called out as forbidden in the brief.
- [x] **AC3**: skill-content tests assert the watch-and-merge instruction is present in both SKILL.md briefs.

## Verification
- `pnpm verify` green locally: 42 files, 350 tests passing (incl. the two new #177 assertions, docsync + output-discipline gates).
- Docs/skill-content change only; no runtime source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)