### PR TITLE
fix(autopilot): spec kill-switch names the situation gate, not removed forge-control

### DIFF
--- a/docs/specs/2026-07-21-forge-autopilot.md
+++ b/docs/specs/2026-07-21-forge-autopilot.md
@@ -96,7 +96,7 @@ Filed tickets enter the queue and are picked up in a later iteration by §5 — 
 
 - **Natural stop:** no actionable ticket remains (all `done`/`wontDo`/`blocked`) → print the run report (merged / escalated / skipped / newly-filed) and exit.
 - **`--limit N`:** stop after N merges.
-- **Kill switch:** honours the forge-control global pause (`.forge-control/paused`) and the per-repo situation gate (open incident / security hold) — autopilot spawns nothing while paused. A human clearing the pause is always manual.
+- **Kill switch:** honours the per-repo **situation gate** (`gates/situationgate.mjs`) — while the repo is in an **open incident** or **security-response** (security hold) situation the gate pauses shipping, so autopilot spawns no new delivery until it clears. Clearing the situation is always a human action (close the incident / lift the security hold), never automated.
 - **Interrupt:** Ctrl-C between tickets is clean (the run ledger is the resume point); mid-ticket, deliver's own resume protocol recovers.
 - **Loop backstop:** a max-iterations guard (default = board size × 2) prevents a pathological file-a-ticket-per-iteration runaway; hitting it escalates rather than looping forever.
 

--- a/tests/skills/autopilot.test.mjs
+++ b/tests/skills/autopilot.test.mjs
@@ -146,6 +146,17 @@ describe('forge:autopilot skill (AC-1, AC-4, #126)', () => {
     expect(s).toMatch(/security.?(response|hold)/i);
   });
 
+  it('#192: the spec kill switch names only the real situation gate — no removed forge-control pause', async () => {
+    const s = await read('docs/specs/2026-07-21-forge-autopilot.md');
+    // AC2: forge-control was removed by ADR-0003 — no dead-subsystem reference remains in the active spec
+    expect(s).not.toMatch(/forge-control/);
+    expect(s).not.toMatch(/\.forge-control/);
+    // AC1: the kill switch describes the real per-repo situation gate (incident / security hold), matching SKILL.md
+    expect(s).toMatch(/situation gate/i);
+    expect(s).toMatch(/incident/i);
+    expect(s).toMatch(/security.?(response|hold)/i);
+  });
+
   it('AC-2 front door + AC-5 files new work + AC-6 safety are all specified', async () => {
     const s = await read('plugin/skills/autopilot/SKILL.md');
     // auto-triage front door, under-specified => escalate + skip


### PR DESCRIPTION
Closes #192 — follow-up to #166.

## Problem
The autopilot spec's §8 kill-switch line still cited the forge-control global pause (`.forge-control/paused`), a subsystem removed by ADR-0003. Nothing produces or reads `.forge-control/paused`. This contradicted the corrected `plugin/skills/autopilot/SKILL.md` (fixed by #166, which was scoped to `plugin/skills/` only, leaving this spec line out of scope).

## Change
- `docs/specs/2026-07-21-forge-autopilot.md` §8 kill-switch text now describes only the real per-repo situation gate (open incident / security hold via `gates/situationgate.mjs`), matching the SKILL.
- Added a `#192` negative-content test mirroring the existing `#166` SKILL assertion, asserting the spec carries no `forge-control` / `.forge-control` reference and names the situation gate.

## Scope guard
Touched only the active autopilot spec (+ its test). Historical forge-control references in the forge-control spec itself, ADRs (incl. 0003), README, and old C1–C8 plans are intentionally preserved per ADR-0003 and were NOT touched.

## Acceptance criteria
- [x] AC1: kill-switch text describes only the real per-repo situation gate (open incident / security hold), matching SKILL.md.
- [x] AC2: no `forge-control` / `.forge-control/paused` reference remains in the spec.

## Verification
`pnpm verify` green locally — 356 tests, incl. the new `#192` spec assertion and the existing `#166` SKILL assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)