### PR TITLE
feat(runner): scaffold local self-hosted runner + private-only refusal (#224)

### DIFF
--- a/plugin/commands/init.md
+++ b/plugin/commands/init.md
@@ -20,6 +20,17 @@ Append `--statusline` when the user said yes in step 2.
 
 4. The script prints each action taken and finishes with a doctor report. Relay the summary: what was created vs adopted, the forge.json path, and any doctor warnings with their fix hints. If the script exits nonzero, report the error verbatim — do not improvise fixes to the board by hand; hand-built GraphQL is exactly what forge exists to remove.
 
+## `--runner` — scaffold a local self-hosted runner (ADR-0005, private repos only)
+
+`--runner` is a distinct mode: instead of the board bootstrap it scaffolds the local self-hosted-runner assets so a **private** repo gets free CI (ephemeral Linux container runner + JIT supervisor, native-Windows host-runner setup, and a trimmed `verify.yml` — PRs Linux-only on the `forge-local` label, Windows main-only + nightly). It **refuses on a public repo** (`gh repo view --json isPrivate`) — a self-hosted runner must never process fork PRs.
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/init.mjs" --runner
+node "${CLAUDE_PLUGIN_ROOT}/scripts/init.mjs" --runner --label my-box
+```
+
+It places assets under `runner/` (+ `.github/workflows/verify.yml`, or `verify.runner.yml` if one already exists), adds `**/.forge/`, `runner.env`, `*.runner.env` to `.gitignore` and the gitleaks allowlist, and prints the per-OS `~/.forge/runner.env` setup. It **never writes the PAT** — that fine-grained "Administration"-only token is set up out-of-band by the owner (see `runner/README.md`). Relay the printed owner steps.
+
 Notes:
 - Status options: on an empty project the standard 6-status set is created automatically; on a board with existing items, options are mapped as-is and missing ones must be added via the UI (ADR-0001).
 - The command needs gh authenticated with the `project` scope (`gh auth refresh -s project` if doctor flags it).

--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -15,23 +15,33 @@ import {
   findIssueByTitle, createIssue, toConfigField,
 } from './lib/board.mjs';
 import { runDoctor } from './doctor.mjs';
+import { runRunnerInit, parseArgs as parseRunnerArgs } from './runner/init.mjs';
 
 const DELIVERY_LOG_TITLE = 'Delivery log';
 
 export function parseArgs(argv) {
-  const args = { project: null, createProject: null, statusline: false, skipDoctor: false };
+  const args = { project: null, createProject: null, statusline: false, skipDoctor: false, runner: false, label: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--project') args.project = Number(argv[++i]);
     else if (a === '--create-project') args.createProject = argv[++i];
     else if (a === '--statusline') args.statusline = true;
     else if (a === '--skip-doctor') args.skipDoctor = true;
+    else if (a === '--runner') args.runner = true;
+    else if (a === '--label') args.label = argv[++i];
   }
   return args;
 }
 
 export async function runInit(ctx) {
   const { gh, cwd, log, args } = ctx;
+
+  // --runner is a distinct mode: scaffold the local self-hosted-runner assets
+  // (ADR-0005 AC2/AC3) instead of the board bootstrap. It has its own private-
+  // only refusal and never touches the project/board.
+  if (args.runner) {
+    return runRunnerInit({ gh, cwd }, parseRunnerArgs(args.label ? ['--label', args.label] : []), log);
+  }
   const actions = [];
   const say = (m) => { actions.push(m); log(m); };
 

--- a/plugin/scripts/runner/init.mjs
+++ b/plugin/scripts/runner/init.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * /forge:init --runner (ADR-0005 decisions 1/3/4, AC2/AC3): scaffold the local
+ * self-hosted-runner assets into a PRIVATE repo — ephemeral Linux Dockerfile +
+ * compose + JIT supervisor, the native-Windows host-runner setup, and a trimmed
+ * verify.yml — then wire the secret-store guards into .gitignore + gitleaks.
+ *
+ * REFUSES on a public repo (the fork-PR RCE guard). Never writes the PAT: it
+ * prints per-OS enable-time instructions for the out-of-band ~/.forge/runner.env
+ * store instead. Placement is missing-only, never overwrite (matches deploy-init).
+ */
+import { readdir, readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { join, dirname, resolve, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { run, makeGh } from '../lib/exec.mjs';
+import { loadConfig } from '../lib/config.mjs';
+
+const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DEFAULT_LABEL = 'forge-local';
+
+// .gitignore lines that keep the PAT store out of git (ADR-0005 decision 1).
+const GITIGNORE_ENTRIES = ['**/.forge/', 'runner.env', '*.runner.env'];
+// gitleaks allowlist path regexes marking the same store as an intentional,
+// out-of-band secret file (belt-and-suspenders alongside .gitignore).
+const GITLEAKS_REGEXES = [
+  String.raw`(^|/)\.forge/`,
+  String.raw`(^|/)runner\.env$`,
+  String.raw`(^|/)[^/]*\.runner\.env$`,
+];
+
+export function parseArgs(argv) {
+  const a = { label: DEFAULT_LABEL };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--label') a.label = argv[++i];
+    else if (argv[i] === '--runner') { /* mode flag consumed by init.mjs */ }
+  }
+  return a;
+}
+
+/** Scaffold file → destination in the consumer repo. */
+function destFor(rel) {
+  if (rel.startsWith('workflows/')) return join('.github', rel);
+  return join('runner', rel);
+}
+
+async function* walk(dir, base = dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(p, base);
+    else yield relative(base, p).replaceAll('\\', '/');
+  }
+}
+
+/** Idempotently ensure the gitleaks allowlist marks the runner.env store. */
+export function ensureGitleaksAllowlist(content, regexes = GITLEAKS_REGEXES) {
+  const missing = regexes.filter((r) => !content.includes(`'''${r}'''`));
+  if (missing.length === 0) return { changed: false, content };
+  const block = missing.map((r) => `  '''${r}''', # forge runner: out-of-band PAT store (never a real leak)`);
+  const lines = content.split(/\r?\n/);
+  const anchor = lines.findIndex((l) => /^\s*paths\s*=\s*\[/.test(l));
+  if (anchor !== -1) {
+    const line = lines[anchor];
+    const openIdx = line.indexOf('[');
+    const closeIdx = line.indexOf(']', openIdx);
+    if (closeIdx !== -1) {
+      // Single-line array `paths = [ … ]`: rewrite to multi-line so the new
+      // entries land INSIDE the array (splicing after the line would put bare
+      // strings outside the array — invalid TOML). Preserve existing entries.
+      const prefix = line.slice(0, openIdx); // e.g. "paths = "
+      const innerRaw = line.slice(openIdx + 1, closeIdx).trim().replace(/,\s*$/, '');
+      const suffix = line.slice(closeIdx + 1);
+      const kept = innerRaw ? [`  ${innerRaw},`] : [];
+      lines.splice(anchor, 1, `${prefix}[`, ...kept, ...block, `]${suffix}`);
+    } else {
+      // Multi-line array: insert right after the `paths = [` line.
+      lines.splice(anchor + 1, 0, ...block);
+    }
+    return { changed: true, content: lines.join('\n') };
+  }
+  // No paths array — append a scoped allowlist section.
+  const appended = `${content.trimEnd()}\n\n[allowlist]\ndescription = "forge runner PAT store — out-of-band, never committed"\npaths = [\n${block.join('\n')}\n]\n`;
+  return { changed: true, content: appended };
+}
+
+export async function runRunnerInit(ctx, args = parseArgs([]), log = console.log) {
+  const { cwd, gh } = ctx;
+
+  // AC2 — private-only refusal (fork-PR RCE guard). One repo-view call for
+  // visibility + owner/name, resolved FIRST, before any asset is written, so a
+  // public repo never gets runner wiring.
+  const view = await gh(['repo', 'view', '--json', 'isPrivate,owner,name'], { parseJson: true });
+  if (!view.ok) return { ok: false, error: `could not determine repo visibility (${view.stderr || 'gh repo view failed'})` };
+  if (view.json?.isPrivate !== true) {
+    return {
+      ok: false,
+      error: 'refusing to scaffold a self-hosted runner on a PUBLIC repo — forks can run untrusted code on your machine (GitHub fork-PR RCE). Runner support is private-repo only (ADR-0005).',
+    };
+  }
+  const repo = { owner: view.json.owner?.login, name: view.json.name };
+  if (!repo.owner || !repo.name) return { ok: false, error: 'could not read repo owner/name from gh repo view' };
+
+  // verify command from forge.json when present; safe default otherwise.
+  const cfg = await loadConfig(cwd);
+  const verify = cfg.config?.conventions?.verify ?? 'pnpm verify';
+  const label = args.label || DEFAULT_LABEL;
+
+  const substitute = (text) => text
+    .replaceAll('{{OWNER}}', repo.owner)
+    .replaceAll('{{REPO}}', repo.name)
+    .replaceAll('{{LABEL}}', label)
+    .replaceAll('{{VERIFY}}', verify);
+
+  const runnerTemplates = join(PLUGIN_ROOT, 'templates', 'runner');
+  const CANONICAL_VERIFY = join('.github', 'workflows', 'verify.yml');
+  const RUNNER_VARIANT = join('.github', 'workflows', 'verify.runner.yml');
+  const RUNNER_VERIFY_MARKER = 'forge local self-hosted-runner CI';
+  const placed = [];
+  const skipped = [];
+  const review = [];
+  for await (const rel of walk(runnerTemplates)) {
+    let destRel = destFor(rel);
+    const body = substitute(await readFile(join(runnerTemplates, rel), 'utf8'));
+    let isReview = false;
+    // The trimmed verify.yml IS the repo's verify workflow — but never clobber a
+    // user's existing one. If a verify.yml exists that we did NOT write (no forge
+    // runner marker), drop the runner variant beside it as verify.runner.yml for
+    // the operator to review + swap in. A verify.yml we already placed is ours,
+    // so a re-run skips it idempotently rather than diverting.
+    if (destRel === CANONICAL_VERIFY) {
+      const existing = await readFile(join(cwd, destRel), 'utf8').catch(() => null);
+      if (existing != null && !existing.includes(RUNNER_VERIFY_MARKER)) {
+        destRel = RUNNER_VARIANT;
+        isReview = true;
+      }
+    }
+    const dest = join(cwd, destRel);
+    try {
+      await stat(dest);
+      skipped.push(destRel);
+      continue; // never overwrite (matches deploy-init)
+    } catch { /* missing — place it */ }
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, body, 'utf8');
+    placed.push(destRel);
+    if (isReview) review.push(destRel);
+  }
+
+  // AC3 — .gitignore: keep the PAT store out of git.
+  const giPath = join(cwd, '.gitignore');
+  let gi = '';
+  try { gi = await readFile(giPath, 'utf8'); } catch { /* none yet */ }
+  const giLines = gi.split(/\r?\n/).map((l) => l.trim());
+  const giAdds = GITIGNORE_ENTRIES.filter((e) => {
+    if (giLines.includes(e)) return false;
+    // `.forge/` (written by plain forge:init) already ignores .forge at any depth,
+    // so don't add a redundant `**/.forge/` line when it's present.
+    if (e === '**/.forge/' && giLines.includes('.forge/')) return false;
+    return true;
+  });
+  if (giAdds.length) {
+    await writeFile(giPath, gi.trimEnd() + (gi.trim() ? '\n' : '') + giAdds.join('\n') + '\n', 'utf8');
+    log(`.gitignore: added ${giAdds.join(', ')}`);
+  }
+
+  // AC3 — gitleaks allowlist context (only when the repo uses gitleaks).
+  const glPath = join(cwd, '.gitleaks.toml');
+  try {
+    const gl = await readFile(glPath, 'utf8');
+    const next = ensureGitleaksAllowlist(gl);
+    if (next.changed) {
+      await writeFile(glPath, next.content, 'utf8');
+      log('.gitleaks.toml: allowlisted the runner.env store paths');
+    }
+  } catch {
+    log('.gitleaks.toml: not found — skipped (the .gitignore entries are the primary guard)');
+  }
+
+  for (const p of placed) log(`placed: ${p}`);
+  for (const s of skipped) log(`kept existing: ${s}`);
+  for (const r of review) log(`REVIEW: ${r} (an existing verify.yml was kept — compare and swap in the runner variant to move CI onto the local runner)`);
+
+  // AC3 — print the enable-time secret setup; NEVER write the secret itself.
+  log('');
+  log('next (owner steps — the secret is set up BY YOU, never by forge, ADR-0005 decision 1):');
+  log('  the one secret = a fine-grained PAT with ONLY "Administration: read & write", scoped to THIS private repo.');
+  log('  it lives out-of-band in ~/.forge/runner.env (gitignored, chmod 600) — never forge.json, a Docker secret, setx /M, or a shell global.');
+  log('');
+  log('  Linux / WSL2 (containerized runner):');
+  log('    mkdir -p ~/.forge && chmod 700 ~/.forge');
+  log('    printf "FORGE_RUNNER_PAT=<token>\\n" > ~/.forge/runner.env && chmod 600 ~/.forge/runner.env');
+  log('    register a systemd service with EnvironmentFile=%h/.forge/runner.env running runner/linux/supervisor.mjs');
+  log('');
+  log('  Windows (native host runner — default when a Windows box is present):');
+  log('    cd runner/windows; .\\setup-runner.ps1 -Install');
+  log('    register a service (e.g. NSSM) running .\\setup-runner.ps1 -Serve with AppEnvironmentExtra=FORGE_RUNNER_PAT=<token>');
+  log('    (route verify.yml Windows leg to the native runner by setting runs-on: [self-hosted, windows, ' + label + '])');
+  log('');
+  log('  full instructions: runner/README.md');
+
+  return { ok: true, placed, skipped, review };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const gh = makeGh(run);
+  runRunnerInit({ gh, cwd: process.cwd() }, parseArgs(process.argv.slice(2))).then((res) => {
+    if (!res.ok) { console.error(`init --runner failed: ${res.error}`); process.exit(1); }
+  }).catch((err) => { console.error(`init --runner failed: ${err.message}`); process.exit(1); });
+}

