### PR TITLE
fix(board): quote-safe title idempotency — no duplicate on quoted titles (#173)

### DIFF
--- a/plugin/scripts/board/create.mjs
+++ b/plugin/scripts/board/create.mjs
@@ -9,6 +9,7 @@ import { pathToFileURL } from 'node:url';
 import { run, makeGh } from '../lib/exec.mjs';
 import { makeBoardCtx } from '../lib/boardctx.mjs';
 import { getIssueNode, addSubIssue } from '../lib/issues.mjs';
+import { titleSearchQuery } from '../lib/board.mjs';
 
 /** Defaults applied to a single ticket spec (flags or a --from JSON entry). */
 export function withDefaults(spec = {}) {
@@ -93,9 +94,12 @@ export async function runCreate(ctx, args, log = console.log) {
     if (!r.ok) return { ok: false, error: r.error };
   }
 
-  // 1. issue: find by exact title first (never duplicate)
+  // 1. issue: find by exact title first (never duplicate). The search is a
+  // coarse, quote-safe prefilter (#173 — a raw quote in the title used to break
+  // it and spawn a duplicate); the exact `i.title === args.title` below is what
+  // actually decides the resume.
   const found = await ctx.gh(
-    ['issue', 'list', '--state', 'all', '--limit', '100', '--search', `"${args.title}" in:title`, '--json', 'number,title,url'],
+    ['issue', 'list', '--state', 'all', '--limit', '100', '--search', titleSearchQuery(args.title), '--json', 'number,title,url'],
     { parseJson: true },
   );
   if (!found.ok) return { ok: false, error: found.stderr || 'issue list failed' };

--- a/plugin/scripts/lib/board.mjs
+++ b/plugin/scripts/lib/board.mjs
@@ -163,9 +163,27 @@ export async function replaceStatusOptions(gh, fieldId, optionDefs) {
   return { ok: true, field: res.json.data.updateProjectV2Field.projectV2Field };
 }
 
+/**
+ * Build the `--search` value for finding an issue by its title (#173).
+ *
+ * A raw `"${title}" in:title` breaks when the title itself contains a double
+ * quote: the interpolated quote terminates the phrase early, GitHub parses a
+ * malformed query, and the target issue can drop out of the returned set —
+ * making the idempotency lookup miss and create a DUPLICATE (spec §6). We strip
+ * double quotes (GitHub tokenization ignores punctuation anyway) and use the
+ * remainder as a coarse phrase prefilter. Correctness of the resume never rests
+ * on the search precision — callers still confirm with an exact
+ * `candidate.title === title` comparison against the returned list. This is
+ * also injection-safe: no interpolated `"` can escape the phrase.
+ */
+export function titleSearchQuery(title) {
+  const cleaned = String(title ?? '').replace(/"/g, ' ').replace(/\s+/g, ' ').trim();
+  return cleaned ? `"${cleaned}" in:title` : 'in:title';
+}
+
 export async function findIssueByTitle(gh, title) {
   const res = await gh(
-    ['issue', 'list', '--state', 'all', '--limit', '100', '--search', `"${title}" in:title`, '--json', 'number,title,state'],
+    ['issue', 'list', '--state', 'all', '--limit', '100', '--search', titleSearchQuery(title), '--json', 'number,title,state'],
     { parseJson: true },
   );
   if (!res.ok) return { ok: false, error: res.stderr || 'issue list failed' };

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -13,6 +13,7 @@ import { runReceipt } from '../plugin/scripts/board/receipt.mjs';
 import { runLog } from '../plugin/scripts/board/log.mjs';
 import { runDigest, renderChildTable, computeFlowMetrics, renderFlow, cycleDays } from '../plugin/scripts/board/digest.mjs';
 import { runStatus } from '../plugin/scripts/board/status.mjs';
+import { findIssueByTitle, titleSearchQuery } from '../plugin/scripts/lib/board.mjs';
 import { fakeGh, REPO_VIEW } from './helpers/fakegh.mjs';
 
 const noop = () => {};
@@ -221,6 +222,84 @@ describe('create (AC-2.1)', () => {
     const res = await runCreate(ctx, createArgs(['--title', 'X', '--label', 'ghost']), noop);
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/issue edit|not found/);
+  });
+});
+
+describe('quoted-title idempotency (AC-173, #173)', () => {
+  // The exact repro from the ticket: a title carrying a literal double-quote.
+  const QT = 'Remove stale "Console daemon" section from troubleshooting.md (ADR-0003)';
+  const CLEANED = '"Remove stale Console daemon section from troubleshooting.md (ADR-0003)" in:title';
+
+  // A STATEFUL gh registry so the round-trip is real: `issue create` appends to
+  // `issues` and the idempotency search reads it back, so a SECOND runCreate can
+  // resume. The search route returns the WHOLE registry (a superset) on purpose
+  // — it proves the resume is decided by the code's exact `title ===` match, not
+  // by the fragile search string.
+  function statefulRoutes() {
+    const issues = [];
+    const items = [];
+    let nextIssue = 40;
+    let nextItem = 1;
+    return [
+      [(j) => j.startsWith('issue list'), () => ({ stdout: JSON.stringify(issues.map((i) => ({ number: i.number, title: i.title, url: i.url }))) })],
+      [(j) => j.startsWith('issue create'), (j, args) => {
+        const title = args[args.indexOf('--title') + 1];
+        const number = nextIssue++;
+        const url = `https://github.com/dngioidev/forge/issues/${number}`;
+        issues.push({ number, title, url });
+        return { stdout: `${url}\n` };
+      }],
+      [(j) => j.startsWith('project item-list'), () => ({ stdout: JSON.stringify({ items: items.slice() }) })],
+      [(j) => j.startsWith('api graphql') && j.includes('projectItems'), { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [] } } } } }) }],
+      [(j) => j.startsWith('project item-add'), (j, args) => {
+        const number = Number((/\/issues\/(\d+)/.exec(args[args.indexOf('--url') + 1]) ?? [])[1]);
+        const id = `ITEM_${nextItem++}`;
+        items.push({ id, content: { number }, type: null, priority: null, size: null, status: null });
+        return { stdout: JSON.stringify({ id }) };
+      }],
+      ['project item-edit', { stdout: '' }],
+    ];
+  }
+
+  it('AC1/AC2: creating twice from a quoted title resumes the SAME issue — no duplicate', async () => {
+    const { ctx, calls } = await ctxWith(statefulRoutes());
+    const flags = ['--title', QT, '--type', 'bug', '--priority', 'p2', '--size', 's'];
+
+    const first = await runCreate(ctx, createArgs(flags), noop);
+    expect(first).toMatchObject({ ok: true, number: 40, resumed: false });
+
+    const second = await runCreate(ctx, createArgs(flags), noop);
+    expect(second).toMatchObject({ ok: true, number: 40, resumed: true }); // resumed #40, not a duplicate
+
+    // the crux: exactly one create + one board-add across BOTH runs
+    expect(calls.filter((c) => c.startsWith('issue create')).length).toBe(1);
+    expect(calls.filter((c) => c.startsWith('project item-add')).length).toBe(1);
+
+    // the search reaching gh is well-formed and quote-safe — the malformed
+    // `"…"Console daemon"…" in:title` form (the #173 bug) never appears
+    expect(calls.some((c) => c.includes(`--search ${CLEANED}`))).toBe(true);
+    expect(calls.some((c) => c.includes(`"${QT}" in:title`))).toBe(false);
+  });
+
+  it('AC2: titleSearchQuery strips embedded quotes into a coarse, well-formed phrase', () => {
+    expect(titleSearchQuery(QT)).toBe(CLEANED);
+    expect(titleSearchQuery('Plain title')).toBe('"Plain title" in:title'); // quote-free is unchanged
+    expect(titleSearchQuery('  a   b  ')).toBe('"a b" in:title');           // whitespace collapsed
+    expect(titleSearchQuery('""')).toBe('in:title');                        // degenerate → no phrase, still valid
+  });
+
+  it('AC3: findIssueByTitle (lib/board.mjs) resolves a quoted title too — same-class fix', async () => {
+    let searchArg = null;
+    const f = fakeGh([
+      [(j) => j.startsWith('issue list'), (j, args) => {
+        searchArg = args[args.indexOf('--search') + 1];
+        return { stdout: JSON.stringify([{ number: 40, title: QT, state: 'OPEN' }]) };
+      }],
+    ]);
+    const res = await findIssueByTitle(f.gh, QT);
+    expect(res).toMatchObject({ ok: true, issue: { number: 40 } });
+    expect(searchArg).toBe(CLEANED);
+    expect(searchArg).not.toContain('"Console daemon"'); // no raw embedded quote leaked into the query
   });
 });
 


