### PR TITLE
docs(community): add OSS community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — default reviewer for forge.
+# The maintainer is requested for review on every pull request.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @dngioidev

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Report a defect in forge (a skill, gate, hook, board script, or workflow)
+title: "bug: <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. forge triages every incoming issue into a
+        typed ticket with acceptance criteria — the fields below map to what
+        triage needs (repro / expected / actual / evidence).
+
+        **Security issues do not belong here** — report them privately via
+        [SECURITY.md](../../SECURITY.md).
+  - type: input
+    id: version
+    attributes:
+      label: forge version / commit
+      description: Plugin version (e.g. v0.16.0) or commit SHA. Run `/forge:doctor` if unsure.
+      placeholder: "v0.16.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of forge misbehaves?
+      options:
+        - a skill (pipeline / care / knowledge)
+        - a gate (verify, plandrift, acgate, docsync, depguard, …)
+        - a hook (capture, denylist, …)
+        - board automation / trail comments
+        - the graph MCP server
+        - CI workflow / templates
+        - other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands or skill invocations, in order.
+      placeholder: |
+        1. Run `forge:autopilot --shape`
+        2. It picks ticket #NNN
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, error output, gate messages, trail comments, or screenshots. Redact secrets and personal data.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version (`node --version`), pnpm version, gh CLI version.
+      placeholder: |
+        OS: Windows 11 / macOS 14 / Ubuntu 24.04
+        Node: 22.13.0
+        pnpm: 10.14.0
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go to SECURITY.md privately).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/dngioidev/forge/security/advisories/new
+    about: Report security issues privately — never in a public issue. See SECURITY.md.
+  - name: Question or idea (Discussions)
+    url: https://github.com/dngioidev/forge/discussions
+    about: Ask a question or float an early idea before filing a formal request.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/dngioidev/forge/security/advisories/new
     about: Report security issues privately — never in a public issue. See SECURITY.md.