--- a/plugin/templates/runner/README.md
+++ b/plugin/templates/runner/README.md
@@ -1,0 +1,81 @@
+# forge local self-hosted runner
+
+Scaffolded by `forge:init --runner` (ADR-0005). **Private repositories only** — a
+self-hosted runner must never process fork/public-repo PRs (GitHub's documented
+fork-PR RCE risk), which is why `forge:init --runner` refuses on a public repo and
+why `verify.yml` keeps the `{{LABEL}}` runner off any untrusted code path.
+
+Free CI for private repos: Linux legs run at $0 on a local ephemeral container
+runner; the Windows leg runs on a native Windows host runner (default when a box
+is present) or trimmed hosted `windows-latest` (main + nightly) as the fallback.
+
+## The one secret — never committed
+
+Steady state uses **just-in-time (JIT) + `--ephemeral`**: a supervisor mints a
+one-hour, single-job runner config per job, so no runner credential outlives a
+job. The only stored secret is a **fine-grained PAT with just
+`Administration: read & write`, scoped to this one private repo**, used solely to
+mint JIT configs.
+
+It lives **only** in a gitignored, `chmod 600` file loaded as the runner
+service's environment — never in `forge.json`, a Docker `secret:`/build arg, a
+machine-level env var (`setx /M`, `/etc/environment`), or an interactive shell.
+
+`~/.forge/runner.env`:
+
+```
+FORGE_RUNNER_PAT=github_pat_xxxxxxxx   # fine-grained, Administration-only, this repo
+```
+
+```sh
+mkdir -p ~/.forge && chmod 700 ~/.forge
+# create the file, paste the token, then:
+chmod 600 ~/.forge/runner.env
+```
+
+`forge:init --runner` added `**/.forge/`, `runner.env`, and `*.runner.env` to
+`.gitignore` and the gitleaks allowlist context so the store can never be
+committed. `forge:doctor` (ticket #225) asserts it is gitignored, untracked, and
+`chmod 600`.
+
+## Enable — Linux / WSL2 (containerized runner)
+
+1. Build the image and confirm Docker + `gh` are on PATH.
+2. Register the supervisor as a **systemd** service that loads the secret as its
+   environment (never an interactive shell):
+
+   ```ini
+   # /etc/systemd/system/forge-runner.service
+   [Service]
+   EnvironmentFile=%h/.forge/runner.env
+   ExecStart=/usr/bin/node %h/<repo>/runner/linux/supervisor.mjs
+   Restart=always
+   ```
+
+   `systemctl --user enable --now forge-runner` (or a system unit under the
+   service account). The supervisor reads `FORGE_RUNNER_PAT` from the service
+   environment only.
+
+## Enable — native Windows host runner (default when a Windows box is present)
+
+1. `cd runner/windows; .\setup-runner.ps1 -Install` (downloads + checksum-verifies
+   the runner binary).
+2. Register a Windows service (e.g. NSSM) that runs `.\setup-runner.ps1 -Serve`
+   with the PAT supplied via the **service environment** — NSSM
+   `AppEnvironmentExtra=FORGE_RUNNER_PAT=<token>` reading your out-of-band store —
+   not `setx`, not this repo.
+3. To route `verify.yml`'s Windows leg to this native runner, change the
+   `test-windows` job's `runs-on` to `[self-hosted, windows, {{LABEL}}]`. Keep the
+   nightly hosted `windows-latest` drift check.
+
+## Isolation notes
+
+- **Linux:** ephemeral one-job-per-container (`docker compose run --rm`), fresh
+  workspace every job. The docker socket bind-mount is root-equivalent on the
+  host — acceptable only because the private-only guard keeps untrusted code off
+  the runner.
+- **Windows (native):** no per-job container teardown, so collaborator code runs
+  on the host. Mitigations: `--ephemeral` (one job per registration), `_work`
+  wiped between jobs, the hard private-only guard, and the concurrency cap.
+- **Concurrency cap:** set `FORGE_RUNNER_CONCURRENCY` (default 1) so a job can't
+  starve the box.

--- a/plugin/templates/runner/linux/Dockerfile
+++ b/plugin/templates/runner/linux/Dockerfile
@@ -1,0 +1,71 @@
+# forge local self-hosted runner — ephemeral Linux image (ADR-0005 decisions 1 + 3).
+#
+# One image, one job, then torn down: the supervisor mints a 1-hour JIT config
+# per job and runs this container with `--ephemeral` so no runner credential or
+# workspace state ever survives a job (`docker compose run --rm`).
+#
+# node + pnpm + gh + the docker CLI are baked in so every Linux leg of verify.yml
+# — pnpm verify, actionlint (docker://), plugin-validate — runs offline of hosted
+# CI. The docker socket is bind-mounted at run time (see docker-compose.yml), NOT
+# baked into the image, so this image holds no host credentials.
+#
+# NO SECRETS IN THIS IMAGE: the Administration-only PAT never enters a build arg
+# or layer — it lives only in the supervisor's service environment and is used
+# solely to mint the per-job JIT config, which is passed in at run time.
+#
+# Pin this to a digest before enabling (#227), e.g.
+#   FROM node:22-bookworm-slim@sha256:<digest> AS base
+# (forge's image convention is digest-pinned; kept as a tag here so the scaffold
+# never ships a fabricated/unresolvable digest.)
+FROM node:22-bookworm-slim AS base
+
+# Pin these before enabling (ADR-0005 / #227 dogfood): the runner release + its
+# published SHA-256. See https://github.com/actions/runner/releases
+ARG RUNNER_VERSION=2.328.0
+ARG RUNNER_SHA256=REPLACE-ME-with-the-published-actions-runner-linux-x64-sha256
+ARG TARGETARCH=x64
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUNNER_ALLOW_RUNASROOT=0 \
+    RUNNER_MANUALLY_TRAP_SIG=1
+
+# Runtime deps: git + the runner's own installdependencies, plus the docker CLI
+# (talks to the bind-mounted host socket) and gh. Pinned apt where the distro
+# provides it; docker-ce-cli + gh come from their vendor apt repos.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      ca-certificates curl gnupg git jq sudo lsb-release; \
+    install -m 0755 -d /etc/apt/keyrings; \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
+    chmod a+r /etc/apt/keyrings/docker.asc; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli.gpg; \
+    chmod a+r /etc/apt/keyrings/githubcli.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends docker-ce-cli gh; \
+    corepack enable; \
+    rm -rf /var/lib/apt/lists/*
+
+# Non-root runner user; the docker group lets it reach the bind-mounted socket.
+RUN groupadd -g 999 docker || true; \
+    useradd -m -s /bin/bash -G docker runner
+WORKDIR /home/runner/actions-runner
+
+# Download + checksum-verify the actions runner release, then run its dependency
+# installer. A mismatched checksum aborts the build (supply-chain guard).
+RUN set -eux; \
+    curl -fsSL -o runner.tar.gz \
+      "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${TARGETARCH}-${RUNNER_VERSION}.tar.gz"; \
+    echo "${RUNNER_SHA256}  runner.tar.gz" | sha256sum -c -; \
+    tar xzf runner.tar.gz; \
+    rm runner.tar.gz; \
+    ./bin/installdependencies.sh; \
+    chown -R runner:docker /home/runner/actions-runner
+
+COPY --chown=runner:docker entrypoint.sh /home/runner/entrypoint.sh
+RUN chmod +x /home/runner/entrypoint.sh
+
+USER runner
+ENTRYPOINT ["/home/runner/entrypoint.sh"]

--- a/plugin/templates/runner/linux/docker-compose.yml
+++ b/plugin/templates/runner/linux/docker-compose.yml
@@ -1,0 +1,29 @@
+# forge ephemeral Linux runner (ADR-0005 decisions 1 + 3).
+#
+# This service is NOT long-running. The supervisor (supervisor.mjs) invokes it
+# once per job via `docker compose run --rm runner`, injecting a freshly-minted
+# 1-hour JIT config as ENCODED_JIT_CONFIG. `--rm` + the runner's own ephemeral
+# one-job lifecycle guarantee no cross-job or cross-repo workspace state.
+#
+# NO SECRETS HERE: the Administration-only PAT is never referenced. Only the
+# per-job JIT config is passed in, and only at run time via the supervisor's
+# `-e ENCODED_JIT_CONFIG=…`. Do not add the PAT to `environment:` or a compose
+# `secret:` — both would widen its exposure beyond the supervisor's process.
+services:
+  runner:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: forge-local-runner:latest
+    # One job, then gone. The supervisor passes ENCODED_JIT_CONFIG per invocation.
+    environment:
+      ENCODED_JIT_CONFIG: ${ENCODED_JIT_CONFIG:?supervisor must inject a per-job JIT config}
+    # actionlint / other docker:// steps need the host docker daemon. The socket
+    # is a powerful grant (root-equivalent on the host) — private-repo, trusted-
+    # collaborator code only (enforced by the private-only refusal). See README.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    # Decision 3 hard concurrency cap is enforced by the supervisor; this keeps a
+    # single container from starving the box.
+    init: true
+    restart: "no"

--- a/plugin/templates/runner/linux/entrypoint.sh
+++ b/plugin/templates/runner/linux/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# forge ephemeral Linux runner entrypoint (ADR-0005 decision 3).
+#
+# Consumes the one-hour JIT config the supervisor minted for THIS job and runs a
+# single job (`--jitconfig` implies one-shot / ephemeral), then the container
+# exits and `docker compose run --rm` tears it down. No `config.sh remove` is
+# needed — a JIT runner auto-deregisters after its single job.
+set -euo pipefail
+
+if [[ -z "${ENCODED_JIT_CONFIG:-}" ]]; then
+  echo "forge-runner: ENCODED_JIT_CONFIG is empty — the supervisor must mint a JIT config per job" >&2
+  exit 1
+fi
+
+# The JIT config is a single-use, self-expiring credential (1h TTL, one job).
+# Do not echo it. run.sh consumes it and removes the runner registration on exit.
+exec ./run.sh --jitconfig "${ENCODED_JIT_CONFIG}"

--- a/plugin/templates/runner/linux/supervisor.mjs
+++ b/plugin/templates/runner/linux/supervisor.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * forge local runner supervisor (ADR-0005 decisions 1 + 3).
+ *
+ * Steady state = JIT + `--ephemeral`. For each free worker slot this loops:
+ *   1. mint a one-hour just-in-time runner config for one job
+ *      (POST /repos/{owner}/{repo}/actions/runners/generate-jitconfig), and
+ *   2. run a single-use `docker compose run --rm` container that consumes it.
+ * No runner credential outlives a job; a leaked JIT config self-expires in 1h.
+ *
+ * SECRET HANDLING (critical): the Administration-only PAT is read ONLY from this
+ * process's own environment (FORGE_RUNNER_PAT), which the runner *service* loads
+ * from the gitignored, chmod-600 ~/.forge/runner.env (systemd EnvironmentFile).
+ * The supervisor:
+ *   - passes it to `gh` via the child process env (GH_TOKEN), never on argv
+ *     (argv is world-readable via /proc/<pid>/cmdline);
+ *   - passes it to NOTHING else — the container only ever sees the JIT config;
+ *   - never logs it or the minted JIT config.
+ * Run this process under the service account, not an interactive shell, so the
+ * token never lands in an ambient shell environment.
+ *
+ * Zero runtime deps (forge zero-dependency principle). Requires `gh` + Docker on
+ * PATH. This is a scaffolded operational asset — enable it per runner/README.md.
+ */
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const OWNER = process.env.FORGE_RUNNER_OWNER || '{{OWNER}}';
+const REPO = process.env.FORGE_RUNNER_REPO || '{{REPO}}';
+const LABEL = process.env.FORGE_RUNNER_LABEL || '{{LABEL}}';
+const MAX_CONCURRENCY = Math.max(1, Number(process.env.FORGE_RUNNER_CONCURRENCY || '1'));
+const COMPOSE_DIR = dirname(fileURLToPath(import.meta.url));
+const PAT = process.env.FORGE_RUNNER_PAT;
+
+let stopping = false;
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => { stopping = true; log(`received ${sig} — draining, no new jobs will start`); });
+}
+
+function log(msg) {
+  // Never interpolate PAT / JIT config into a log line.
+  process.stdout.write(`[forge-runner ${new Date().toISOString()}] ${msg}\n`);
+}
+
+/** Run a command, capturing stdout. Extra env is merged into the child only. */
+function exec(cmd, args, { env = {}, capture = false } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, {
+      cwd: COMPOSE_DIR,
+      env: { ...process.env, ...env },
+      stdio: capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+    });
+    let out = '';
+    if (capture) child.stdout.on('data', (d) => { out += d; });
+    child.on('error', (err) => resolve({ ok: false, code: -1, stdout: '', error: err.message }));
+    child.on('close', (code) => resolve({ ok: code === 0, code, stdout: out }));
+  });
+}
+
+/**
+ * Mint a single-use JIT config for one job. The PAT is handed to gh via env
+ * (GH_TOKEN), never on the command line. Returns the encoded JIT config string.
+ */
+async function mintJitConfig() {
+  const name = `forge-local-${randomUUID().slice(0, 8)}`;
+  const res = await exec('gh', [
+    'api', '-X', 'POST', `/repos/${OWNER}/${REPO}/actions/runners/generate-jitconfig`,
+    '-f', `name=${name}`,
+    '-F', 'runner_group_id=1',
+    '-f', 'labels[]=self-hosted', '-f', 'labels[]=linux', '-f', `labels[]=${LABEL}`,
+    '-f', 'work_folder=_work',
+    '--jq', '.encoded_jit_config',
+  ], { env: { GH_TOKEN: PAT }, capture: true });
+  if (!res.ok) return { ok: false, error: `generate-jitconfig failed (exit ${res.code})` };
+  const jit = res.stdout.trim();
+  if (!jit) return { ok: false, error: 'generate-jitconfig returned no encoded_jit_config' };
+  return { ok: true, jit, name };
+}
+
+/** Run exactly one job in a fresh ephemeral container, then tear it down. */
+async function runOneJob() {
+  const minted = await mintJitConfig();
+  if (!minted.ok) { log(`mint failed: ${minted.error}`); return false; }
+  log(`minted JIT config for ${minted.name} — starting ephemeral container`);
+  const res = await exec('docker', ['compose', 'run', '--rm', 'runner'], {
+    env: { ENCODED_JIT_CONFIG: minted.jit },
+  });
+  log(`container for ${minted.name} exited (code ${res.code})`);
+  return true;
+}
+
+/** One worker slot: keep taking single jobs until asked to stop. */
+async function worker(slot) {
+  while (!stopping) {
+    const ok = await runOneJob();
+    if (!ok) await new Promise((r) => setTimeout(r, 10_000)); // back off on mint failure
+  }
+  log(`worker ${slot} drained`);
+}
+
+async function main() {
+  if (!PAT) {
+    log('FORGE_RUNNER_PAT is not set — load it from ~/.forge/runner.env into the service environment (see runner/README.md). Refusing to start.');
+    process.exit(1);
+  }
+  if (OWNER.startsWith('{{') || REPO.startsWith('{{')) {
+    log('owner/repo not substituted — re-run forge:init --runner in the target repo.');
+    process.exit(1);
+  }
+  log(`supervising ${OWNER}/${REPO} on label "${LABEL}", concurrency ${MAX_CONCURRENCY}`);
+  await Promise.all(Array.from({ length: MAX_CONCURRENCY }, (_, i) => worker(i + 1)));
+  log('all workers drained — exiting');
+}
+
+main().catch((err) => { log(`fatal: ${err.message}`); process.exit(1); });

