### PR TITLE
fix(cli): add .catch to isMain entrypoints so real I/O errors exit cleanly (#204)

### DIFF
--- a/plugin/scripts/autopilot/ledger.mjs
+++ b/plugin/scripts/autopilot/ledger.mjs
@@ -104,7 +104,12 @@ const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(proc
 if (isMain) {
   const sub = process.argv[2];
   if (sub === 'report') {
-    loadRun(process.cwd()).then((run) => console.log(renderReport(run)));
+    // A genuine read failure on an existing run.json (EACCES/EBUSY/AV-lock) now
+    // propagates (#185) — catch it so it exits cleanly instead of surfacing as a
+    // raw unhandled-rejection trace (#204).
+    loadRun(process.cwd())
+      .then((run) => console.log(renderReport(run)))
+      .catch((err) => { console.error(`ledger report failed: ${err.message}`); process.exit(1); });
   } else {
     console.error('usage: ledger.mjs report');
     process.exit(1);

--- a/plugin/scripts/deploy/init.mjs
+++ b/plugin/scripts/deploy/init.mjs
@@ -120,5 +120,5 @@ if (isMain) {
   const gh = makeGh(run);
   runDeployInit({ gh, cwd: process.cwd() }, parseArgs(process.argv.slice(2))).then((res) => {
     if (!res.ok) { console.error(`deploy-init failed: ${res.error}`); process.exit(1); }
-  });
+  }).catch((err) => { console.error(`deploy-init failed: ${err.message}`); process.exit(1); });
 }

--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -238,5 +238,5 @@ if (isMain) {
   runInit(ctx).then((res) => {
     if (!res.ok) { console.error(`init failed: ${res.error}`); process.exit(1); }
     process.exit(res.doctor && !res.doctor.ok ? 1 : 0);
-  });
+  }).catch((err) => { console.error(`init failed: ${err.message}`); process.exit(1); });
 }

--- a/tests/autopilot/engine.test.mjs
+++ b/tests/autopilot/engine.test.mjs
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mkdtemp, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { selectNext, actionFor, actionableQueue, normalize } from '../../plugin/scripts/autopilot/select.mjs';
@@ -280,6 +282,31 @@ describe('autopilot run ledger (#129, AC-6)', () => {
       vi.doUnmock('node:fs/promises');
       vi.resetModules();
     }
+  });
+
+  // #204: the `report` CLI entrypoint calls loadRun(...).then(...). Now that loadRun
+  // propagates a real I/O error (#185), the entrypoint must .catch it — a genuine read
+  // failure on an existing run.json must exit cleanly with a one-line message, NOT a
+  // raw Node unhandled-rejection stack trace.
+  const LEDGER_CLI = fileURLToPath(new URL('../../plugin/scripts/autopilot/ledger.mjs', import.meta.url));
+
+  it('AC-204.2: `report` exits non-zero with a clean message when run.json read fails — no unhandled-rejection trace', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-autopilot-'));
+    // Force a genuine (non-ENOENT, non-SyntaxError) read error: make run.json a
+    // DIRECTORY, so readFile throws EISDIR — which loadRun propagates rather than
+    // treating as absent/corrupt. Cross-platform (no EACCES/chmod juggling).
+    await mkdir(join(cwd, RUN_RELPATH), { recursive: true });
+    let err;
+    try {
+      execFileSync(process.execPath, [LEDGER_CLI, 'report'], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (e) { err = e; }
+    expect(err, 'report should have exited non-zero').toBeTruthy();
+    expect(err.status).not.toBe(0);
+    const stderr = String(err.stderr ?? '');
+    expect(stderr).toMatch(/ledger report failed:/);      // clean, controlled one-liner
+    expect(stderr).not.toMatch(/UnhandledPromiseRejection/); // not a raw rejection
+    expect(stderr).not.toMatch(/node:internal\/process\/promises/);
+    expect(stderr).not.toMatch(/^\s+at .+:\d+:\d+/m);        // no stack frames
   });
 
   it('AC-B164.3: startRun recovers from a truncated run.json and starts a clean run', async () => {


### PR DESCRIPTION
Closes #204

Follow-up from the #185 security review (low, non-blocking).

## Problem
Now that `readJson`/`mergeJson` propagate real I/O errors (#185), three `isMain` CLI blocks called their entrypoint with `.then(...)` but no `.catch`. A genuine read failure (EACCES/EBUSY/AV-lock) on an *existing* file surfaced as a raw Node unhandled-rejection stack trace + nonzero exit instead of the controlled `console.error`/`process.exit(1)` those tools use elsewhere.

## Fix
Added `.catch` handlers matching each file's existing error/exit style:
- `plugin/scripts/autopilot/ledger.mjs` — `report` subcommand `loadRun(...).then` → `ledger report failed: <msg>`
- `plugin/scripts/init.mjs` — `runInit(...).then` → `init failed: <msg>`
- `plugin/scripts/deploy/init.mjs` — `runDeployInit(...).then` → `deploy-init failed: <msg>`

## Acceptance criteria
- [x] AC1: each isMain block catches a rejected entrypoint and prints a one-line error + exits non-zero (no raw unhandled-rejection trace). Verified manually per file.
- [x] AC2: a subprocess test (`tests/autopilot/engine.test.mjs`, `AC-204.2`) asserts the clean-exit path for the ledger `report` entrypoint — forces `run.json` to a directory so `readFile` throws `EISDIR` (a real, non-ENOENT/non-SyntaxError I/O error that `loadRun` propagates), then asserts non-zero exit + one-line message + no stack-trace/unhandled-rejection markers. Confirmed the test fails if the `.catch` is removed (guards against regression).

## Verification (honest — CI is infra-down this run)
- `pnpm verify` green locally: 42 files, 377 tests pass.
- forge:reviewer → pass, zero critical/high.
- forge:security → pass, zero critical/high.
- GitHub Actions minutes are exhausted this run, so CI fails at startup (0 steps) regardless of diff — known infra failure, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)