### PR TITLE
fix(board): verify the Status field actually moved to Done after a done-move (#178)

### DIFF
--- a/plugin/scripts/board/create.mjs
+++ b/plugin/scripts/board/create.mjs
@@ -180,15 +180,23 @@ export async function runCreate(ctx, args, log = console.log) {
     log(`field: ${fieldKey}=${wanted}`);
   }
 
-  // #178 (AC3): warn loudly when a non-top-level ticket is created parentless,
-  // so a follow-up gets reparented under its epic instead of orphaned on the
-  // board. Warning-only path (auto-parenting needs epic resolution the caller
-  // holds) — the linkage hint names the exact reparent command.
+  // #178 (AC3): warn loudly when a non-top-level ticket is left orphaned, so a
+  // follow-up gets reparented under its epic instead of stranded on the board.
+  // Warning-only path (auto-parenting needs epic resolution the caller holds) —
+  // the hint names the exact reparent command. Reconcile against the issue's
+  // ACTUAL parent (like every other step here), not just this call's --parent
+  // flag, so a resumed create of an already-reparented ticket doesn't false-warn.
+  let parentless = false;
   if (args.parent == null && !TOP_LEVEL_TYPES.has(args.type)) {
-    log(`⚠ #${issue.number} created parentless — a '${args.type}' should be a child of an epic (board hierarchy). Link it: forge board reparent --issue ${issue.number} --parent <epic#>`);
+    const node = await getIssueNode(ctx.gh, ctx.owner, ctx.repo, issue.number);
+    if (!node.ok) return { ok: false, error: node.error };
+    parentless = node.parentNumber == null;
+    if (parentless) {
+      log(`⚠ #${issue.number} created parentless — a '${args.type}' should be a child of an epic (board hierarchy). Link it: forge board reparent --issue ${issue.number} --parent <epic#>`);
+    }
   }
 
-  return { ok: true, number: issue.number, itemId, resumed, parentless: args.parent == null && !TOP_LEVEL_TYPES.has(args.type) };
+  return { ok: true, number: issue.number, itemId, resumed, parentless };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/plugin/scripts/board/create.mjs
+++ b/plugin/scripts/board/create.mjs
@@ -18,6 +18,14 @@ export function withDefaults(spec = {}) {
 
 const KNOWN_FLAGS = '--title --body --body-file --type --priority --size --status --phase --area --parent --assignee --label --milestone --from';
 
+/**
+ * #178 (AC3): the board hierarchy law — ONLY these types live at the top level;
+ * every other ticket (item/bug/test/…) must be a child of an epic. A non-epic
+ * created WITHOUT a parent is the parentless-follow-up smell (real: follow-ups
+ * #185 and #192 were filed orphan during the autopilot run).
+ */
+const TOP_LEVEL_TYPES = new Set(['epic', 'program']);
+
 export function parseArgs(argv) {
   const a = withDefaults();
   a.from = null;
@@ -172,7 +180,15 @@ export async function runCreate(ctx, args, log = console.log) {
     log(`field: ${fieldKey}=${wanted}`);
   }
 
-  return { ok: true, number: issue.number, itemId, resumed };
+  // #178 (AC3): warn loudly when a non-top-level ticket is created parentless,
+  // so a follow-up gets reparented under its epic instead of orphaned on the
+  // board. Warning-only path (auto-parenting needs epic resolution the caller
+  // holds) — the linkage hint names the exact reparent command.
+  if (args.parent == null && !TOP_LEVEL_TYPES.has(args.type)) {
+    log(`⚠ #${issue.number} created parentless — a '${args.type}' should be a child of an epic (board hierarchy). Link it: forge board reparent --issue ${issue.number} --parent <epic#>`);
+  }
+
+  return { ok: true, number: issue.number, itemId, resumed, parentless: args.parent == null && !TOP_LEVEL_TYPES.has(args.type) };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/plugin/scripts/board/move.mjs
+++ b/plugin/scripts/board/move.mjs
@@ -19,6 +19,42 @@ export function normalizeStatusKey(s) {
   return String(s ?? '').replace(/-([a-z])/g, (_, c) => c.toUpperCase());
 }
 
+/**
+ * #178: a Projects single-select mutation can return ok yet silently NOT persist
+ * (observed on iomanage #73 — the issue was CLOSED but the Status field stayed
+ * put, so the post-merge ritual reported "board → Done" while the field sat at
+ * Backlog). After a move we RE-READ the item and confirm the field now equals
+ * the requested status. A concrete mismatch is retried once, then FAILS LOUDLY
+ * rather than reporting a move that never took — a closed issue stuck at a
+ * non-Done status is a reliable tell of a dropped board mutation. An unreadable
+ * status (item-list index lag returning a fallback item with no field, #114)
+ * can be neither confirmed nor disproved — we WARN and proceed unverified so
+ * lag alone never manufactures a false failure.
+ */
+export async function verifyStatusMoved(ctx, issue, itemId, status, log = console.log) {
+  let current = null;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const re = await ctx.findItemByIssue(issue);
+    if (!re.ok) return { ok: false, error: `verify move failed: ${re.error}` };
+    current = re.item ? ctx.itemFieldKey(re.item, 'status') : null;
+    if (current === status) return { ok: true, verified: true };
+    if (attempt === 1) {
+      log(`#${issue}: status still '${current ?? 'unreadable'}' after move — retrying once`);
+      const redo = await ctx.setSelect(itemId, 'status', status);
+      if (!redo.ok) return { ok: false, error: redo.error };
+    }
+  }
+  // re-read after the retry STILL doesn't match:
+  if (current == null) {
+    log(`#${issue}: could not confirm status moved to ${status} (item not readable on re-read) — proceeding unverified`);
+    return { ok: true, verified: false };
+  }
+  return {
+    ok: false,
+    error: `move to '${status}' did NOT persist — board Status is still '${current}' after re-read (a silently-dropped Projects mutation; a closed issue stuck at '${current}' is the #73 tell). Re-run the move or fix the Status field by hand.`,
+  };
+}
+
 export async function runMove(ctx, args, log = console.log) {
   if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
   const status = normalizeStatusKey(args.status);
@@ -35,8 +71,11 @@ export async function runMove(ctx, args, log = console.log) {
   }
   const set = await ctx.setSelect(found.item.id, 'status', status);
   if (!set.ok) return set;
+  // AC1: confirm the mutation actually took before reporting success.
+  const verified = await verifyStatusMoved(ctx, args.issue, found.item.id, status, log);
+  if (!verified.ok) return verified;
   log(`#${args.issue}: status -> ${status}`);
-  return { ok: true, changed: true };
+  return { ok: true, changed: true, verified: verified.verified };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -223,6 +223,47 @@ describe('create (AC-2.1)', () => {
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/issue edit|not found/);
   });
+
+  // #178 AC3: parentless follow-ups (real: #185, #192) are the board-hierarchy
+  // smell — a non-epic must be a child of an epic. Warn loudly at create time.
+  const parentlessRoutes = [
+    ['issue list', { stdout: '[]' }],
+    ['issue create', { stdout: createdIssueUrl }],
+    [(j) => j.startsWith('project item-list'), itemList([])],
+    ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
+    ['project item-edit', { stdout: '' }],
+  ];
+
+  it('AC-178.3: a non-epic created WITHOUT --parent emits a parentless warning (#178)', async () => {
+    const logs = [];
+    const { ctx } = await ctxWith(parentlessRoutes);
+    const res = await runCreate(ctx, createArgs(['--title', 'Follow-up', '--type', 'bug']), (m) => logs.push(m));
+    expect(res).toMatchObject({ ok: true, parentless: true });
+    expect(logs.some((m) => /parentless/i.test(m) && /reparent/.test(m))).toBe(true);
+  });
+
+  it('AC-178.3: an epic created WITHOUT --parent does NOT warn (top-level is legitimate) (#178)', async () => {
+    const logs = [];
+    const { ctx } = await ctxWith(parentlessRoutes);
+    const res = await runCreate(ctx, createArgs(['--title', 'New epic', '--type', 'epic']), (m) => logs.push(m));
+    expect(res).toMatchObject({ ok: true, parentless: false });
+    expect(logs.some((m) => /parentless/i.test(m))).toBe(false);
+  });
+
+  it('AC-178.3: a child created WITH --parent does NOT warn (#178)', async () => {
+    const logs = [];
+    const { ctx } = await ctxWith([
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: createdIssueUrl }],
+      ...issueNodes('I_child', null),
+      [(j) => j.startsWith('project item-list'), itemList([])],
+      ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'Child', '--type', 'bug', '--parent', '2']), (m) => logs.push(m));
+    expect(res).toMatchObject({ ok: true, parentless: false });
+    expect(logs.some((m) => /parentless/i.test(m))).toBe(false);
+  });
 });
 
 describe('quoted-title idempotency (AC-173, #173)', () => {
@@ -360,16 +401,59 @@ describe('reparent (AC-87.2, AC-87.3, #87)', () => {
 });
 
 describe('move (AC-2.2)', () => {
-  it('moves and is a no-op when already there', async () => {
-    const { ctx, calls } = await ctxWith([
-      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_2', content: { number: 5 }, status: 'In progress' }])],
-      ['project item-edit', { stdout: '' }],
-    ]);
+  // A stateful board so a re-read reflects the mutation (#178 verify-after-move):
+  // item-edit updates `status` by the option id it sets, item-list reads it back.
+  const OPT_TO_NAME = { sb: 'Backlog', sr: 'Ready', sp: 'In progress', sv: 'In review', sk: 'Blocked / Needs decision', sd: 'Done', sw: "Won't do" };
+  function statefulItem(number, initial) {
+    let status = initial;
+    return [
+      [(j) => j.startsWith('project item-list'), () => itemList([{ id: 'ITEM_2', content: { number }, status }])],
+      [(j) => j.startsWith('project item-edit'), (j, args) => {
+        const id = args[args.indexOf('--single-select-option-id') + 1];
+        if (OPT_TO_NAME[id]) status = OPT_TO_NAME[id];
+        return { stdout: '' };
+      }],
+    ];
+  }
+
+  it('moves, verifies the field actually moved, and is a no-op when already there', async () => {
+    const { ctx, calls } = await ctxWith(statefulItem(5, 'In progress'));
     const moved = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'done']), noop);
-    expect(moved).toMatchObject({ ok: true, changed: true });
-    const same = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'inProgress']), noop);
+    expect(moved).toMatchObject({ ok: true, changed: true, verified: true });
+    // now genuinely at Done → moving to done again is a no-op (no second edit)
+    const same = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'done']), noop);
     expect(same).toMatchObject({ ok: true, changed: false });
     expect(calls.filter((c) => c.startsWith('project item-edit')).length).toBe(1);
