### PR TITLE
feat(dispatcher): expose statusline/agy/review CLIs; document monitors exclusion (#172)

### DIFF
--- a/plugin/bin/forge
+++ b/plugin/bin/forge
@@ -12,13 +12,19 @@ S="$ROOT/scripts"
 usage() {
   cat >&2 <<'USAGE'
 forge — dispatcher for forge's node CLIs
-  forge init|doctor|release [args…]
+  forge init|doctor|statusline|release [args…]
   forge <area> <command> [args…]
-      areas: board, gate, autopilot, care, deploy, design, graph, learn, backends
+      areas: board, gate, autopilot, care, deploy, design, graph, learn, backends, agy, review
+  note: monitors/* (ci-watch, decisions-watch) are background watchers registered in
+        plugin/monitors/monitors.json (when: on-skill-invoke:autopilot), launched by the
+        monitor runner — not interactive dispatcher commands, so they are excluded here.
 examples:
   forge board create --title "…" --type item
   forge gate docsync --base main
   forge autopilot select --dry-run
+  forge agy ask --question "where is X handled?"
+  forge review agy-opinion --ticket 172
+  forge statusline
   forge release --dry-run
 USAGE
 }
@@ -27,15 +33,23 @@ USAGE
 area="$1"; shift
 
 case "$area" in
-  -h|--help|help) usage; exit 0 ;;
-  init|doctor)    target="$S/$area.mjs" ;;
-  release)        target="$S/release/release.mjs" ;;
+  -h|--help|help)          usage; exit 0 ;;
+  init|doctor|statusline)  target="$S/$area.mjs" ;;
+  release)                 target="$S/release/release.mjs" ;;
   gate|gates)
     [ $# -ge 1 ] || { echo "forge $area: missing <command>" >&2; usage; exit 2; }
     sub="$1"; shift; target="$S/gates/$sub.mjs" ;;
-  board|autopilot|care|deploy|design|graph|learn|backends)
+  board|autopilot|care|deploy|design|graph|learn|backends|agy|review)
     [ $# -ge 1 ] || { echo "forge $area: missing <command>" >&2; usage; exit 2; }
     sub="$1"; shift; target="$S/$area/$sub.mjs" ;;
+  # monitors/* (ci-watch, decisions-watch) are deliberately NOT dispatched: they are
+  # background watchers registered in plugin/monitors/monitors.json
+  # (when: on-skill-invoke:autopilot) and launched by the monitor runner as long-running
+  # polling loops, not interactive `forge <area> <cmd>` CLIs. Run them via the monitor
+  # runner / their node path, not the dispatcher.
+  monitors)
+    echo "forge: 'monitors' are background watchers (plugin/monitors/monitors.json), not a dispatcher command" >&2
+    usage; exit 2 ;;
   *) echo "forge: unknown area '$area'" >&2; usage; exit 2 ;;
 esac
 

--- a/tests/bin/forge.test.mjs
+++ b/tests/bin/forge.test.mjs
@@ -27,10 +27,30 @@ describe('forge dispatcher (#150)', () => {
     expect(dry(['autopilot', 'select', '--dry-run'])).toMatch(/scripts\/autopilot\/select\.mjs --dry-run$/);
   });
 
-  it.runIf(HAS_BASH)('resolves single-level init/doctor/release', () => {
+  // #172 — agy/review are CLI entrypoints reachable via the dispatcher.
+  it.runIf(HAS_BASH)('resolves agy/review areas to scripts/<area>/<cmd>.mjs (#172)', () => {
+    expect(dry(['agy', 'ask', '--question', 'x'])).toMatch(/scripts\/agy\/ask\.mjs --question x$/);
+    expect(dry(['review', 'agy-opinion', '--ticket', '172'])).toMatch(/scripts\/review\/agy-opinion\.mjs --ticket 172$/);
+  });
+
+  it.runIf(HAS_BASH)('resolves single-level init/doctor/statusline/release', () => {
     expect(dry(['init', '--project', '8'])).toMatch(/scripts\/init\.mjs --project 8$/);
     expect(dry(['doctor'])).toMatch(/scripts\/doctor\.mjs$/);
+    expect(dry(['statusline'])).toMatch(/scripts\/statusline\.mjs$/); // #172
     expect(dry(['release', '--dry-run'])).toMatch(/scripts\/release\/release\.mjs --dry-run$/);
+  });
+
+  // #172 — monitors are background watchers (monitors.json, on-skill-invoke:autopilot),
+  // deliberately excluded from the interactive dispatcher and documented as such (AC1).
+  it('documents the monitors exclusion in usage/source (#172)', () => {
+    const s = readFileSync(bin, 'utf8');
+    expect(s).toMatch(/monitors\/\*.*background watchers/i);
+    expect(s).toMatch(/on-skill-invoke:autopilot/);
+  });
+
+  it.runIf(HAS_BASH)('monitors area is deliberately not dispatched — exits non-zero (#172)', () => {
+    expect(() => execFileSync('bash', [bin, 'monitors', 'ci-watch'], { stdio: 'ignore' })).toThrow();
+    expect(() => execFileSync('bash', [bin, 'monitors', 'decisions-watch'], { stdio: 'ignore' })).toThrow();
   });
 
   it.runIf(HAS_BASH)('fails fast: no args, unknown area, missing command, missing script', () => {


### PR DESCRIPTION
Closes #172

## Problem
Four main-guarded CLI entrypoints were reachable only by direct `node` path, not through the `forge <area> <cmd>` dispatcher — an inconsistency in the dispatcher contract from #150.

## AC1 decision — inclusive where sensible, documented exclusion otherwise
Verified all five cited scripts are genuinely main-guarded CLI entrypoints, then split them by whether they are *interactive* CLIs:

**Wired (inclusive):**
- `plugin/scripts/statusline.mjs` -> `forge statusline` (top-level, sibling of `init`/`doctor`, same `$S/$area.mjs` mapping)
- `plugin/scripts/agy/ask.mjs` -> `forge agy ask` (new `agy` two-level area)
- `plugin/scripts/review/agy-opinion.mjs` -> `forge review agy-opinion` (new `review` two-level area)

These three are invoked by direct `node` path in skill docs (investigate/review/spike SKILL.md), i.e. exactly the inconsistency the ticket describes.

**Documented exclusion:**
- `plugin/scripts/monitors/ci-watch.mjs`, `plugin/scripts/monitors/decisions-watch.mjs` -> deliberately NOT dispatched. They are background watchers registered in `plugin/monitors/monitors.json` with `when: on-skill-invoke:autopilot`, launched by the monitor runner as long-running polling loops for the life of an autopilot session — not interactive `forge <area> <cmd>` commands. The dispatcher documents this in both the `usage()` block and an explicit `monitors)` case that prints a clear message and exits 2 (previously fell through to the generic unknown-area catch-all).

## AC checklist
- [x] AC1 — intended contract decided and encoded: inclusive for statusline/agy/review, documented exclusion for monitors.
- [x] AC2 — `agy`/`review` areas + `statusline` case added; `tests/bin/forge.test.mjs` extended to cover agy/review/statusline routing AND to assert the documented monitors exclusion (source text + non-zero exit).

## Verification (honest)
- `pnpm verify` (vitest, full suite incl. manifests/plugin-validity test): **362 passed, exit 0** locally.
- Manual dry-run smoke test: `forge agy ask`, `forge review agy-opinion`, `forge statusline` resolve to the right scripts; `forge monitors ci-watch` prints the exclusion message and exits 2.
- `forge:reviewer` (full branch): verdict **pass**, zero findings.
- `forge:security` (full branch): verdict **pass**, zero critical/high (one low: pre-existing unsanitized `$sub` path pattern, unchanged trust boundary, now also applies to the two new hardcoded areas).

## CI note
GitHub Actions minutes are exhausted this run, so CI jobs fail at startup (0 steps) — infrastructure, not this diff. Owner authorized merge on LOCAL-green for this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)