--- a/plugin/templates/runner/windows/setup-runner.ps1
+++ b/plugin/templates/runner/windows/setup-runner.ps1
@@ -1,0 +1,104 @@
+<#
+  forge native Windows host runner (ADR-0005 decision 4, owner-amended).
+
+  When a Windows box is present this is the DEFAULT path for the Windows leg: a
+  native runner (no container) running `pnpm verify` on real Windows exactly as
+  the developer does. It registers `--ephemeral` (one job per registration) and
+  wipes _work between jobs; the hard private-only guard (never fork/public PRs)
+  plus the Decision-3 concurrency cap are the isolation contract for host-level
+  execution. Keep the nightly hosted windows-latest drift check in verify.yml.
+
+  SECRET HANDLING (critical): the Administration-only PAT is read ONLY from this
+  process's environment ($env:FORGE_RUNNER_PAT), which the Windows *service*
+  supplies (the service's own environment, or NSSM `AppEnvironmentExtra`) from an
+  out-of-band store — NEVER from this script, `forge.json`, a machine-level
+  `setx /M`, or an interactive-shell-global var. This script never writes the
+  secret. It is handed to `gh` via the child env (GH_TOKEN), never on argv, and
+  never logged.
+
+  Enable (run once to install the runner binary, then register the service):
+    1. gh auth is NOT used for minting — the service provides $env:FORGE_RUNNER_PAT.
+    2. .\setup-runner.ps1 -Install            # downloads + unpacks the runner
+    3. Register a Windows service (e.g. NSSM) that runs:  .\setup-runner.ps1 -Serve
+       with AppEnvironmentExtra=FORGE_RUNNER_PAT=<token from your secret store>
+  See runner/README.md for the full per-OS instructions.
+#>
+[CmdletBinding()]
+param(
+  [switch]$Install,
+  [switch]$Serve,
+  [string]$Owner = '{{OWNER}}',
+  [string]$Repo = '{{REPO}}',
+  [string]$Label = '{{LABEL}}',
+  [string]$RunnerVersion = '2.328.0',
+  # Pin the published SHA-256 for actions-runner-win-x64-<version>.zip before enabling (#227).
+  [string]$RunnerSha256 = 'REPLACE-ME-with-the-published-actions-runner-win-x64-sha256'
+)
+
+$ErrorActionPreference = 'Stop'
+$RunnerDir = Join-Path $PSScriptRoot 'actions-runner'
+
+function Write-Log([string]$Message) {
+  # Never interpolate the PAT or a JIT config into a log line.
+  Write-Host "[forge-runner $([DateTime]::UtcNow.ToString('o'))] $Message"
+}
+
+function Install-Runner {
+  New-Item -ItemType Directory -Force -Path $RunnerDir | Out-Null
+  $zip = Join-Path $env:TEMP "actions-runner-win-x64-$RunnerVersion.zip"
+  $url = "https://github.com/actions/runner/releases/download/v$RunnerVersion/actions-runner-win-x64-$RunnerVersion.zip"
+  Write-Log "downloading actions runner $RunnerVersion"
+  Invoke-WebRequest -Uri $url -OutFile $zip
+  $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash
+  if ($actual -ne $RunnerSha256.ToUpper()) {
+    throw "runner checksum mismatch: got $actual, expected $RunnerSha256 (supply-chain guard — refusing to install)"
+  }
+  Expand-Archive -Path $zip -DestinationPath $RunnerDir -Force
+  Remove-Item $zip -Force
+  Write-Log "runner unpacked to $RunnerDir"
+}
+
+function New-JitConfig {
+  $name = "forge-local-win-$([Guid]::NewGuid().ToString('N').Substring(0,8))"
+  # PAT to gh via child env (GH_TOKEN), never on the command line.
+  $prev = $env:GH_TOKEN
+  $env:GH_TOKEN = $env:FORGE_RUNNER_PAT
+  try {
+    $jit = & gh api -X POST "/repos/$Owner/$Repo/actions/runners/generate-jitconfig" `
+      -f "name=$name" -F 'runner_group_id=1' `
+      -f 'labels[]=self-hosted' -f 'labels[]=windows' -f "labels[]=$Label" `
+      -f 'work_folder=_work' --jq '.encoded_jit_config'
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($jit)) {
+      throw "generate-jitconfig failed (exit $LASTEXITCODE)"
+    }
+    return $jit.Trim()
+  } finally {
+    $env:GH_TOKEN = $prev
+  }
+}
+
+function Serve-Runner {
+  if (-not $env:FORGE_RUNNER_PAT) {
+    throw 'FORGE_RUNNER_PAT is not set — the service must supply it (NSSM AppEnvironmentExtra). Refusing to start.'
+  }
+  if ($Owner -like '{{*') { throw 'owner/repo not substituted — re-run forge:init --runner in the target repo.' }
+  Write-Log "serving $Owner/$Repo on label `"$Label`" (native ephemeral, one job per registration)"
+  Push-Location $RunnerDir
+  try {
+    while ($true) {
+      $jit = New-JitConfig
+      Write-Log 'minted JIT config — running one job'
+      # --jitconfig implies a single ephemeral job; the runner auto-deregisters after.
+      & .\run.cmd --jitconfig $jit
+      # Wipe the workspace between jobs (no per-job container teardown on native).
+      $work = Join-Path $RunnerDir '_work'
+      if (Test-Path $work) { Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+  } finally {
+    Pop-Location
+  }
+}
+
+if ($Install) { Install-Runner }
+elseif ($Serve) { Serve-Runner }
+else { Write-Log 'nothing to do — pass -Install or -Serve (see runner/README.md)' }

--- a/plugin/templates/runner/workflows/verify.yml
+++ b/plugin/templates/runner/workflows/verify.yml
@@ -1,0 +1,86 @@
+# forge local self-hosted-runner CI (ADR-0005 decisions 3 + 4).
+#
+# PRIVATE REPOS ONLY. A self-hosted runner must never process fork PRs — forge:init
+# --runner refuses on a public repo, and this workflow keeps the local `{{LABEL}}`
+# runner off any untrusted code path (see docs/security & GitHub's self-hosted-runner
+# security guidance).
+#
+# Cost model: Linux legs run for $0 on the local ephemeral container runner
+# (`{{LABEL}}` label). The Windows leg is trimmed to main + nightly on hosted
+# `windows-latest` (the fallback shape). When a native Windows host runner is
+# present (the ADR-0005 default), switch the `test-windows` job's `runs-on` to
+# `[self-hosted, windows, {{LABEL}}]` — see runner/README.md.
+name: verify
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Nightly hosted windows-latest drift check — catches "works on my box" host
+    # drift vs the clean hosted image even when Windows legs run locally.
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Linux legs — every PR + push, on the free local ephemeral runner.
+  test-linux:
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, {{LABEL}}]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: {{VERIFY}}
+
+  # Windows leg — main + nightly only (never on PRs). Hosted fallback; flip
+  # runs-on to the native self-hosted Windows runner when a box is present.
+  test-windows:
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: {{VERIFY}}
+
+  # actionlint runs a container (docker://) — the local runner mounts the docker
+  # socket so this works on the free runner exactly as on hosted.
+  actionlint:
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, {{LABEL}}]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: docker://rhysd/actionlint@sha256:1d74bfc9fd1963af8f89a7c22afaaafd42f49aad711a09951d02cb996398f61d # 1.7.7
+        with:
+          args: -color
+
+  plugin-validate:
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, {{LABEL}}]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - run: npm install -g @anthropic-ai/claude-code
+      - run: claude plugin validate ./plugin --strict

--- a/tests/runner.test.mjs
+++ b/tests/runner.test.mjs
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile, readdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runRunnerInit, parseArgs, ensureGitleaksAllowlist } from '../plugin/scripts/runner/init.mjs';
+import { runInit, parseArgs as parseInitArgs } from '../plugin/scripts/init.mjs';
+import { fakeGh } from './helpers/fakegh.mjs';
+
+const noop = () => {};
+
+// One repo-view call now returns isPrivate + owner + name together.
+const PRIVATE = { stdout: JSON.stringify({ isPrivate: true, owner: { login: 'dngioidev' }, name: 'forge' }) };
+const PUBLIC = { stdout: JSON.stringify({ isPrivate: false, owner: { login: 'dngioidev' }, name: 'forge' }) };
+
+function privateRoutes() {
+  return [[(j) => j.startsWith('repo view'), PRIVATE]];
+}
+
+async function tmpCwd() {
+  return mkdtemp(join(tmpdir(), 'forge-runner-'));
+}
+
+async function walkFiles(dir, base = dir, out = []) {
+  for (const e of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) await walkFiles(p, base, out);
+    else out.push(p);
+  }
+  return out;
+}
+
+describe('runner init — arg wiring', () => {
+  it('init.mjs parseArgs recognizes --runner and --label', () => {
+    expect(parseInitArgs(['--runner'])).toMatchObject({ runner: true });
+    expect(parseInitArgs(['--runner', '--label', 'my-box'])).toMatchObject({ runner: true, label: 'my-box' });
+  });
+
+  it('runner parseArgs defaults the label to forge-local', () => {
+    expect(parseArgs([])).toMatchObject({ label: 'forge-local' });
+    expect(parseArgs(['--label', 'x'])).toMatchObject({ label: 'x' });
+  });
+
+  it('runInit --runner short-circuits to the runner scaffold — no board bootstrap calls', async () => {
+    const cwd = await tmpCwd();
+    const { gh, calls } = fakeGh(privateRoutes());
+    const res = await runInit({ gh, cwd, log: noop, args: parseInitArgs(['--runner']) });
+    expect(res.ok).toBe(true);
+    expect(res.placed).toBeTruthy(); // runner-mode return shape, not board bootstrap
+    // the board flow (auth/project/issue) never runs
+    expect(calls.some((c) => c.startsWith('auth status'))).toBe(false);
+    expect(calls.some((c) => c.includes('project'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('issue'))).toBe(false);
+    await stat(join(cwd, 'runner', 'linux', 'Dockerfile'));
+  });
+});
+
+describe('AC2 — private-repo scaffold', () => {
+  it('places the ephemeral Linux runner, Windows setup, and trimmed verify.yml with substitutions', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh(privateRoutes());
+    const res = await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    expect(res.ok).toBe(true);
+
+    // ephemeral Linux container runner assets
+    const dockerfile = await readFile(join(cwd, 'runner', 'linux', 'Dockerfile'), 'utf8');
+    expect(dockerfile).toContain('actions-runner'); // runner baked in
+    expect(dockerfile).toContain('corepack enable'); // pnpm
+    expect(dockerfile).toContain('gh'); // gh baked in
+    expect(dockerfile).toContain('sha256sum -c'); // checksum-verified download (supply chain)
+
+    const compose = await readFile(join(cwd, 'runner', 'linux', 'docker-compose.yml'), 'utf8');
+    expect(compose).toContain('/var/run/docker.sock:/var/run/docker.sock'); // socket mount for actionlint
+    expect(compose).toContain('ENCODED_JIT_CONFIG'); // JIT config injected per job
+    expect(compose).not.toContain('FORGE_RUNNER_PAT'); // no PAT in compose
+    expect(compose).not.toMatch(/^\s*secrets:/m); // no compose secrets block
+
+    const supervisor = await readFile(join(cwd, 'runner', 'linux', 'supervisor.mjs'), 'utf8');
+    expect(supervisor).toContain('generate-jitconfig'); // mints 1h JIT per job
+    expect(supervisor).toContain("'--rm'"); // single-use container
+    expect(supervisor).toContain('dngioidev'); // owner substituted
+    expect(supervisor).toContain('forge-local'); // label substituted
+
+    await stat(join(cwd, 'runner', 'linux', 'entrypoint.sh'));
+    const ps1 = await readFile(join(cwd, 'runner', 'windows', 'setup-runner.ps1'), 'utf8');
+    expect(ps1).toContain('Get-FileHash'); // checksum-verified windows runner download
+    expect(ps1).toContain('forge-local');
+
+    await stat(join(cwd, 'runner', 'README.md'));
+
+    // trimmed verify.yml — PRs Linux-only on forge-local; Windows main+nightly
+    const verify = await readFile(join(cwd, '.github', 'workflows', 'verify.yml'), 'utf8');
+    expect(verify).toContain('self-hosted, linux, forge-local');
+    expect(verify).toContain("if: github.event_name != 'pull_request'"); // windows off PRs
+    expect(verify).toContain('windows-latest'); // hosted fallback + nightly drift
+    expect(verify).toContain('schedule:'); // nightly drift check
+    expect(verify).toContain('pnpm verify'); // {{VERIFY}} substituted
+    for (const token of ['{{OWNER}}', '{{REPO}}', '{{LABEL}}', '{{VERIFY}}']) {
+      expect(verify).not.toContain(token);
+    }
+  });
+
+  it('uses conventions.verify from forge.json and a custom --label', async () => {
+    const cwd = await tmpCwd();
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify({
+      board: { projectNumber: 8, projectId: 'PVT_x', fields: {
+        status: { id: 'PVTSSF_1', options: { backlog: 'a' } }, priority: { id: 'PVTSSF_2', options: { p0: 'b' } },
+        size: { id: 'PVTSSF_3', options: { s: 'c' } }, type: { id: 'PVTSSF_4', options: { epic: 'd' } },
+      } }, conventions: { verify: 'npm test' },
+    }), 'utf8');
+    const { gh } = fakeGh(privateRoutes());
+    await runRunnerInit({ gh, cwd }, parseArgs(['--label', 'my-box']), noop);
+    const verify = await readFile(join(cwd, '.github', 'workflows', 'verify.yml'), 'utf8');
+    expect(verify).toContain('self-hosted, linux, my-box');
+    expect(verify).toContain('npm test');
+    expect(verify).not.toContain('forge-local');
+  });
+
+  it('never overwrites an existing verify.yml — drops verify.runner.yml for review', async () => {
+    const cwd = await tmpCwd();
+    await mkdir(join(cwd, '.github', 'workflows'), { recursive: true });
+    await writeFile(join(cwd, '.github', 'workflows', 'verify.yml'), '# user CI\n', 'utf8');
+    const { gh } = fakeGh(privateRoutes());
+    const res = await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    expect(res.ok).toBe(true);
+    expect(await readFile(join(cwd, '.github', 'workflows', 'verify.yml'), 'utf8')).toBe('# user CI\n');
+    const variant = await readFile(join(cwd, '.github', 'workflows', 'verify.runner.yml'), 'utf8');
+    expect(variant).toContain('self-hosted, linux, forge-local');
+    expect(res.review).toContain(join('.github', 'workflows', 'verify.runner.yml'));
+  });
+
+  it('re-run is a no-op — all assets kept, none re-placed', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh(privateRoutes());
+    await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    const second = await runRunnerInit({ gh: fakeGh(privateRoutes()).gh, cwd }, parseArgs([]), noop);
+    expect(second.ok).toBe(true);
+    expect(second.placed).toEqual([]);
+  });
+});
+
+describe('AC2 — public-repo refusal (fork-PR RCE guard)', () => {
+  it('refuses on a public repo with a clear message and writes nothing', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh([[(j) => j.startsWith('repo view'), PUBLIC]]);
+    const res = await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/public repo/i);
+    expect(res.error).toMatch(/private-repo only|fork/i);
+    // no assets written
+    await expect(stat(join(cwd, 'runner'))).rejects.toBeTruthy();
+    await expect(stat(join(cwd, '.github'))).rejects.toBeTruthy();
+  });
+
+  it('errors when visibility cannot be determined', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh([[(j) => j.startsWith('repo view'), { ok: false, stderr: 'boom' }]]);
+    const res = await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/visibility/i);
+  });
+});
+
+describe('AC3 — secret-store guards, no secret committed', () => {
+  it('adds the runner.env store to .gitignore (idempotent)', async () => {
+    const cwd = await tmpCwd();
+    await writeFile(join(cwd, '.gitignore'), 'node_modules/\n', 'utf8');
+    const { gh } = fakeGh(privateRoutes());
+    await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    let gi = await readFile(join(cwd, '.gitignore'), 'utf8');
+    for (const e of ['**/.forge/', 'runner.env', '*.runner.env']) expect(gi).toContain(e);
+    expect(gi).toContain('node_modules/'); // preserved
+
+    // re-run does not duplicate
+    await runRunnerInit({ gh: fakeGh(privateRoutes()).gh, cwd }, parseArgs([]), noop);
+    gi = await readFile(join(cwd, '.gitignore'), 'utf8');
+    expect(gi.match(/^runner\.env$/gm).length).toBe(1);
+  });
+
+  it('adds the store paths to an existing gitleaks allowlist (idempotent)', async () => {
+    const cwd = await tmpCwd();
+    await writeFile(join(cwd, '.gitleaks.toml'), '[extend]\nuseDefault = true\n\n[allowlist]\ndescription = "x"\npaths = [\n  \'\'\'AKIAEXAMPLE\'\'\',\n]\n', 'utf8');
+    const { gh } = fakeGh(privateRoutes());
+    await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    const gl = await readFile(join(cwd, '.gitleaks.toml'), 'utf8');
+    expect(gl).toContain('runner\\.env$');
+    expect(gl).toContain('.forge/');
+
+    // ensureGitleaksAllowlist is idempotent
+    const again = ensureGitleaksAllowlist(gl);
+    expect(again.changed).toBe(false);
+  });
+
+  it('ensureGitleaksAllowlist appends an allowlist when no paths array exists', () => {
+    const { changed, content } = ensureGitleaksAllowlist('title = "cfg"\n[extend]\nuseDefault = true\n');
+    expect(changed).toBe(true);
+    expect(content).toMatch(/\[allowlist\]/);
+    expect(content).toContain('runner\\.env$');
+  });
+
+  it('ensureGitleaksAllowlist handles a SINGLE-LINE paths array without corrupting TOML', () => {
+    const { changed, content } = ensureGitleaksAllowlist('[allowlist]\npaths = ["AKIAEXAMPLE"]\n');
+    expect(changed).toBe(true);
+    // rewritten to a valid multi-line array: existing entry kept INSIDE the array,
+    // new entries before the closing bracket (no bare strings outside the array).
+    expect(content).toContain('runner\\.env$');
+    const open = content.indexOf('paths = [');
+    const close = content.indexOf(']', open);
+    const inner = content.slice(open, close);
+    expect(inner).toContain('AKIAEXAMPLE'); // kept
+    expect(inner).toContain('runner\\.env$'); // new entry is inside the array
+    // idempotent on the rewritten form
+    expect(ensureGitleaksAllowlist(content).changed).toBe(false);
+  });
+
+  it('gitleaks step is skipped gracefully when the repo has no .gitleaks.toml', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh(privateRoutes());
+    const res = await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    expect(res.ok).toBe(true);
+    await expect(stat(join(cwd, '.gitleaks.toml'))).rejects.toBeTruthy(); // not created
+  });
+
+  it('writes NO secret: no runner.env created, no PAT-shaped token in any placed file', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh(privateRoutes());
+    await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+    // init never writes the secret store itself
+    await expect(stat(join(cwd, '.forge', 'runner.env'))).rejects.toBeTruthy();
+    await expect(stat(join(cwd, 'runner.env'))).rejects.toBeTruthy();
+    // no committed file carries a real PAT-shaped token value
+    const files = await walkFiles(cwd);
+    for (const f of files) {
+      const body = await readFile(f, 'utf8');
+      expect(body).not.toMatch(/github_pat_[A-Za-z0-9_]{20,}/);
+      expect(body).not.toMatch(/ghp_[A-Za-z0-9]{30,}/);
+    }
+  });
+});