+  });
+
+  it('AC-178.1/AC-178.2: a silently-dropped move (re-read still shows the OLD status) fails loudly (#178)', async () => {
+    // item-list ALWAYS reports the old status; item-edit "succeeds" but never persists.
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_2', content: { number: 5 }, status: 'In review' }])],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'done']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/did NOT persist/);
+    expect(res.error).toContain('inReview'); // names the stuck status (resolved key)
+    // it retried the mutation once before giving up (2 edits, not 1)
+    expect(calls.filter((c) => c.startsWith('project item-edit')).length).toBe(2);
+  });
+
+  it('AC-178.1: an unreadable re-read (item-list lag) warns but does not false-fail (#178)', async () => {
+    // First list has the item (old status) so the move fires; every later list
+    // lags empty AND the issue-side fallback returns no status field → unverifiable.
+    let listCalls = 0;
+    const logs = [];
+    const { ctx } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), () => itemList(listCalls++ === 0 ? [{ id: 'ITEM_2', content: { number: 5 }, status: 'In review' }] : [])],
+      [(j) => j.startsWith('api graphql') && j.includes('projectItems'),
+        { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [{ id: 'ITEM_2', project: { number: 8 } }] } } } } }) }],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'done']), (m) => logs.push(m));
+    expect(res).toMatchObject({ ok: true, changed: true, verified: false });
+    expect(logs.some((m) => /could not confirm/.test(m))).toBe(true);
   });
 
   it('unknown status errors listing valid keys; off-board issue says run create', async () => {
@@ -381,10 +465,7 @@ describe('move (AC-2.2)', () => {
   });
 
   it('AC-108.1: accepts kebab-case status aliases (in-progress -> inProgress) (#108)', async () => {
-    const { ctx, calls } = await ctxWith([
-      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_2', content: { number: 5 }, status: 'Ready' }])],
-      ['project item-edit', { stdout: '' }],
-    ]);
+    const { ctx, calls } = await ctxWith(statefulItem(5, 'Ready'));
     const moved = await runMove(ctx, moveArgs(['--issue', '5', '--status', 'in-progress']), noop);
     expect(moved).toMatchObject({ ok: true, changed: true }); // resolved to inProgress, not rejected as unknown
     expect(calls.filter((c) => c.startsWith('project item-edit')).length).toBe(1);

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -145,6 +145,7 @@ describe('create (AC-2.1)', () => {
     const { ctx, calls } = await ctxWith([
       ['issue list', { stdout: '[]' }],
       ['issue create', { stdout: createdIssueUrl }],
+      [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_c', parent: null } } } }) }],
       [(j) => j.startsWith('project item-list'), itemList([])],
       ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
       ['project item-edit', { stdout: '' }],
@@ -158,6 +159,7 @@ describe('create (AC-2.1)', () => {
     const { ctx, calls } = await ctxWith([
       ['issue list', { stdout: '[]' }],
       ['issue create', { stdout: createdIssueUrl }],
+      [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_c', parent: null } } } }) }],
       [(j) => j.startsWith('project item-list'), itemList([])],
       [(j) => j.startsWith('api graphql') && j.includes('projectItems'), { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [] } } } } }) }],
       ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
@@ -179,6 +181,7 @@ describe('create (AC-2.1)', () => {
     const { ctx, calls } = await ctxWith([
       ['issue list', { stdout: '[]' }],
       ['issue create', { stdout: createdIssueUrl }],
+      [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_c', parent: null } } } }) }],
       [(j) => j.startsWith('project item-list'), itemList([])],
       [(j) => j.startsWith('api graphql') && j.includes('projectItems'), { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [] } } } } }) }],
       ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
@@ -201,6 +204,7 @@ describe('create (AC-2.1)', () => {
       ['issue list', { stdout: '[]' }],
       ['issue create', { stdout: createdIssueUrl }],
       ['issue edit', { stdout: '' }],
+      [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_c', parent: null } } } }) }],
       [(j) => j.startsWith('project item-list'), itemList([])],
       ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
       ['project item-edit', { stdout: '' }],
@@ -226,15 +230,17 @@ describe('create (AC-2.1)', () => {
 
   // #178 AC3: parentless follow-ups (real: #185, #192) are the board-hierarchy
   // smell — a non-epic must be a child of an epic. Warn loudly at create time.
+  // Genuinely-orphaned issue: getIssueNode reports no parent → warning fires.
   const parentlessRoutes = [
     ['issue list', { stdout: '[]' }],
     ['issue create', { stdout: createdIssueUrl }],
+    [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_child', parent: null } } } }) }],
     [(j) => j.startsWith('project item-list'), itemList([])],
     ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
     ['project item-edit', { stdout: '' }],
   ];
 
-  it('AC-178.3: a non-epic created WITHOUT --parent emits a parentless warning (#178)', async () => {
+  it('AC-178.3: a non-epic with no actual parent emits a parentless warning (#178)', async () => {
     const logs = [];
     const { ctx } = await ctxWith(parentlessRoutes);
     const res = await runCreate(ctx, createArgs(['--title', 'Follow-up', '--type', 'bug']), (m) => logs.push(m));
@@ -244,10 +250,12 @@ describe('create (AC-2.1)', () => {
 
   it('AC-178.3: an epic created WITHOUT --parent does NOT warn (top-level is legitimate) (#178)', async () => {
     const logs = [];
-    const { ctx } = await ctxWith(parentlessRoutes);
+    // epics are top-level → the parent state is never even queried
+    const { ctx, calls } = await ctxWith(parentlessRoutes);
     const res = await runCreate(ctx, createArgs(['--title', 'New epic', '--type', 'epic']), (m) => logs.push(m));
     expect(res).toMatchObject({ ok: true, parentless: false });
     expect(logs.some((m) => /parentless/i.test(m))).toBe(false);
+    expect(calls.some((c) => c.includes('parent { number }'))).toBe(false); // no needless lookup
   });
 
   it('AC-178.3: a child created WITH --parent does NOT warn (#178)', async () => {
@@ -261,6 +269,21 @@ describe('create (AC-2.1)', () => {
       ['project item-edit', { stdout: '' }],
     ]);
     const res = await runCreate(ctx, createArgs(['--title', 'Child', '--type', 'bug', '--parent', '2']), (m) => logs.push(m));
+    expect(res).toMatchObject({ ok: true, parentless: false });
+    expect(logs.some((m) => /parentless/i.test(m))).toBe(false);
+  });
+
+  it('AC-178.3: a resumed create without --parent does NOT warn when the ticket is already parented (#178)', async () => {
+    // reviewer catch: reconcile against the ACTUAL parent, not this call's flag —
+    // a follow-up already reparented (via `board reparent`) must not re-warn.
+    const logs = [];
+    const { ctx } = await ctxWith([
+      ['issue list', { stdout: JSON.stringify([{ number: 20, title: 'Follow-up', url: 'https://github.com/dngioidev/forge/issues/20' }]) }],
+      [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_child', parent: { number: 2 } } } } }) }],
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_1', content: { number: 20 }, type: 'Bug', priority: 'P1', size: 'M', status: 'Backlog' }])],
+      ['project item-edit', { stdout: '' }],
+    ]);
+    const res = await runCreate(ctx, createArgs(['--title', 'Follow-up', '--type', 'bug']), (m) => logs.push(m));
     expect(res).toMatchObject({ ok: true, parentless: false });
     expect(logs.some((m) => /parentless/i.test(m))).toBe(false);
   });
@@ -290,6 +313,7 @@ describe('quoted-title idempotency (AC-173, #173)', () => {
         issues.push({ number, title, url });
         return { stdout: `${url}\n` };
       }],
+      [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_c', parent: null } } } }) }],
       [(j) => j.startsWith('project item-list'), () => ({ stdout: JSON.stringify({ items: items.slice() }) })],
       [(j) => j.startsWith('api graphql') && j.includes('projectItems'), { stdout: JSON.stringify({ data: { repository: { issue: { projectItems: { nodes: [] } } } } }) }],
       [(j) => j.startsWith('project item-add'), (j, args) => {
@@ -349,6 +373,7 @@ describe('batch create --from (AC-87.1, #87)', () => {
     const { ctx } = await ctxWith([
       ['issue list', { stdout: '[]' }],
       ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/20\n' }],
+      [(j) => j.startsWith('api graphql') && j.includes('parent { number }'), { stdout: JSON.stringify({ data: { repository: { issue: { id: 'I_c', parent: null } } } }) }],
       [(j) => j.startsWith('project item-list'), itemList([])],
       ['project item-add', { stdout: JSON.stringify({ id: 'ITEM_1' }) }],
       ['project item-edit', { stdout: '' }],

--- a/tests/escalate.test.mjs
+++ b/tests/escalate.test.mjs
@@ -31,10 +31,12 @@ async function cwdWithConfig() {
 
 describe('escalate (AC-3.2)', () => {
   it('open: moves to blocked, posts decision comment, journals, writes pending file', async () => {
+    // stateful board so the #178 verify-after-move re-read sees the mutation land
+    let status = 'In progress';
     const f = fakeGh([
       ['repo view', REPO_VIEW],
-      [(j) => j.startsWith('project item-list'), { stdout: JSON.stringify({ items: [{ id: 'IT3', content: { number: 3 }, status: 'In progress' }] }) }],
-      ['project item-edit', { stdout: '' }],
+      [(j) => j.startsWith('project item-list'), () => ({ stdout: JSON.stringify({ items: [{ id: 'IT3', content: { number: 3 }, status }] }) })],
+      [(j) => j.startsWith('project item-edit'), () => { status = 'Blocked / Needs decision'; return { stdout: '' }; }],
       [(j) => j.includes('/comments?'), { stdout: '[]' }],
       [(j) => j.includes('/issues/3/comments'), { stdout: JSON.stringify({ id: 501 }) }],
     ]);


### PR DESCRIPTION
Closes #178

## Problem
On iomanage #73 the post-merge ritual reported "board → Done" but the Projects **Status** field stayed at Backlog while the issue itself was closed. The `move --status done` mutation silently didn't persist, and success was reported on the `item-edit` exit code alone. A closed issue stuck at a non-Done status is a reliable tell of a dropped board mutation.

## Fix
**AC1 — verify-after-move (`plugin/scripts/board/move.mjs`)**
`runMove` now RE-READS the item after the status mutation (new `verifyStatusMoved`) and confirms the Status field equals the requested key:
- concrete mismatch → retry the mutation once, then **fail loudly** (non-zero exit + clear error naming the stuck status) rather than reporting a move that never took;
- unreadable re-read (item-list index lag returning a fallback item with no field, #114) → can't be confirmed or disproved, so it **warns and proceeds unverified** — lag alone never manufactures a false failure;
- the existing no-op "already there" path is untouched (short-circuits before any mutation/verify).

**AC3 — parentless follow-up warning (`plugin/scripts/board/create.mjs`)**
`runCreate` warns when a non-top-level ticket (anything but epic/program) is left **genuinely orphaned** — reconciled against the issue's actual parent via `getIssueNode` (not just this call's `--parent` flag, so a resumed create of an already-reparented follow-up doesn't false-warn). Warning-only path per the ticket; the hint names the exact `board reparent` command. Real: follow-ups #185/#192 were filed parentless during the autopilot run.

## Acceptance criteria
- [x] **AC1** — the ritual re-reads the item after a done-move and fails loudly if the Status field is not `done` (esp. when the issue is closed).
- [x] **AC2** — a test simulates a move whose re-read still shows the OLD status and asserts the verification exits non-zero (and retried once); plus an unreadable-lag case.
- [x] **AC3** — follow-up creation emits a clear parentless warning (reconciled against real parent state), with warn / no-warn / already-parented coverage.

## Verification (honest)
- `pnpm verify` green **locally**: 42 files, **371 tests** passing.
- Full-branch `forge:reviewer` and `forge:security` run via subagents — security clean (zero critical/high); a reviewer Major on the AC3 warning firing off the flag rather than actual parent state was fixed in commit d8fc4e4 (reconcile against `getIssueNode`, added a resumed-already-parented test).
- **CI note:** GitHub Actions minutes are exhausted for this run, so CI jobs fail at startup (0 steps executed) — infra, not this diff. Confirmed once via `gh pr checks`; not watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)