### PR TITLE
fix(init): wire statusline with absolute node path, not bare `node` (#181)

### DIFF
--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -209,10 +209,17 @@ export async function runInit(ctx) {
   // 8. Status line (opt-in via --statusline; the command md asks the user first).
   // Written to settings.local.json: the command embeds a machine-specific
   // absolute path, which must never land in the shared committed settings.
+  //
+  // #181: wire the ABSOLUTE node binary (process.execPath), not a bare `node`.
+  // Claude Code spawns the status-line command in a process that may not have
+  // `node` on PATH (e.g. node installed to %LOCALAPPDATA%\node22\current) — a
+  // bare `node` then dies with exit 127 and the bar renders silently blank.
+  // process.execPath is the node currently running init: the portable, absolute
+  // source. Both it and scriptPath are quoted to tolerate spaces in the paths.
   if (args.statusline) {
     const scriptPath = resolve(dirname(fileURLToPath(import.meta.url)), 'statusline.mjs');
     await mergeJson(join(cwd, '.claude', 'settings.local.json'), {
-      statusLine: { type: 'command', command: `node "${scriptPath}"` },
+      statusLine: { type: 'command', command: `"${process.execPath}" "${scriptPath}"` },
     });
     say('statusline: wired into .claude/settings.local.json');
   }

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -252,6 +252,76 @@ describe('runInit — adopt mode (AC-1.3)', () => {
   });
 });
 
