### PR TITLE
chore(license): add MIT LICENSE + license field for marketplace distribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 dngioi.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.15.0",
   "private": true,
   "description": "Portable AI-dev-platform Claude Code plugin: pipeline skills, agent roster, board automation, learning loop, graph RAG",
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=22.13"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -4,6 +4,7 @@
   "displayName": "Forge",
   "version": "0.15.0",
   "description": "AI dev platform: pipeline skills, Claude-native agent roster, GitHub Projects board automation, learning loop, graph RAG",
+  "license": "MIT",
   "author": {
     "name": "dngioi.dev"
   },

--- a/tests/manifests.test.mjs
+++ b/tests/manifests.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFile } from 'node:fs/promises';
+import { readFile, access } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -25,5 +25,45 @@ describe('plugin manifests (AC-1.1 structural half)', () => {
       const md = await readFile(join(root, 'plugin', 'commands', `${cmd}.md`), 'utf8');
       expect(md.length).toBeGreaterThan(50);
     }
+  });
+});
+
+describe('license distribution metadata (#170)', () => {
+  it('AC-170.1 a LICENSE file exists at repo root with verbatim MIT text', async () => {
+    await expect(access(join(root, 'LICENSE'))).resolves.toBeUndefined();
+    const text = (await readFile(join(root, 'LICENSE'), 'utf8')).replace(/\r\n/g, '\n');
+    // Canonical MIT License body (SPDX: MIT) — full-text match, not a spot-check,
+    // so any accidental edit to the warranty/liability paragraphs is caught.
+    const canonical = `MIT License
+
+Copyright (c) 2026 dngioi.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+    expect(text).toBe(canonical);
+  });
+
+  it('AC-170.2 both manifests declare license: MIT and match', async () => {
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+    const plugin = JSON.parse(await readFile(join(root, 'plugin', '.claude-plugin', 'plugin.json'), 'utf8'));
+    expect(pkg.license).toBe('MIT');
+    expect(plugin.license).toBe('MIT');
+    expect(pkg.license).toBe(plugin.license);
   });
 });


### PR DESCRIPTION
Closes #170

## What
Closes the distribution/legal + marketplace-metadata gap: the plugin ships via `/plugin install forge@forge` but had no LICENSE and no `license` field in either manifest (flagged by the 2026-07-21 self-audit, #148 T1.1).

Owner decision (resolved by orchestrator): **MIT**.

## Changes
- Add root `LICENSE` — verbatim canonical MIT License text; `Copyright (c) 2026 dngioi.dev` (holder derived from `plugin.json` `author.name`; `package.json` has no `author`).
- `package.json`: `"license": "MIT"` (after `description`).
- `plugin/.claude-plugin/plugin.json`: `"license": "MIT"` (after `description`).
- `tests/manifests.test.mjs`: AC-170.1 / AC-170.2 assertions.

## Acceptance criteria
- [x] AC1 — `LICENSE` file exists at repo root (MIT, chosen by owner).
- [x] AC2 — `license: "MIT"` set in both `plugin.json` and `package.json`; values match.

## Verification (honest)
- `pnpm verify` — 42 files / 359 tests green (incl. new AC-170.1/AC-170.2).
- `claude plugin validate ./plugin --strict` — passes locally with the new field.
- acgate — AC-170.1 + AC-170.2 covered by passing tests.
- forge:reviewer + forge:security — verdict **pass**, zero critical/high.

Chosen license: MIT. Copyright holder: dngioi.dev, year 2026.