### PR TITLE
fix(autopilot): kill-switch names the real situation gate, not removed forge-control

### DIFF
--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -131,7 +131,7 @@ When delivery surfaces a need out of the current ticket's scope, file it rather 
 
 - **Natural stop:** no actionable ticket remains → print the run report (merged / escalated / skipped / newly-filed) and exit.
 - **`--limit N`:** stop after N merges.
-- **Kill switch:** honour the per-repo **situation gate** (`gates/situationgate.mjs`) — while the repo is in an **open incident** or **security-response** (security hold) situation the gate pauses ship/release (during an incident only `hotfix/*` proceeds; during a security hold only `respond`/`investigate` run), so autopilot spawns no new delivery until it clears. Clearing the situation is always a human action (close the incident / lift the security hold), never automated.
+- **Kill switch:** honour the per-repo **situation gate** (`gates/situationgate.mjs`) — while the repo is in an **open incident** or **security-response** (security hold) situation the gate pauses shipping (during an incident, ship proceeds only on a `hotfix/*` branch and release is refused outright; during a security hold only `respond`/`investigate` run), so autopilot spawns no new delivery until it clears. Clearing the situation is always a human action (close the incident / lift the security hold), never automated.
 - **Interrupt:** Ctrl-C between tickets is clean (the run ledger is the resume point); mid-ticket, deliver's own resume protocol recovers.
 - **Loop backstop:** a max-iterations guard (default = board size × 2) prevents a file-a-ticket-per-iteration runaway — hitting it escalates rather than looping forever.
 

--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -131,7 +131,7 @@ When delivery surfaces a need out of the current ticket's scope, file it rather 
 
 - **Natural stop:** no actionable ticket remains → print the run report (merged / escalated / skipped / newly-filed) and exit.
 - **`--limit N`:** stop after N merges.
-- **Kill switch:** honour the forge-control global pause (`.forge-control/paused`) and the per-repo situation gate (open incident / security hold) — spawn nothing while paused. Clearing a pause is always a human, never automated.
+- **Kill switch:** honour the per-repo **situation gate** (`gates/situationgate.mjs`) — while the repo is in an **open incident** or **security-response** (security hold) situation the gate pauses ship/release (during an incident only `hotfix/*` proceeds; during a security hold only `respond`/`investigate` run), so autopilot spawns no new delivery until it clears. Clearing the situation is always a human action (close the incident / lift the security hold), never automated.
 - **Interrupt:** Ctrl-C between tickets is clean (the run ledger is the resume point); mid-ticket, deliver's own resume protocol recovers.
 - **Loop backstop:** a max-iterations guard (default = board size × 2) prevents a file-a-ticket-per-iteration runaway — hitting it escalates rather than looping forever.
 

--- a/tests/skills/autopilot.test.mjs
+++ b/tests/skills/autopilot.test.mjs
@@ -135,6 +135,17 @@ describe('forge:autopilot skill (AC-1, AC-4, #126)', () => {
     expect(s).toMatch(/PR-only|awaiting-human/i);
   });
 
+  it('#166: the kill switch names only the real situation gate — no removed forge-control pause', async () => {
+    const s = await read('plugin/skills/autopilot/SKILL.md');
+    // AC2: forge-control was removed by ADR-0003 — no dead-subsystem reference remains
+    expect(s).not.toMatch(/forge-control/);
+    expect(s).not.toMatch(/\.forge-control/);
+    // AC1: the kill switch describes the real per-repo situation gate (incident / security hold)
+    expect(s).toMatch(/situation gate/i);
+    expect(s).toMatch(/incident/i);
+    expect(s).toMatch(/security.?(response|hold)/i);
+  });
+
   it('AC-2 front door + AC-5 files new work + AC-6 safety are all specified', async () => {
     const s = await read('plugin/skills/autopilot/SKILL.md');
     // auto-triage front door, under-specified => escalate + skip


### PR DESCRIPTION
## What & why
`skills/autopilot/SKILL.md` told the loop to "honour the forge-control global pause (`.forge-control/paused`)". forge-control was removed by ADR-0003 (`docs/decisions/0003-remove-control-console.md`) and nothing in `plugin/` produces or reads `.forge-control/paused` — the contract pointed at a dead subsystem.

The kill-switch line now describes only the pause mechanism that exists today: the per-repo **situation gate** (`plugin/scripts/gates/situationgate.mjs`) — open **incident** (only `hotfix/*` proceeds) or **security-response** / security hold (only `respond`/`investigate` run), cleared only by a human.

## Acceptance criteria
- [x] **AC1** — the kill-switch section describes only the real gate (per-repo situation gate: open incident / security hold) and the real pause behaviour that exists today.
- [x] **AC2** — no reference to forge-control / `.forge-control/paused` remains in `plugin/skills/` (grep-confirmed: 0 occurrences in all of `plugin/`).

## Verification
- New negative-content test `tests/skills/autopilot.test.mjs` (#166): asserts no `forge-control`/`.forge-control` reference and that the situation gate (incident / security hold) is named.
- `pnpm verify` (vitest run): **355 passed** (42 files), incl. the pre-existing `/paused|kill switch/i` safety-rail assertion which still matches on "Kill switch".
- `grep -r 'forge-control' plugin/` → 0 matches.

Closes #166
