### PR TITLE
fix(jsonfile): readJson returns null only for ENOENT, propagates real I/O errors (#185)

### DIFF
--- a/plugin/scripts/autopilot/ledger.mjs
+++ b/plugin/scripts/autopilot/ledger.mjs
@@ -25,10 +25,12 @@ async function readRun(cwd) {
   try {
     return await readJson(join(cwd, RUN_RELPATH));
   } catch (err) {
-    // readJson already maps a missing/unreadable file to null, so the only thing
-    // that reaches here is JSON.parse choking on a truncated/corrupt file — treat
-    // that as a fresh run. A real I/O error must surface, not silently overwrite
-    // an in-flight run.json with a fresh one.
+    // readJson maps a MISSING file (ENOENT) to null, but propagates a real I/O
+    // error (EACCES/EIO/EBUSY/…) and a JSON.parse SyntaxError (#185). A truncated
+    // or hand-corrupted ledger (SyntaxError) is treated as a fresh run; a genuine
+    // read failure must surface here, not silently overwrite an in-flight run.json
+    // with a fresh one. This re-throw branch is now reachable (it was dead while
+    // readJson swallowed every read error as null upstream — the #185 fix).
     if (err instanceof SyntaxError) return null;
     throw err;
   }

--- a/plugin/scripts/lib/jsonfile.mjs
+++ b/plugin/scripts/lib/jsonfile.mjs
@@ -2,13 +2,22 @@ import { readFile, writeFile, mkdir, rename, rm } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { randomBytes } from 'node:crypto';
 
-/** Read a JSON file; returns null when missing, throws on broken JSON. */
+/**
+ * Read a JSON file; returns null ONLY when the file is missing (ENOENT).
+ * A genuine read failure on an existing file — EACCES, EIO, EBUSY (AV/lock on
+ * Windows), EMFILE, etc. — propagates rather than masquerading as "absent", so
+ * correctness-critical state (run.json, plan ledgers) can't silently reset to a
+ * fresh value on a transient I/O error (#185). Callers that genuinely want
+ * "treat unreadable as absent" opt in explicitly with `.catch(() => null)`.
+ * A `SyntaxError` from broken JSON still throws (unchanged).
+ */
 export async function readJson(path) {
   let raw;
   try {
     raw = await readFile(path, 'utf8');
-  } catch {
-    return null;
+  } catch (err) {
+    if (err?.code === 'ENOENT') return null;
+    throw err;
   }
   return JSON.parse(raw);
 }

--- a/tests/autopilot/engine.test.mjs
+++ b/tests/autopilot/engine.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mkdtemp, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -259,6 +259,27 @@ describe('autopilot run ledger (#129, AC-6)', () => {
     await writeRaw(cwd, '{ "version": 1, "startedAt": "2026-07-21T00:00:00Z", "outcom');
     const run = await loadRun(cwd);
     expect(run).toMatchObject({ version: 1, iterations: 0, outcomes: [] });
+  });
+
+  it('AC-185.3: loadRun PROPAGATES a real I/O error on run.json — never a silent fresh-run reset', async () => {
+    // The #185 fix makes readJson re-throw non-ENOENT read errors, which makes
+    // readRun's re-throw branch reachable: a transient read failure (EACCES/EIO/
+    // EBUSY — AV lock on Windows) on an in-flight run.json must surface, NOT be
+    // masked as a fresh run that discards the run's merged/escalated progress.
+    vi.resetModules();
+    vi.doMock('node:fs/promises', async (orig) => {
+      const actual = await orig();
+      const eacces = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      return { ...actual, readFile: async () => { throw eacces; } };
+    });
+    try {
+      const { loadRun: throwingLoad } = await import('../../plugin/scripts/autopilot/ledger.mjs');
+      const cwd = await mkdtemp(join(tmpdir(), 'forge-autopilot-'));
+      await expect(throwingLoad(cwd)).rejects.toMatchObject({ code: 'EACCES' });
+    } finally {
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+    }
   });
 
   it('AC-B164.3: startRun recovers from a truncated run.json and starts a clean run', async () => {

--- a/tests/lib/jsonfile.test.mjs
+++ b/tests/lib/jsonfile.test.mjs
@@ -6,9 +6,36 @@ import { join } from 'node:path';
 import { readJson, writeJson, mergeJson } from '../../plugin/scripts/lib/jsonfile.mjs';
 
 describe('jsonfile', () => {
-  it('readJson returns null for missing files', async () => {
+  it('AC-185.1: readJson returns null for a MISSING file (ENOENT)', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'forge-json-'));
     expect(await readJson(join(dir, 'nope.json'))).toBe(null);
+  });
+
+  it('AC-185.3: readJson PROPAGATES a non-ENOENT read error (EACCES) — not silently null', async () => {
+    // A genuine I/O error on an EXISTING file (permission denied, lock, AV) must
+    // surface, not be swallowed as "absent" — the silent-data-loss class #185/#164
+    // guards against. Inject a readFile that throws a coded EACCES to hit the branch
+    // (a real EACCES is hard to force portably on Windows).
+    vi.resetModules();
+    vi.doMock('node:fs/promises', async (orig) => {
+      const actual = await orig();
+      const eacces = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      return { ...actual, readFile: async () => { throw eacces; } };
+    });
+    try {
+      const { readJson: throwingRead } = await import('../../plugin/scripts/lib/jsonfile.mjs');
+      await expect(throwingRead(join(tmpdir(), 'exists-but-locked.json'))).rejects.toMatchObject({ code: 'EACCES' });
+    } finally {
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+    }
+  });
+
+  it('AC-185.1: readJson still throws a SyntaxError on broken JSON (unchanged)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-json-'));
+    const p = join(dir, 'broken.json');
+    await writeFile(p, '{ not: valid json', 'utf8');
+    await expect(readJson(p)).rejects.toBeInstanceOf(SyntaxError);
   });
 
   it('writeJson creates parent directories and round-trips', async () => {


### PR DESCRIPTION
Closes #185

## Problem
`lib/jsonfile.mjs` `readJson` caught **every** `readFile` error and returned `null`, not just `ENOENT`. A genuine I/O error (EACCES/EIO/EBUSY/AV-lock on Windows/EMFILE) on an existing, valid file was indistinguishable from "file absent". A transient read failure on an in-flight `run.json` therefore silently fell back to a fresh run, discarding progress — the silent-data-loss class #164 set out to prevent, via a different trigger. It also left the autopilot ledger's `readRun` re-throw branch (added in #184) **unreachable**.

## Fix (AC1)
In `readJson`'s catch: `if (err?.code === 'ENOENT') return null; throw err;`. Non-ENOENT read errors now propagate. `JSON.parse` stays outside the catch, so a `SyntaxError` on broken JSON still throws (unchanged).

## Caller audit (AC2) — the crux
Grepped the whole `plugin/` tree; `readJson` has exactly 6 call sites. Every best-effort caller **already** opts into "treat unreadable as absent" via a pre-existing `.catch(() => null)`, so the now-throwing `readJson` is caught and returns null identically — **no regression, zero new opt-ins required**.

| Caller | Pattern | Behaviour after fix | Regression? | Action |
|---|---|---|---|---|
| `doctor.mjs:137-138` | `.catch(() => null)` | throw caught -> null (best-effort health check) | No | none |
| `gates/plandrift.mjs:56` | `.catch(() => null) ?? {}` | throw caught -> null -> `{}` | No | none |
| `gates/groundgate.mjs:47` | `.catch(() => null)` | throw caught -> null | No | none |
| `monitors/decisions-watch.mjs:24` | `.catch(() => null)` | throw caught -> skip file | No | none |
| `jsonfile.mjs:42` `mergeJson` (internal) | `(await readJson) ?? {}`, no catch | **propagates** real I/O error | No — **safer**: prevents merging into `{}` and clobbering an existing-but-unreadable settings file | none (leave) |
| `autopilot/ledger.mjs:26` `readRun` | try/catch: null on `SyntaxError`, re-throw else | re-throw branch **now reachable** — real I/O error surfaces | No — this **is** the fix's intent | comment updated (was stale) |

The lowest-churn approach keeps each caller's intended behaviour without adding a `bestEffort` option (no caller needs one — the `.catch(() => null)` idiom already is the explicit opt-in).

## Tests (AC3)
`tests/lib/jsonfile.test.mjs`:
- ENOENT (missing file) still returns `null`.
- A non-ENOENT read error (injected coded `EACCES` via `vi.doMock`) **propagates** — asserts it throws, not silent null.
- Broken JSON still throws `SyntaxError` (unchanged).

`tests/autopilot/engine.test.mjs` (added per reviewer):
- `loadRun` **propagates** an injected `EACCES` on `run.json` — pins the now-reachable re-throw branch so a transient read failure never silently resets an in-flight run.

## Verification (honest)
- `pnpm verify` **green locally: 376/376, 42 files** — exercises the doctor/plandrift/groundgate/decisions/init/ledger callers, strong evidence AC2 didn't regress. Reasoned about each caller explicitly above (tests don't cover every error path).
- `forge:reviewer`: **pass**, zero critical/high. Independently re-verified the caller audit (confirmed 6 call sites, mergeJson-throwing is correct/safer). One **minor** coverage note -> addressed by the added ledger test.
- `forge:security`: **pass**, zero critical/high. Three **low** robustness notes (isMain blocks lack `.catch` -> ungraceful exit on real I/O error; same-user local CLI only, no cross-boundary DoS/disclosure) -> filed as follow-up **#204**.

## CI note
GitHub Actions minutes are exhausted this run — all jobs fail at startup (0 steps) as known infra, not this diff. Merge authorized on LOCAL-GREEN by the owner for this run.

## AC checklist
- [x] AC1: `readJson` returns null only for ENOENT; other I/O errors propagate.
- [x] AC2: all callers audited (table above); none regress; best-effort callers opt in explicitly (pre-existing `.catch`).
- [x] AC3: tests assert EACCES-style read error surfaces and ENOENT still returns null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
