### PR TITLE
docs(statusline): re-init is a real fix for bare-node blank bar (§1/§2)

### DIFF
--- a/plugin/commands/statusline.md
+++ b/plugin/commands/statusline.md
@@ -7,13 +7,14 @@ Diagnose and repair the status line (it fails silent by design — this command 
 ## 1. Is it wired?
 
 Read `.claude/settings.local.json` and `.claude/settings.json` for a `statusLine` key (local wins). Report which file, and the exact command string.
-- **Missing everywhere** → fix: `node "${CLAUDE_PLUGIN_ROOT}/scripts/init.mjs" --project <n> --statusline` (re-init is idempotent; `--statusline` overwrites only the statusLine key in settings.local.json).
+- **Missing everywhere** → fix: `node "${CLAUDE_PLUGIN_ROOT}/scripts/init.mjs" --project <n> --statusline` (re-init is idempotent; `--statusline` overwrites only the statusLine key in settings.local.json, wiring the **absolute** node binary `process.execPath` — #181).
 - **Present in shared settings.json** → warn: machine-specific paths break teammates; move it to settings.local.json (delete there, re-run the fix above).
 
 ## 2. Do the paths exist?
 
 From the wired command string, verify the `node` executable and the script path both exist on disk.
 - **Either missing** (moved checkout, moved portable node) → same fix as §1: the re-wire writes current correct paths.
+- **Wired to a bare `node`** (the command is `node …` with no absolute path) → the node-not-on-PATH → blank-bar cause: Claude Code may spawn the status line without `node` on PATH, so it exits 127 and the bar renders silently blank. Same fix as §1 — since #181 `init --statusline` wires the **absolute** node binary (`process.execPath`), re-init genuinely heals this (before #181 it rewrote the same bare `node`, a no-op for this failure mode).
 
 ## 3. Does the script run?
 


### PR DESCRIPTION
Closes #202 — follow-up to #181.

## What
Updates the `/forge:statusline` command doc (§1 "Is it wired?" and §2 "Do the paths exist?") so the remediation text correctly presents re-init (`init --statusline`) as a **real** healing action for the node-not-on-PATH → blank-bar case.

Since #181, `init --statusline` wires the **absolute** node binary via `process.execPath` (`plugin/scripts/init.mjs` ~L213-222: `command: "${process.execPath}" "${scriptPath}"`). Before #181, init wired a bare `node`, so re-running init rewrote the same broken bare-`node` command — a no-op for that failure mode. The doc now reflects the post-#181 behaviour.

- §1: notes the fix wires the absolute node binary `process.execPath` (#181).
- §2: adds a bullet for the bare-`node` wiring (node-not-on-PATH → exit 127 → silently blank bar) and states re-init genuinely heals it now, unlike before #181.

Docs-only; no code change. Single file: `plugin/commands/statusline.md`.

## Acceptance criteria
- [x] **AC-1**: §1/§2 remediation text no longer implies re-init is a no-op for the bare-`node`/blank-bar case; it correctly points to `init --statusline` as a healing action.
- [x] **AC-2**: text stays consistent with post-#181 behaviour (absolute `process.execPath` wiring).

## Verification
- `pnpm verify` green locally: 379 tests passed (42 files). Docs-only edit; no test asserts this command's prose, and the docsync gate checks only the docs/ route index + skills-in-handbook, not command prose — unaffected.
- Full-branch `forge:reviewer` and `forge:security` both returned verdict **pass**, zero critical/high. Reviewer fact-checked the `process.execPath` claim and the #181/#203 references against `init.mjs`.

> **CI note:** GitHub Actions minutes are exhausted for this run — all jobs fail at startup (0 steps, `startup_failure`), which is infrastructure, not this diff. Merge authorized on local-green for this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)