### PR DESCRIPTION
Closes #224. Refs #180.

Implements **ADR-0005 AC2 + AC3** (decisions 1/3/4, incl. both owner amendments): `forge:init --runner` scaffolds a local self-hosted GitHub Actions runner for a **private** repo, and refuses on a public one.

## Acceptance criteria

### AC2 — scaffold runner assets (private repo only)
- [x] Ephemeral **Linux container runner** — node/pnpm/gh baked in, docker socket mounted for `actionlint`/`plugin-validate` → `plugin/templates/runner/linux/{Dockerfile,docker-compose.yml,entrypoint.sh}`
- [x] **JIT supervisor** — mints a 1-hour `generate-jitconfig` per job, runs single-use `--ephemeral` containers, concurrency-capped → `supervisor.mjs`
- [x] **Native-Windows host runner** setup (Windows service, `--ephemeral`) → `windows/setup-runner.ps1`
- [x] **Trimmed `verify.yml`** — PRs Linux-only on `forge-local`; Windows main-only + nightly hosted drift check → `workflows/verify.yml`
- [x] **REFUSE on a public repo** (`gh repo view --json isPrivate`) — the fork-PR RCE guard, resolved before any file is written
- Tests → `tests/runner.test.mjs` "AC2 — private-repo scaffold" / "AC2 — public-repo refusal"