### PR DESCRIPTION
Closes #173

## Problem
`board/create.mjs` and `lib/board.mjs` `findIssueByTitle` built the idempotency lookup as `gh issue list --search '"${title}" in:title'`. A literal double-quote **inside** the title terminated the phrase early, GitHub parsed a malformed query, the target issue dropped out of the returned set, the exact `title === candidate.title` match then missed, and a **duplicate issue was created** — violating spec §6 idempotency. Reproduced in the 2026-07-21 self-audit (created #167, resume created dup #171).

## Fix
New shared, dependency-free helper `titleSearchQuery(title)` in `lib/board.mjs`:
- strips embedded double-quotes (GitHub tokenization ignores punctuation anyway) and collapses whitespace, then wraps the remainder as a coarse, **well-formed** phrase prefilter;
- correctness of the resume rests entirely on the caller's exact `candidate.title === title` JS comparison against the returned list — the search is only a prefilter;
- injection-safe: no interpolated `"` can escape the phrase (and all `gh` calls already go through argv arrays / `shell:false`).

Both interpolated-title sites adopt it: `create.mjs` (the idempotency search) and `lib/board.mjs findIssueByTitle` (also used by `init.mjs` for the delivery-log issue).

## AC3 sweep
Grepped `plugin/scripts/` for interpolated-title / `--search` lookups. **Only two** sites had the pattern (both fixed here). Every other board script — `close.mjs`, `move.mjs`, `comment.mjs`, `reparent.mjs` — resolves issues by numeric `--issue`, not by title, so none share the bug. No follow-up needed.

## Acceptance criteria
- [x] **AC1** — creating twice from a quoted-title spec resumes the same issue, no duplicate (`tests/board.test.mjs` AC-173: stateful two-pass `runCreate` round-trip asserts exactly one `issue create` + one `project item-add`).
- [x] **AC2** — regression test covers a quoted-title round-trip through `runCreate`, plus `titleSearchQuery` unit cases (quoted / plain / whitespace / degenerate all-quote).
- [x] **AC3** — same-class sweep done; `findIssueByTitle` fixed and covered; siblings verified clean.

## Verification (honest — CI infra is down this run)
- `pnpm verify` (vitest) green locally: **365 passed** (42 files), incl. the new AC-173 block.
- `forge:reviewer` full-branch: **pass**, zero critical/high.
- `forge:security` full-branch: **pass**, zero critical/high (two low/informational recall-only notes on Unicode smart-quotes / empty-title fallback; exact-match gate keeps mutation-safety intact).
- CI itself: Actions minutes are exhausted, so all jobs fail at startup (0 steps) — infrastructure, not this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)