-  - name: Question or idea (Discussions)
-    url: https://github.com/dngioidev/forge/discussions
-    about: Ask a question or float an early idea before filing a formal request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a new capability or improvement for forge
+title: "item: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an idea. forge shapes proposals into typed tickets
+        with **acceptance criteria** before they enter the pipeline — the fields
+        below mirror that shape (problem → proposal → acceptance criteria), so a
+        well-formed request can move straight to planning.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's missing or painful today? Describe the situation, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should forge do? How would it fit the existing pipeline (triage → plan → execute → ship)?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, testable conditions that define "done" (forge maps each to a passing test at ship).
+      placeholder: |
+        - AC1: ...
+        - AC2: ...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why this one.
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which lane does this touch?
+      options:
+        - pipeline skill (ideate / plan / execute / ship / release / …)
+        - care skill (hotfix / respond / maintain / investigate)
+        - board automation / trail
+        - gates / hooks
+        - graph / code intelligence
+        - docs / community
+        - other
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+  Title must be a Conventional Commit — it becomes the squash commit on merge.
+  e.g. feat(autopilot): add worktree pool for parallel delivery
+-->
+
+## What & why
+
+<!-- One or two sentences: what this changes and the problem it solves. -->
+
+Closes #<!-- issue number (required — forge is ticket-first) -->
+
+## Acceptance criteria coverage
+
+<!-- List each AC-ID from the issue and the test that proves it. -->
+
+- [ ] AC1: <criterion> — covered by `<test file / name>`
+- [ ] AC2: <criterion> — covered by `<test file / name>`
+
+## Verification (be honest — "not verified" is a valid answer)
+
+- [ ] `pnpm verify` passes locally
+- [ ] What was verified: <!-- how you exercised the change end-to-end -->
+- [ ] What was NOT verified / known gaps: <!-- state "none" only if true -->
+
+## Checklist
+
+- [ ] Linked to a tracking issue (`Closes #N`)
+- [ ] Branch name follows `<type>/<issue>-<slug>`
+- [ ] Commits follow Conventional Commits with an issue reference
+- [ ] New/changed docs under `docs/` are added to the route index (`docs/README.md`); a new skill is mentioned in the handbook (docsync gate)
+- [ ] No secrets, credentials, or personal data added
+- [ ] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,136 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement privately, through
+GitHub's **"Report a vulnerability"** private reporting on this repository's
+**Security** tab (which reaches the maintainer confidentially), or by contacting
+the maintainer **[@dngioidev](https://github.com/dngioidev)** directly through
+their GitHub profile.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to forge
+
+Thanks for your interest in forge — a portable AI-dev-platform plugin for Claude Code. forge is built *by its own pipeline*: every feature is ticketed, planned, gated, trailed, and merged through the same skills it ships. Contributions follow the same path. This guide gets you from a clone to a merge-ready PR.
+
+## Ground rules (read these first)
+
+forge has a few laws that shape every contribution — they are enforced by mechanical gates, not by reviewer taste:
+
+1. **Ticket-first.** Every change starts as a GitHub issue on the board; silent side-work is not accepted. If you find something out of scope mid-work, open a new issue rather than folding it into an unrelated PR.
+2. **Honest verification.** Every PR states what was verified and what was **not**. "Unknown" is a valid answer — an untested claim is not.
+3. **Gates are scripts, not opinions.** A refused gate names its reason and the command that unblocks it. Fix the cause or explain why the gate is wrong; don't route around it.
+4. **The owner merges every PR.** Contributors open PRs and wait for review; merge is always the maintainer's action.
+
+## Prerequisites
+
+| need | check | fix |
+| --- | --- | --- |
+| Node ≥ 22.13 | `node --version` | [nodejs.org](https://nodejs.org) (the portable zip works — no admin needed) |
+| pnpm 10.14+ | `pnpm --version` | `corepack enable` then `corepack prepare pnpm@10.14.0 --activate` |
+| git + a GitHub account | `git --version` | [git-scm.com](https://git-scm.com) |
+| gh CLI (for board/PR work) | `gh auth status` | `gh auth login` |
+
+forge's `packageManager` is pinned to `pnpm@10.14.0` in `package.json`; Corepack will honor it automatically.
+
+## Local setup
+
+```bash
+git clone https://github.com/dngioidev/forge.git
+cd forge
+pnpm install
+pnpm verify
+```
+
+`pnpm verify` runs the full test suite (`vitest run`). A green `pnpm verify` is the single most important signal — **it must pass locally before you open a PR**, and CI runs the same command.
+
+## The forge pipeline (how work flows)
+
+forge's own delivery pipeline, front to back:
+
+```
+triage → plan → execute (per-task: scope → failing tests → implement → review) → ship → merge → release
+```
+
+- **triage** — one incoming idea/bug becomes a correctly-typed ticket (bug / item / test / chore) with acceptance criteria (AC-IDs) and a board slot.
+- **plan** — the ticket becomes a task-by-task plan under `docs/plans/`, each task carrying a Files list, AC-IDs, and a test plan.
+- **execute** — the plan is worked task by task: tests come *with* the code (often before it), then implementation, then review.
+- **ship** — the gate ladder runs, the PR opens with an AC checklist and honest verification, and trail comments land on the issue.
+
+You do **not** have to run the forge skills to contribute — but your PR is measured against the same gates they enforce, so it helps to know them.
+
+## Branching
+
+Branch off the latest `main`, named `<type>/<issue-number>-<slug>`:
+
+```
+fix/123-null-ledger-crash
+feat/145-parallel-worktrees
+docs/212-community-health-files
+chore/210-secret-scan
+test/165-cover-run-release
+```
+
+Spike branches (`spike/...`) are for throwaway research and are never merged.
+
+## Commit format
+
+Conventional Commits, with the driving issue referenced in the body or footer:
+
+```
+feat(autopilot): add worktree pool for parallel delivery
+
+Closes #145
+```
+
+- Types in use: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `perf`.
+- An optional scope in parentheses names the area (`autopilot`, `board`, `gates`, `agy`, …).
+- Reference the issue with `Closes #N` / `Fixes #N` (auto-closes on merge) or a plain `#N` for a related-but-not-closing link.
+
+`release` derives the CHANGELOG straight from these commits, so an accurate type and scope matter.
+
+## The gate ladder (what a PR is checked against)
+
+`ship` runs these in order; contributors should expect the same bar:
+
+| gate | checks |
+| --- | --- |
+| conventions | branch / commit / PR naming; spike branches never ship |
+| verify | `pnpm verify` is green locally |
+| plandrift | touched files stay within the plan's Files list (+ defaults) |
+| testintent | pre-existing assertions aren't silently weakened |
+| depguard | new deps exist, are ≥ 90 days old, and have ≥ 500 downloads |
+| acgate | every acceptance-criterion ID is covered by a passing test |
+| docsync | every doc under `docs/` is in the route index (`docs/README.md`); a new skill is in the handbook |
+| review / security | role-card review of the diff; criticals block |
+
+If you add or change a doc under `docs/`, add its one-line entry to `docs/README.md`. If you add a skill, mention it in `docs/guides/handbook.md`. These are enforced by the `docsync` gate.
+
+## How PRs are reviewed
+
+1. Open the PR against `main` using the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) — fill in the linked issue, the AC coverage, and the honest verification section.
+2. Two automated role passes run on the diff: a **reviewer** (correctness → simplification → efficiency) and a **security** pass (injection, secrets, supply chain, CI/hook surface). Both report severity-tagged findings; any critical/high must be resolved.
+3. `CODEOWNERS` requests the maintainer as reviewer automatically.
+4. The maintainer reviews and merges. PRs are squash-merged; keep the PR title in conventional-commit form since it becomes the squash commit.
+
+## Reporting bugs & proposing features
+
+Use the issue templates — [bug report](.github/ISSUE_TEMPLATE/) or feature request — so your report lands with the fields triage needs (repro/expected/actual for bugs; problem/proposal/acceptance criteria for features).
+
+## Code of conduct & security
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). To report a security vulnerability, follow [SECURITY.md](SECURITY.md) — **do not** open a public issue for security reports.
+
+## License
+
+forge is MIT-licensed. By contributing, you agree that your contributions are licensed under the same [MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,14 @@ You do **not** have to run the forge skills to contribute — but your PR is mea
 
 ## Branching
 
-Branch off the latest `main`, named `<type>/<issue-number>-<slug>`:
+Branch off the latest `main`, named `<type>/<issue-number>-<slug>` (the number is the issue you're closing; the slugs below are illustrative):
 
 ```
-fix/123-null-ledger-crash
-feat/145-parallel-worktrees
-docs/212-community-health-files
-chore/210-secret-scan
-test/165-cover-run-release
+fix/<n>-null-ledger-crash
+feat/<n>-parallel-worktrees
+docs/<n>-community-health-files
+chore/<n>-secret-scan
+test/<n>-cover-run-release
 ```
 
 Spike branches (`spike/...`) are for throwaway research and are never merged.
@@ -80,10 +80,11 @@ Closes #145
 
 ## The gate ladder (what a PR is checked against)
 
-`ship` runs these in order; contributors should expect the same bar:
+`ship` runs these in order; contributors should expect the same bar. The full authoritative ladder (including the `situation` gate and the final `CI green` check) is in the [handbook](docs/guides/handbook.md#6-the-gate-ladder-what-ship-runs-in-order):
 
 | gate | checks |
 | --- | --- |
+| situation | an active incident / security-response blocks non-hotfix ship |
 | conventions | branch / commit / PR naming; spike branches never ship |
 | verify | `pnpm verify` is green locally |
 | plandrift | touched files stay within the plan's Files list (+ defaults) |
@@ -92,6 +93,7 @@ Closes #145
 | acgate | every acceptance-criterion ID is covered by a passing test |
 | docsync | every doc under `docs/` is in the route index (`docs/README.md`); a new skill is in the handbook |
 | review / security | role-card review of the diff; criticals block |
+| CI green | never ask for merge on red |
 
 If you add or change a doc under `docs/`, add its one-line entry to `docs/README.md`. If you add a skill, mention it in `docs/guides/handbook.md`. These are enforced by the `docsync` gate.
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ A portable AI-dev-platform plugin for Claude Code: 20 pipeline skills in 5 lanes
 ## Laws worth knowing before you disagree with a gate
 
 Ticket-first, always — silent side-work is forbidden. Owner merges every PR. Situations (incident, security-response) change what's *allowed*, not what's suggested. Gates are mechanical scripts — run them, don't argue with them. `"Unknown" is a valid answer.`
+
+## Contributing
+
+Contributions follow forge's own pipeline. Start with the **[Contributing guide](CONTRIBUTING.md)** — setup, `pnpm verify`, branching/commit conventions, and how PRs are reviewed. All participation is governed by the **[Code of Conduct](CODE_OF_CONDUCT.md)**. To report a vulnerability, see **[SECURITY.md](SECURITY.md)** (private reporting — never a public issue). forge is [MIT](LICENSE)-licensed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+forge is a Claude Code plugin that automates a development pipeline — it runs
+scripts, hooks, and gates against a contributor's repository and GitHub board.
+We take the security of that surface seriously and appreciate reports made
+responsibly.
+
+## Supported versions
+
+forge is distributed through the Claude Code plugin marketplace and ships from
+`main`. Security fixes are applied to the latest released version. Always run the
+most recent release; older versions are not separately patched.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue, pull request, or discussion for a security
+vulnerability.** Public disclosure before a fix is available puts every user at
+risk.
+
+Report privately through **GitHub's private vulnerability reporting**:
+
+1. Go to the repository's **[Security tab](https://github.com/dngioidev/forge/security)**.
+2. Click **"Report a vulnerability"** to open a private security advisory.
+3. Describe the issue with the detail below.
+
+This channel is private between you and the maintainer — it does not expose any
+personal email address and keeps the report confidential until a fix ships.
+
+If you cannot use GitHub's private reporting, contact the maintainer
+**[@dngioidev](https://github.com/dngioidev)** through their GitHub profile to
+arrange a private disclosure channel.
+
+## What to include
+
+A good report lets us reproduce and assess quickly:
+
+- The affected component (a skill, gate, hook, board script, the graph MCP
+  server, a workflow, …) and version/commit.
+- A clear description of the vulnerability and its impact (e.g. command
+  injection, secret exposure, privilege escalation, supply-chain risk).
+- Step-by-step reproduction, including any configuration (`.claude/forge.json`)
+  or environment needed.
+- A proof of concept if you have one, and any suggested remediation.
+
+## What to expect
+
+- **Acknowledgement** within **3 business days** of your report.
+- An initial **assessment and severity triage** within **7 business days**.
+- Ongoing updates as we work a fix; we will coordinate a disclosure timeline
+  with you and credit you in the advisory unless you prefer to remain anonymous.
+- A published GitHub Security Advisory and release once the fix is available.
+
+## Scope
+
+In scope: the forge plugin code in this repository — skills, `plugin/scripts/**`
+(gates, hooks, board automation, the graph server), CI workflows, and shipped
+templates.
+
+Out of scope: vulnerabilities in Claude Code itself, GitHub, Node.js, pnpm, or
+third-party dependencies (report those upstream — though we welcome a heads-up if
+a dependency advisory affects forge). Findings that require an already-privileged
+local attacker or social engineering of the maintainer are generally out of
+scope.
+
+Thank you for helping keep forge and its users safe.


### PR DESCRIPTION
## What & why

None of the standard OSS community health files existed. This adds the full, forge-tailored set so outside contributors and users have what they need and GitHub surfaces them in the contribution UI.

Closes #212

## Files added
- `CONTRIBUTING.md` — Node/pnpm setup, `pnpm verify`, the forge pipeline + branching/commit conventions (conventional + issue ref), the gate ladder, and how PRs are reviewed.
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1; enforcement contact via GitHub private reporting + the `@dngioidev` handle (no personal email exposed).
- `SECURITY.md` — private vulnerability reporting via the Security tab, what to include, response expectations, and scope.
- `.github/ISSUE_TEMPLATE/{bug_report.yml,feature_request.yml}` — YAML issue forms mirroring forge's triage shape; `config.yml` disables blank issues and adds a private-security contact link.
- `.github/PULL_REQUEST_TEMPLATE.md` — linked-issue, AC-coverage, honest-verification, and conventions checklist.
- `.github/CODEOWNERS` — `* @dngioidev` as default reviewer (handle verified via `gh api`).
- `README.md` — links to CONTRIBUTING, CODE_OF_CONDUCT, SECURITY.

## Acceptance criteria
- [x] AC1: CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md exist, are forge-specific (not stubs), each with a real non-personal contact.
- [x] AC2: `.github/ISSUE_TEMPLATE/` has a bug + feature form and `.github/PULL_REQUEST_TEMPLATE.md` exists (valid GitHub issue-form YAML — renders in the UI).
- [x] AC3: CODEOWNERS exists; `@dngioidev` resolves as the repo owner and default reviewer.
- [x] AC4: README links to CONTRIBUTING and CODE_OF_CONDUCT (and SECURITY).

## Verification (honest)
- `pnpm verify` green locally — 42 files, 379 tests pass.
- CODEOWNERS handle confirmed to resolve via `gh api users/dngioidev` (User).
- All internal relative links checked to resolve (root files, `../` from `.github/`, `docs/guides/handbook.md` anchor).
- `docsync` gate scans only `docs/**`, so the new root-level docs correctly need no route-index entry (confirmed against `plugin/scripts/gates/docsync.mjs`).
- `forge:reviewer` and `forge:security` full-branch passes: both **pass**, zero critical/high. Security confirmed no personal email/secret leaked. The 4 minor reviewer findings were all addressed (Discussions link removed since Discussions is disabled; branch examples use placeholders; gate-ladder table completed + linked to handbook).
- **NOT verified locally:** live GitHub rendering of the issue forms (no local YAML/issue-form validator available — validated by careful manual read against GitHub's schema).

## CI note
CI is infra-down this run (Actions quota — jobs fail at startup with 0 steps, not a diff problem). Owner authorized a LOCAL-green bar for this run.