### AC3 — no secret in any committed file
- [x] `init` only **prints** per-OS `~/.forge/runner.env` setup; **never writes the PAT**
- [x] Adds `**/.forge/`, `runner.env`, `*.runner.env` to `.gitignore` **and** the gitleaks allowlist context (single-line + multi-line TOML handled)
- Tests → `tests/runner.test.mjs` "AC3 — secret-store guards, no secret committed"

## Design notes (per ADR-0005)
- **PAT store (Decision 1, amended):** fine-grained *Administration-only* PAT lives out-of-band in gitignored, chmod-600 `~/.forge/runner.env`, loaded only as the runner **service** env (systemd `EnvironmentFile` / NSSM `AppEnvironmentExtra`). Passed to `gh` via `GH_TOKEN` in the child env — never argv, never logged, never `forge.json`/Docker secret/machine-level env.
- **Windows (Decision 4, amended):** native host runner scaffolded as the default path; generated `verify.yml` keeps hosted-Windows trimmed (main + nightly `schedule:`) as the fallback + retains the nightly `windows-latest` drift check.
- **Isolation (Decision 3):** ephemeral one-job-per-container on the `forge-local` label; docker-socket bind-mount documented and gated by the private-only guard.
- **Wiring:** `--runner` is a distinct mode in `plugin/scripts/init.mjs` that short-circuits the board bootstrap. Existing `verify.yml` is never clobbered — the runner variant lands as `verify.runner.yml` for review.

## Verification
- `pnpm verify` — **394 tests green** (43 files), including 15 new AC-mapped runner tests.
- `claude plugin validate ./plugin --strict` — passes.
- Generated `verify.yml` sanity-checked after substitution (valid GHA YAML; no orphaned `{{…}}` tokens; GitHub `${{ }}` expressions preserved).
- **Reviews:** `forge:security` → **pass** (no critical/high; PAT handling, private-only ordering, supply-chain checksums, gitignore/gitleaks all confirmed). `forge:reviewer` → one **major** (single-line-TOML gitleaks corruption) **fixed** + 3 minors addressed (merged `gh repo view` call, gitignore redundancy guard, end-to-end `runInit --runner` short-circuit test).

## Out of scope (follow-ups)
- #225 — `doctor` runner-health check (registered/online + store gitignored/untracked/chmod-600).
- #226 — `forge.json` `runner` block + docs.
- #227 — end-to-end dogfood (owner provisions the box + mints the PAT; pins the `REPLACE-ME` runner checksums + base-image digest, which fail closed until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