+describe('runInit — statusline wiring (#181)', () => {
+  // A fresh-bootstrap route set (mirrors the fresh-bootstrap describe) so runInit
+  // reaches the statusline step and writes .claude/settings.local.json.
+  function bootstrapRoutes() {
+    let fieldsCall = 0;
+    return [
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project create', { stdout: JSON.stringify({ id: 'PVT_new', number: 9, title: 'forge' }) }],
+      ['project link', { stdout: '' }],
+      [(j) => j.startsWith('api graphql') && j.includes('fields(first: 50)'), () => {
+        fieldsCall += 1;
+        return fieldsCall === 1
+          ? fieldsResponse(0, [{ id: 'PVTSSF_new1', name: 'Status', options: [{ id: 'a', name: 'Todo' }, { id: 'b', name: 'In Progress' }, { id: 'c', name: 'Done' }] }])
+          : fieldsResponse(0, FRESH_FULL_FIELDS);
+      }],
+      [(j) => j.includes('updateProjectV2Field'), { stdout: JSON.stringify({ data: { updateProjectV2Field: { projectV2Field: { id: 'PVTSSF_new1', options: [] } } } }) }],
+      [(j) => j.includes('createProjectV2Field'), { stdout: JSON.stringify({ data: { createProjectV2Field: { projectV2Field: { id: 'PVTSSF_x', options: [] } } } }) }],
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/42\n' }],
+    ];
+  }
+
+  // AC-1 / AC-4: the wired statusLine.command embeds the absolute node binary
+  // (process.execPath), never a bare `node`, and both paths are quoted so a
+  // space in the path (e.g. C:\Program Files\nodejs\node.exe) survives.
+  it('AC-181.1/AC-181.4: wires the absolute process.execPath, quoted, not a bare `node`', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh(bootstrapRoutes());
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--create-project', 'forge', '--statusline', '--skip-doctor']) });
+    expect(res.ok).toBe(true);
+
+    const settings = await readJson(join(cwd, '.claude', 'settings.local.json'));
+    const cmd = settings.statusLine.command;
+    expect(settings.statusLine.type).toBe('command');
+    // AC-1: the absolute node binary currently running the test is embedded.
+    expect(cmd).toContain(process.execPath);
+    // AC-2 (unit-checkable slice): it is NOT a bare `node` invocation — that is
+    // exactly the wiring that renders blank when node is off the spawned PATH.
+    expect(cmd).not.toMatch(/^node\s/);
+    // AC-4: the node binary is quoted, so a space in the path cannot split the arg.
+    expect(cmd).toContain(`"${process.execPath}"`);
+    // the script argument is also quoted.
+    expect(cmd).toMatch(/"[^"]*statusline\.mjs"$/);
+  });
+
+  // AC-3: re-running --statusline heals a pre-existing bare-`node` wiring — the
+  // statusLine.command key is idempotently overwritten with the absolute path.
+  it('AC-181.3: re-init overwrites a stale bare-`node` command in place', async () => {
+    const cwd = await tmpCwd();
+    // seed a settings.local.json carrying the OLD broken bare-`node` wiring
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(
+      join(cwd, '.claude', 'settings.local.json'),
+      JSON.stringify({ statusLine: { type: 'command', command: 'node "C:/old/statusline.mjs"' }, other: { keep: true } }, null, 2),
+      'utf8',
+    );
+
+    const { gh } = fakeGh(bootstrapRoutes());
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--create-project', 'forge', '--statusline', '--skip-doctor']) });
+    expect(res.ok).toBe(true);
+
+    const settings = await readJson(join(cwd, '.claude', 'settings.local.json'));
+    expect(settings.statusLine.command).toContain(`"${process.execPath}"`);
+    expect(settings.statusLine.command).not.toContain('node "C:/old/statusline.mjs"');
+    // unrelated keys survive the merge (no-clobber rule)
+    expect(settings.other).toEqual({ keep: true });
+  });
+});
+
 describe('runInit — failure modes', () => {
   it('fails with a clear message when gh is unauthenticated', async () => {
     const cwd = await tmpCwd();


### PR DESCRIPTION
Closes #181

## Problem
`init.mjs` wired the Claude Code status line with a bare `node "<script>"`. Claude Code spawns the status-line command in a process that may not have `node` on PATH (e.g. node installed to `%LOCALAPPDATA%\node22\current\node.exe`, as on the maintainer's machine 2026-07-22). The command then dies with exit 127 and — because the status line fails silent by design — the bar renders **completely blank** with no error surfaced. Worse, re-running init rewrote the *same* bare-`node` command, so the documented `/forge:statusline` "re-init" remediation was a no-op for this failure mode.

## Fix
At init time, wire the **absolute** node binary via `process.execPath` (the node currently running init — portable and absolute), quoted alongside the script path so both tolerate spaces:

```js
statusLine: { type: 'command', command: `"${process.execPath}" "${scriptPath}"` }
```

`mergeJson`/`deepMerge` overwrites the `statusLine.command` string leaf on each run, so a stale bare-`node` wiring is healed on the next `init --statusline`.

## Acceptance criteria
- [x] **AC-1** — init writes an absolute node path (`process.execPath`) into `settings.local.json` `statusLine.command`, quoted to tolerate spaces.
- [x] **AC-2** — the wired command resolves even when `node` is absent from the spawning process's PATH. *(Behavioural guarantee; unit-verified via the absolute-path + quoting assertions in AC-4 — a PATH-stripped Claude status-line process can't be spawned in a unit test. The command no longer depends on PATH at all: it names the node binary by absolute path.)*
- [x] **AC-3** — existing bare-`node` wirings are healed on the next `init --statusline` (idempotent overwrite of the `statusLine` key via `mergeJson`; new test seeds a stale bare-`node` command and asserts it is replaced while unrelated keys survive).
- [x] **AC-4** — regression test covers the `process.execPath` interpolation + quoting (`tests/init.test.mjs`, two new `#181` tests).

## Verification
- `pnpm verify` (= `vitest run`): **373/373 pass** locally, including 2 new `#181` tests.
- `forge:reviewer` (full branch): **pass**, zero findings.
- `forge:security` (full branch): **pass**, zero findings. No new injection surface — both interpolated values are runtime-derived (Node's own binary path, the plugin's own installed file path); written as an encoded JSON string via atomic `writeJson`; `settings.local.json` is gitignored so the machine-specific path never lands in a committed file.

## Follow-up
Filed **#202** (child of epic #182) to revisit the `/forge:statusline` §1/§2 "re-init" remediation text — re-init is now a real fix rather than a no-op (out of scope for #181 per its Notes).

> ⚠️ CI note: GitHub Actions minutes are exhausted this run, so all jobs fail at startup (0 steps, `startup_failure`) — infrastructure, not this diff. Verified green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)