### PR TITLE
docs: fix stale skill/role counts and dead shell-windows link (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # forge
 
-A portable AI-dev-platform plugin for Claude Code: 18 pipeline skills in 5 lanes, an 11-role Claude-native agent roster, GitHub Projects board automation with a ticket-trail law, mechanical ship gates, a learning loop, and a graph-RAG index. The platform ships itself — every feature here was planned, gated, trailed, and merged through its own pipeline.
+A portable AI-dev-platform plugin for Claude Code: 20 pipeline skills in 5 lanes, a 12-role Claude-native agent roster, GitHub Projects board automation with a ticket-trail law, mechanical ship gates, a learning loop, and a graph-RAG index. The platform ships itself — every feature here was planned, gated, trailed, and merged through its own pipeline.
 
 ## Install
 

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -62,7 +62,7 @@ forge replaces ship / plan+execute / brainstorm one-for-one. Once installed and 
 
 ## Troubleshooting
 
-- **`gh: command not found` inside scripts** — gh must be on the *user* PATH, not just the shell profile. On Windows, a portable install to `%LOCALAPPDATA%` works: add the gh `bin` directory to your user `Path` (System Settings → Environment Variables, or `setx PATH "%PATH%;%LOCALAPPDATA%\GitHub CLI"`), then restart the shell so spawned scripts inherit it.
+- **`gh: command not found` inside scripts** — gh must be on the *user* PATH, not just the shell profile. On Windows, a portable install to `%LOCALAPPDATA%` works: add the gh `bin` directory (e.g. `%LOCALAPPDATA%\GitHub CLI`) to your user `Path` via System Settings → Environment Variables, then restart the shell so spawned scripts inherit it.
 - **`token lacks the 'project' scope`** — `gh auth refresh -s project`.
 - **Board writes fail with dangling ids** — someone edited field options in the UI; re-run `/forge:init` to re-map, then `/forge:doctor`.
 - **Anything else** — `/forge:doctor` first; its hints are the supported fixes.

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -22,7 +22,7 @@ In a Claude Code session inside the target repo:
 
 (or from the terminal: `claude plugin marketplace add dngioidev/forge` then `claude plugin install forge@forge`.)
 
-This brings the 18 skills, the `/forge:*` commands, the safety + learning hooks, and the graph MCP server. Nothing runs against your repo yet.
+This brings the 20 skills, the `/forge:*` commands, the safety + learning hooks, and the graph MCP server. Nothing runs against your repo yet.
 
 ## 2. Bootstrap: `/forge:init`
 
@@ -62,7 +62,7 @@ forge replaces ship / plan+execute / brainstorm one-for-one. Once installed and 
 
 ## Troubleshooting
 
-- **`gh: command not found` inside scripts** — gh must be on the *user* PATH, not just the shell profile; portable installs to `%LOCALAPPDATA%` work (see [shell notes template](../../plugin/templates/shell-windows.md) on Windows).
+- **`gh: command not found` inside scripts** — gh must be on the *user* PATH, not just the shell profile. On Windows, a portable install to `%LOCALAPPDATA%` works: add the gh `bin` directory to your user `Path` (System Settings → Environment Variables, or `setx PATH "%PATH%;%LOCALAPPDATA%\GitHub CLI"`), then restart the shell so spawned scripts inherit it.
 - **`token lacks the 'project' scope`** — `gh auth refresh -s project`.
 - **Board writes fail with dangling ids** — someone edited field options in the UI; re-run `/forge:init` to re-map, then `/forge:doctor`.
 - **Anything else** — `/forge:doctor` first; its hints are the supported fixes.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -34,7 +34,7 @@ Still stale? Check you're not shadowed: a repo-local override (a same-named skil
 
 ## 5. Environment breaks (Windows portable installs)
 
-- **`gh: command not found` inside scripts** — gh must be on the *user* PATH; in Git Bash sessions export it (see the shell notes template).
+- **`gh: command not found` inside scripts** — gh must be on the *user* PATH, not just the current shell. In Git Bash, export it for the session (`export PATH="$PATH:/c/Users/$USER/AppData/Local/GitHub CLI"`) or add gh's `bin` dir to the user `Path` permanently so spawned scripts inherit it.
 - **`spawn pnpm ENOENT`** — bare `.cmd` shims need the cmd.exe retry that `exec.mjs run()` provides; if you hit this in a consumer repo's verify command, invoke via `pnpm.cmd` or ensure the shim dir is on PATH.
 - **gh auth/scope lost** — `gh auth refresh -s project`.
 


### PR DESCRIPTION
Closes #168

## Problem
Docs stated counts that no longer match reality, and linked/mentioned a template file (`plugin/templates/shell-windows.md`) that does not exist.

## Measured facts (verified empirically in this repo)
- **Skills: 20** — `plugin/skills/` has 20 directories (autopilot, board, brainstorm, deliver, design, distill, execute, execute-agents, hotfix, ideate, investigate, maintain, plan, release, respond, review, shape, ship, spike, triage).
- **Roles: 12** — `plugin/agents/` has 12 cards, incl. `second-opinion.md` (added in v0.14.0).
- `plugin/templates/shell-windows.md` does **not** exist; ADR-0004 intentionally removed it with the multi-backend plane (it was "used only by `sync.renderBlock`").

## Acceptance criteria
- [x] **AC1** — current-state counts read 20 / 12:
  - `README.md:3` — 18→20 skills, 11→12 roles ("an 11-role" → "a 12-role").
  - `docs/guides/install.md:25` — "18 skills" → "20 skills".
  - Historical mentions left untouched (CHANGELOG, `docs/specs`, `docs/plans`, `docs/decisions`, and the `docs/README.md` SP4 plan bullet — these describe past state, not the current roster).
- [x] **AC2** — no dead link remains. Chose **replace over create**: ADR-0004 deleted the template on purpose, so resurrecting it would contradict a standing decision. Replaced both live references with correct inline Windows gh-PATH guidance:
  - `docs/guides/install.md:65` — dead markdown link → GUI Environment-Variables guidance.
  - `docs/guides/troubleshooting.md:37` — "(see the shell notes template)" mention → Git Bash `export PATH=…` guidance.

## Verification
- `pnpm verify` — 42 files / 356 tests green.
- No live reference to `shell-windows` outside historical `docs/{decisions,plans,spikes}` (grep-confirmed).
- forge:reviewer + forge:security — both **pass**, zero critical/high. (Reviewer's minor `setx` footgun nit addressed by pointing to the Environment Variables GUI instead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)