### PR TITLE
chore(security): OSS gate — full-history secret scan + repeatable tooling (#210)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -25,8 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: 0 # full history so gitleaks scans every commit, not just the tip
+          # fetch-depth: 0 is what gives full history (unshallow) so gitleaks scans
+          # every commit reachable from the checked-out ref, not just the tip.
+          fetch-depth: 0
       # gitleaks v8.30.1 — pinned by digest (see .github/workflows/verify.yml actionlint step).
       - uses: docker://ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f # v8.30.1
         with:
+          # --log-opts=--all scans any extra refs present (defensive; checkout
+          # materialises one ref, so it usually equals a full default history walk).
           args: detect --source=/github/workspace --config=/github/workspace/.gitleaks.toml --no-git=false --redact --log-opts=--all

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,32 @@
+name: secret-scan
+
+# Regression gate for issue #210 (OSS secret-scan). Runs gitleaks over the full
+# git history on every push to main and every PR. Self-contained: uses the
+# pinned gitleaks container image directly (same docker-by-digest pattern as the
+# actionlint step in verify.yml), so it needs no third-party action or license
+# and runs free on public repos. Honours .gitleaks.toml (allowlists documented
+# test fixtures; see docs/security/oss-secret-scan.md).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0 # full history so gitleaks scans every commit, not just the tip
+      # gitleaks v8.30.1 — pinned by digest (see .github/workflows/verify.yml actionlint step).
+      - uses: docker://ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f # v8.30.1
+        with:
+          args: detect --source=/github/workspace --config=/github/workspace/.gitleaks.toml --no-git=false --redact --log-opts=--all

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,34 @@
+# gitleaks configuration for forge (OSS secret-scan gate, issue #210).
+#
+# Extends the built-in ruleset and adds a narrowly-scoped allowlist for the
+# repo's own test fixtures: strings that are intentionally shaped like secrets
+# so the unit tests can prove the pre-send scanner and journal redactor catch
+# them. These are NOT live credentials. See docs/security/oss-secret-scan.md
+# for the full triage.
+#
+# Used by:
+#   - .github/workflows/secret-scan.yml (CI regression gate)
+#   - a full-history scan:
+#       gitleaks detect --source . --no-git=false --redact --log-opts=--all
+
+title = "forge secret-scan config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentionally fake, secret-shaped test fixtures (not live credentials) — see docs/security/oss-secret-scan.md"
+
+# Globally-known non-secret: AWS's own documented example access key id.
+regexes = [
+  '''AKIAIOSFODNN7EXAMPLE''',
+]
+
+# Files whose whole purpose is to contain secret-SHAPED example strings that
+# exercise the repo's redaction / pre-send scanning code paths. Scoped to the
+# exact fixture files (present and historical) rather than all of tests/, so a
+# real credential added elsewhere is still caught.
+paths = [
+  '''tests/lib/journal\.test\.mjs$''',
+  '''tests/backends/presend\.test\.mjs$''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -27,8 +27,15 @@ regexes = [
 # Files whose whole purpose is to contain secret-SHAPED example strings that
 # exercise the repo's redaction / pre-send scanning code paths. Scoped to the
 # exact fixture files (present and historical) rather than all of tests/, so a
-# real credential added elsewhere is still caught.
+# real credential added elsewhere is still caught. Anchored ^…$ because gitleaks
+# matches path regexes unanchored (substring), so a bare suffix would also
+# exempt differently-nested lookalike paths — anchoring keeps the scope exact.
+#
+# Residual (inherent to any path allowlist): the ENTIRE content of these two
+# files is exempt, so a real secret pasted into one of them would not be caught
+# by this gate. Accepted: they are redaction-test fixtures by design; a real
+# credential belongs in neither.
 paths = [
-  '''tests/lib/journal\.test\.mjs$''',
-  '''tests/backends/presend\.test\.mjs$''',
+  '''^tests/lib/journal\.test\.mjs$''',
+  '''^tests/backends/presend\.test\.mjs$''',
 ]

--- a/docs/security/oss-secret-scan.md
+++ b/docs/security/oss-secret-scan.md
@@ -42,6 +42,12 @@ docker run --rm -v "$PWD/work:/repo" \
 trufflehog's format/checksum-aware detectors did not match any of the 5 strings
 gitleaks flagged — corroborating that they are not real credentials.
 
+Digest provenance: the pinned gitleaks digest was obtained by pulling
+`ghcr.io/gitleaks/gitleaks:latest`, which self-reported `version v8.30.1`; its
+`RepoDigests` entry is the `sha256:c00b6bd0…` used in `secret-scan.yml`. Pinning
+by digest is deliberate so CI runs that exact image indefinitely even as
+`:latest` moves.
+
 ---
 
 ## AC2 — triage (every finding)
@@ -54,16 +60,21 @@ redactor catch them. Values redacted here per the ticket's no-plaintext rule.
 | --- | --- | --- | --- | --- |
 | 1 | `generic-api-key` | `tests/backends/presend.test.mjs:20` | False positive | Fixture in a test that asserts `scanPrompt` **refuses** secret-shaped input. File is history-only (presend backend was later removed). |
 | 2 | `jwt` | `tests/backends/presend.test.mjs:11` | False positive | Fabricated JWT in the same "refuses known secret patterns" fixture list. |
-| 3 | `aws-access-token` | `tests/lib/journal.test.mjs:47` | False positive | `AKIAIOSFODNN7EXAMPLE` — AWS's own **documented example** access key id, used in a redaction test. |
+| 3 | `aws-access-token` | `tests/lib/journal.test.mjs:47` | False positive | `AKIAABCDEFGHIJKLMNOP` — a fabricated AWS-shaped key inside a `redact({ nested: { list: [...] } })` test asserting nested values are scrubbed. |
 | 4 | `generic-api-key` | `tests/lib/journal.test.mjs:35` | False positive | Fake `GH_TOKEN=ghp_…` in a test asserting the journal redacts it to `[redacted]`. |
 | 5 | `generic-api-key` | `tests/lib/journal.test.mjs:36` | False positive | Fake `token:` value in the same redaction test. |
 
 **No true positives. No rotation and no history rewrite are required.**
 
-These fixtures are excluded going forward by `.gitleaks.toml` — scoped to the two
-exact fixture files (present + historical) plus the AWS example-key literal, so a
-real credential added anywhere else is still caught. Re-scanning the full history
-**with** that config returns `no leaks found` (0).
+Note: the deleted `presend.test.mjs` also contained `AKIAIOSFODNN7EXAMPLE` (AWS's
+own documented example key) at its line 8, but it is **not** among the 5 findings
+— gitleaks' default ruleset already allowlists that well-known literal.
+
+These fixtures are excluded going forward by `.gitleaks.toml` — path-scoped to the
+two exact fixture files (present + historical, anchored `^…$`), plus a redundant
+explicit regex for the AWS example literal as defense-in-depth. A real credential
+added **anywhere else** is still caught. Re-scanning the full history **with** that
+config returns `no leaks found` (0).
 
 ---
 

--- a/docs/security/oss-secret-scan.md
+++ b/docs/security/oss-secret-scan.md
@@ -1,0 +1,104 @@
+# OSS gate — full-history secret & credential scan (issue #210)
+
+**Epic:** #209 (open-source the repository) · **Gate:** hard, pre-publish (irreversible once public)
+**Date:** 2026-07-23 · **Scope:** every commit on every ref that becomes public at flip
+(49 branches + 91 PR refs + 17 tags → 204 unique content-bearing commits, ~1.5 MB)
+
+Once the repo is public, **all history is public** — not just the current tree. This scan
+covers the complete published history via a `--mirror` clone of `origin` (mirror = exactly
+the refs that become public), not just the working tree.
+
+---
+
+## AC1 — scans run (both tools, full history, all refs)
+
+Reproduce from a mirror clone (guarantees all branches, tags, and PR refs):
+
+```sh
+# 1. Mirror all published refs (branches + tags + refs/pull/*)
+git clone --mirror https://github.com/dngioidev/forge.git mirror.git
+
+# 2. gitleaks v8.30.1 — full history, all refs, redacted output
+docker run --rm -v "$PWD/mirror.git:/repo" \
+  ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f \
+  detect --source=/repo --no-git=false --redact \
+  --log-opts="--all --glob=refs/pull/*"
+
+# 3. trufflehog v3.95.9 — full history, verified + unknown detectors
+#    (trufflehog wants a working .git, so scan a non-bare clone that has every
+#     ref materialised as a local branch)
+docker run --rm -v "$PWD/work:/repo" \
+  trufflesecurity/trufflehog@sha256:59b244249d1a1aef4baa24fe73d3c931616264482580d806d77f6c74d26b3e42 \
+  git file:///repo --results=verified,unknown --json
+```
+
+**Raw results (2026-07-23):**
+
+| Tool | Version | Commits/chunks scanned | Findings |
+| --- | --- | --- | --- |
+| gitleaks | v8.30.1 | 204 commits (all refs) | 5 (all false positives — see AC2) |
+| trufflehog | v3.95.9 | 1368 chunks, all 265 reachable commits | **0 verified, 0 unverified** |
+
+trufflehog's format/checksum-aware detectors did not match any of the 5 strings
+gitleaks flagged — corroborating that they are not real credentials.
+
+---
+
+## AC2 — triage (every finding)
+
+All 5 gitleaks hits are **false positives**: strings deliberately shaped like
+secrets so the repo's own tests can prove the pre-send scanner and the journal
+redactor catch them. Values redacted here per the ticket's no-plaintext rule.
+
+| # | Rule | File : line | Verdict | Reason |
+| --- | --- | --- | --- | --- |
+| 1 | `generic-api-key` | `tests/backends/presend.test.mjs:20` | False positive | Fixture in a test that asserts `scanPrompt` **refuses** secret-shaped input. File is history-only (presend backend was later removed). |
+| 2 | `jwt` | `tests/backends/presend.test.mjs:11` | False positive | Fabricated JWT in the same "refuses known secret patterns" fixture list. |
+| 3 | `aws-access-token` | `tests/lib/journal.test.mjs:47` | False positive | `AKIAIOSFODNN7EXAMPLE` — AWS's own **documented example** access key id, used in a redaction test. |
+| 4 | `generic-api-key` | `tests/lib/journal.test.mjs:35` | False positive | Fake `GH_TOKEN=ghp_…` in a test asserting the journal redacts it to `[redacted]`. |
+| 5 | `generic-api-key` | `tests/lib/journal.test.mjs:36` | False positive | Fake `token:` value in the same redaction test. |
+
+**No true positives. No rotation and no history rewrite are required.**
+
+These fixtures are excluded going forward by `.gitleaks.toml` — scoped to the two
+exact fixture files (present + historical) plus the AWS example-key literal, so a
+real credential added anywhere else is still caught. Re-scanning the full history
+**with** that config returns `no leaks found` (0).
+
+---
+
+## AC3 — enable GitHub secret scanning + push protection (run AT FLIP time)
+
+These require the repo to be public (or GHAS); free for public repos. Not enabled
+by this ticket — run when #209 flips visibility:
+
+1. Flip the repo to **Public** (owner action, tracked by epic #209).
+2. **Settings → Code security and analysis:**
+   - **Secret scanning** → **Enable**.
+   - **Push protection** → **Enable** (blocks new commits that introduce detected secrets).
+3. CLI equivalent (needs `admin:repo` scope):
+   ```sh
+   gh api -X PATCH repos/dngioidev/forge \
+     -f security_and_analysis[secret_scanning][status]=enabled \
+     -f security_and_analysis[secret_scanning_push_protection][status]=enabled
+   ```
+4. Verify: `forge:doctor` reports secret scanning + push protection on; and
+   **Settings → Code security** shows both enabled with the alerts tab reachable.
+5. The `secret-scan` workflow (this PR) then runs free on every push/PR as the
+   ongoing regression gate, complementing GitHub's native scanning.
+
+---
+
+## AC4 — sign-off (OWNER action — hard gate for the public flip)
+
+Based on the two independent full-history scans above (gitleaks: 5 findings, all
+triaged as fake test fixtures; trufflehog: 0), the delivery agent's finding is:
+
+> No live secrets were found in the tree or in the full git history.
+
+The **attestation itself is the owner's to give**. Owner: confirm the triage
+above and record, on issue #210:
+
+> ✅ Signed off: **no live secrets remain in tree or history.** — @<owner>, 2026-07-__
+
+Until that line exists, the epic #209 public flip stays blocked.


### PR DESCRIPTION
## What & why
Pre-publish **security gate** for epic #209 (open-sourcing this currently-private repo). Once public, **all git history is public**, not just the working tree — so the full published history was scanned for secrets before the flip. Ticket #210.

## Scan (AC1) — two tools, full history, all refs
Scanned a `--mirror` clone of origin = exactly the refs that become public: **49 branches + 91 PR refs + 17 tags → 204 unique commits (~1.5 MB)**.

| Tool | Version | Coverage | Result |
| --- | --- | --- | --- |
| gitleaks | v8.30.1 | 204 commits, all refs | 5 findings — **all false positives** |
| trufflehog | v3.95.9 | 1368 chunks, 265 reachable commits | **0 verified, 0 unverified** |

## Triage (AC2) — no true positives
All 5 gitleaks hits are intentionally fake, secret-shaped strings in the repo's own tests (redaction / pre-send scanner fixtures), incl. AWS's documented example key `AKIAIOSFODNN7EXAMPLE`. Values redacted. Per-finding table in `docs/security/oss-secret-scan.md`. **No rotation, no history rewrite required.**

## What ships (repeatable tooling)
- **`.gitleaks.toml`** — extends default rules; narrowly allowlists the two fixture files + the AWS example-key literal (a real secret anywhere else is still caught). Re-scanning full history with this config → `no leaks found` (0).
- **`.github/workflows/secret-scan.yml`** — gitleaks over full history on push/PR, pinned by image digest (same docker-by-digest pattern as the existing actionlint step), free on public repos, no third-party action/license.
- **`docs/security/oss-secret-scan.md`** — reproducible commands + redacted results (AC1), triage (AC2), GitHub secret-scanning + push-protection enablement runbook to run at flip (AC3), owner sign-off request (AC4).

## Not done here (deliberate — owner/irreversible actions)
- **AC3** GitHub secret scanning + push protection: needs the repo public; enablement runbook attached, to run at flip.
- **AC4** "no live secrets remain" attestation: the owner's to give → committed with `Refs #210` (not `Closes`); AC4 sign-off is being escalated to the owner.

## Verification
- `pnpm verify` → 379 tests pass.
- `actionlint` → clean on all workflows.
- gitleaks full-history re-scan **with** the new config → 0 findings.

> Note: CI is currently infra-down (Actions minutes exhausted → 0-step startup_failure, not a diff issue). Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)