### PR TITLE
feat(runner): forge.json `runner` block + validation + docs (#226)

### DIFF
--- a/docs/guides/handbook.md
+++ b/docs/guides/handbook.md
@@ -109,6 +109,21 @@ Rollback = redeploy the previous digest (one command, runbook). Migrations are f
 | `team` | members, roles, approval policy (solo default: you are maintainer of everything) |
 | `features` | deploy · graph · designReview · e2e — all off by default |
 | `deploy` | environments chain, healthcheck, registry |
+| `runner` | local self-hosted runner config (labels · sharing · windows · advancedCi) — off by default, PRIVATE repos only (see below) |
+
+### Local self-hosted runner (ADR-0005)
+
+Opt-in, **private-repo-only** free CI on a local GitHub Actions runner. `/forge:init --runner` scaffolds the assets (ephemeral Linux container + JIT supervisor, native-Windows host setup, trimmed `verify.yml`) and **refuses on a public repo** — a fork could run untrusted code on your machine (GitHub's fork-PR RCE). If the repo ever goes public, remove the runner wiring. The one secret (a fine-grained *Administration*-only PAT) lives **only** in a gitignored, `chmod 600` `~/.forge/runner.env` loaded as the runner service's env — never in `forge.json`. The `runner` block records config, not secrets:
+
+| field | default | meaning |
+| --- | --- | --- |
+| `enabled` | `false` | master switch — absent/`false` means no local runner |
+| `labels` | `["self-hosted","linux","forge-local"]` | labels the runner registers with and `verify.yml` targets |
+| `sharing` | `"repo"` | `"repo"` = one box, one registration **per private repo** (solo default); `"org"` = one org-runner-group registration serves all repos (team, needs a free org) |
+| `windows` | `"native"` | `"native"` runs the Windows leg on a native host runner at $0 (default when a Windows box is present); `"hosted"` is the fallback (PRs Linux-only, Windows on main + nightly drift check) |
+| `advancedCi` | all `false` | owner-gated upside — `linuxMatrix`, `deploySmoke` (build + `terraform plan`, never `apply`), `nightly` (maintain + graph reindex + security sweep) |
+
+**Solo vs. team:** `sharing: "repo"` is the honest solo default (GitHub runner *groups* are org/enterprise-only, so a personal account shares one box by registering it per repo). `sharing: "org"` is the only path GitHub calls true sharing and requires moving the repos into a (free) org. Full setup: [install guide](install.md#local-self-hosted-runner-runner-block--private-repos-only) and `runner/README.md`.
 
 ## 11. When something's wrong
 

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -52,6 +52,41 @@ Run it after init and any time something feels off. ✗ items block work and say
 
 **Theme (optional):** `/theme` → **Forge (smithy)** for forge's ember-on-steel identity.
 
+### Local self-hosted runner (`runner` block — PRIVATE repos only)
+
+Private repos have a metered monthly Actions-minute cap (Windows bills at 2×). A local self-hosted runner drops that GitHub bill to $0 and lets you afford heavier pipelines (ADR-0005). `/forge:init --runner` scaffolds the runner assets (see [handbook](handbook.md#local-self-hosted-runner-adr-0005) and `runner/README.md`); this section covers the **`runner` block in `.claude/forge.json`** that records the config those assets read.
+
+> **Security rule — private repos only.** A self-hosted runner must **never** process fork/public-repo PRs: a fork can run untrusted code on your machine (GitHub's documented fork-PR RCE). `/forge:init --runner` **refuses on a public repo**, and if this repo ever goes public the runner wiring must be removed. Do not enable a runner on anything a stranger can open a PR against.
+
+Add the block only if you run a local runner — it is entirely optional and off by default:
+
+```jsonc
+// .claude/forge.json
+"runner": {
+  "enabled": true,                                  // default false — runner off until you opt in
+  "labels": ["self-hosted", "linux", "forge-local"], // routing labels the workflow targets
+  "sharing": "repo",                                // "repo" (default, solo) | "org" (team, opt-in)
+  "windows": "native",                              // "native" (default when a Windows box is present) | "hosted" (fallback)
+  "advancedCi": {                                   // decision 5 — all off by default, owner-gated (may spend money)
+    "linuxMatrix": false,
+    "deploySmoke": false,
+    "nightly": false
+  }
+}
+```
+
+| field | default | meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Master switch. Absent or `false` = no local runner. |
+| `labels` | `["self-hosted","linux","forge-local"]` | Labels the runner registers with and `verify.yml` targets, so jobs route to your box and only your box. |
+| `sharing` | `"repo"` | `"repo"` registers the one physical box **per private repo** (solo/personal accounts — N registrations, zero org setup). `"org"` points at an org runner group so **one** registration serves all repos — the only path GitHub calls true sharing, and it needs a (free) org. |
+| `windows` | `"native"` | `"native"` runs the Windows leg on a native Windows host runner at $0 (default when you develop on Windows). `"hosted"` is the fallback when no Windows box exists — PRs run Linux-only locally, Windows trims to main + a nightly hosted drift check. |
+| `advancedCi.*` | all `false` | Optional upside (decision 5): `linuxMatrix` (full Linux matrix per PR), `deploySmoke` (build + `terraform plan`, never `apply`), `nightly` (maintain + graph reindex + security sweep). Off by default because anything that provisions infra or hits a paid API is **owner-gated**. |
+
+**Solo vs. team boundary (honest):** on a personal account, `sharing: "repo"` is the real default — "many repos on one box" is achieved operationally (one machine, one registration per repo), because GitHub runner *groups* are an org/enterprise construct. True one-registration-serves-many sharing (`sharing: "org"`) requires moving the private repos into a (free) org. Pick `repo` unless you already run an org.
+
+Malformed values are rejected by `/forge:doctor` and any config load (e.g. `sharing: "enterprise"`, a non-boolean `enabled`); omitted fields take the defaults above.
+
 ## 5. Working in it
 
 Everything is ticket-first: `/forge:ticket` for quick triage, then the lane skills (ideate → brainstorm → design → plan → execute → ship → release; hotfix/respond/maintain for care). `forge board status` (or the status line) is the one-glance catch-up. The owner merges every PR — agents never do.

--- a/plugin/scripts/lib/config.mjs
+++ b/plugin/scripts/lib/config.mjs
@@ -6,6 +6,51 @@ export const CONFIG_RELPATH = join('.claude', 'forge.json');
 const FIELD_KEYS = ['status', 'priority', 'size', 'type'];
 const OPTIONAL_FIELD_KEYS = ['phase', 'area']; // #114/#146: consumer-defined single-selects, mapped by init when the project has them
 
+// ADR-0005 (#226/AC5) — local self-hosted runner config block.
+const RUNNER_SHARING = ['repo', 'org']; // decision 2: per-repo default, org opt-in
+const RUNNER_WINDOWS = ['native', 'hosted']; // decision 4: native default (box present), hosted fallback
+const RUNNER_ADVANCED_KEYS = ['linuxMatrix', 'deploySmoke', 'nightly']; // decision 5: owner-gated CI upside
+
+/**
+ * Documented defaults for the ADR-0005 `runner` block (spec #226/AC5). A runner
+ * is off until explicitly enabled; when on, it registers the standard forge-local
+ * label set, shares per-repo (solo default; `org` is the opt-in team path), and
+ * takes the Windows leg on a native host runner (falling back to `hosted` when no
+ * Windows box is present). Advanced-CI toggles (decision 5) are all off — anything
+ * that could spend money stays owner-gated.
+ */
+export const RUNNER_DEFAULTS = Object.freeze({
+  enabled: false,
+  labels: Object.freeze(['self-hosted', 'linux', 'forge-local']),
+  sharing: 'repo',
+  windows: 'native',
+});
+
+/**
+ * Resolve a `runner` block to its effective config: the documented defaults filled
+ * in for every field the consumer omitted. An absent/non-object block resolves to
+ * all defaults (runner disabled). Assumes validateConfig already rejected malformed
+ * shapes; any value that is still the wrong type falls back to its default rather
+ * than propagating, so callers (init/doctor) always see a well-formed block.
+ */
+export function normalizeRunner(runner) {
+  const r = (runner && typeof runner === 'object' && !Array.isArray(runner)) ? runner : {};
+  const adv = (r.advancedCi && typeof r.advancedCi === 'object' && !Array.isArray(r.advancedCi)) ? r.advancedCi : {};
+  return {
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : RUNNER_DEFAULTS.enabled,
+    labels: (Array.isArray(r.labels) && r.labels.length > 0 && r.labels.every((l) => typeof l === 'string' && l.trim().length > 0))
+      ? [...r.labels]
+      : [...RUNNER_DEFAULTS.labels],
+    sharing: RUNNER_SHARING.includes(r.sharing) ? r.sharing : RUNNER_DEFAULTS.sharing,
+    windows: RUNNER_WINDOWS.includes(r.windows) ? r.windows : RUNNER_DEFAULTS.windows,
+    advancedCi: {
+      linuxMatrix: adv.linuxMatrix === true,
+      deploySmoke: adv.deploySmoke === true,
+      nightly: adv.nightly === true,
+    },
+  };
+}
+
 /**
  * Structural validation of .claude/forge.json — plain checks, no schema
  * library (zero-dependency principle, spec §2). Returns every problem it
@@ -114,6 +159,38 @@ export function validateConfig(cfg) {
     }
   }
 
+  // ADR-0005 (#226/AC5) — optional `runner` block. Validated only when present;
+  // absent means "no local runner", which is the safe default.
+  if (cfg.runner !== undefined) {
+    const r = cfg.runner;
+    if (typeof r !== 'object' || r === null || Array.isArray(r)) {
+      push('runner: must be an object');
+    } else {
+      if (r.enabled !== undefined && typeof r.enabled !== 'boolean') push('runner.enabled: must be a boolean');
+      if (r.labels !== undefined) {
+        if (!Array.isArray(r.labels) || r.labels.length === 0) {
+          push('runner.labels: must be a non-empty array of label strings');
+        } else {
+          r.labels.forEach((l, i) => {
+            if (typeof l !== 'string' || l.trim().length === 0) push(`runner.labels[${i}]: must be a non-empty string`);
+          });
+        }
+      }
+      if (r.sharing !== undefined && !RUNNER_SHARING.includes(r.sharing)) push('runner.sharing: must be "repo" or "org"');
+      if (r.windows !== undefined && !RUNNER_WINDOWS.includes(r.windows)) push('runner.windows: must be "native" or "hosted"');
+      if (r.advancedCi !== undefined) {
+        if (typeof r.advancedCi !== 'object' || r.advancedCi === null || Array.isArray(r.advancedCi)) {
+          push('runner.advancedCi: must be an object');
+        } else {
+          for (const [k, v] of Object.entries(r.advancedCi)) {
+            if (!RUNNER_ADVANCED_KEYS.includes(k)) push(`runner.advancedCi.${k}: unknown toggle (valid: ${RUNNER_ADVANCED_KEYS.join(', ')})`);
+            else if (typeof v !== 'boolean') push(`runner.advancedCi.${k}: must be a boolean`);
+          }
+        }
+      }
+    }
+  }
+
   return { ok: errors.length === 0, errors };
 }
 
@@ -133,5 +210,7 @@ export async function loadConfig(cwd) {
     return { ok: false, missing: false, errors: [`${CONFIG_RELPATH} is not valid JSON: ${err.message}`], config: null };
   }
   const v = validateConfig(cfg);
-  return { ok: v.ok, missing: false, errors: v.errors, config: cfg };
+  // #226/AC5: expose the runner block with documented defaults applied, so
+  // init/doctor read one well-formed shape regardless of what the file omitted.
+  return { ok: v.ok, missing: false, errors: v.errors, config: cfg, runner: normalizeRunner(cfg?.runner) };
 }

--- a/tests/lib/config.test.mjs
+++ b/tests/lib/config.test.mjs
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { validateConfig, loadConfig } from '../../plugin/scripts/lib/config.mjs';
+import { validateConfig, loadConfig, normalizeRunner, RUNNER_DEFAULTS } from '../../plugin/scripts/lib/config.mjs';
 
 function validCfg() {
   return {
@@ -104,6 +104,93 @@ describe('validateConfig', () => {
     const r = validateConfig(cfg);
     expect(r.errors.some((e) => e.includes('maintainer'))).toBe(true);
   });
+
+  // ADR-0005 #226/AC5 — the optional `runner` block.
+  it('AC5: accepts an absent runner block (runner off is the default)', () => {
+    expect(validateConfig(validCfg()).ok).toBe(true);
+  });
+
+  it('AC5: accepts a well-formed runner block', () => {
+    const cfg = validCfg();
+    cfg.runner = {
+      enabled: true,
+      labels: ['self-hosted', 'linux', 'forge-local'],
+      sharing: 'repo',
+      windows: 'native',
+      advancedCi: { linuxMatrix: true, deploySmoke: false, nightly: true },
+    };
+    expect(validateConfig(cfg)).toEqual({ ok: true, errors: [] });
+  });
+
+  it('AC5: rejects malformed runner values (enabled, sharing, windows, labels)', () => {
+    const cfg = validCfg();
+    cfg.runner = { enabled: 'yes', sharing: 'enterprise', windows: 'linux', labels: ['ok', ''] };
+    const r = validateConfig(cfg);
+    expect(r.ok).toBe(false);
+    expect(r.errors).toContain('runner.enabled: must be a boolean');
+    expect(r.errors).toContain('runner.sharing: must be "repo" or "org"');
+    expect(r.errors).toContain('runner.windows: must be "native" or "hosted"');
+    expect(r.errors.some((e) => e.includes('runner.labels[1]'))).toBe(true);
+  });
+
+  it('AC5: rejects a non-object runner block and an empty labels array', () => {
+    const asArray = validCfg(); asArray.runner = [];
+    expect(validateConfig(asArray).errors).toContain('runner: must be an object');
+
+    const emptyLabels = validCfg(); emptyLabels.runner = { labels: [] };
+    expect(validateConfig(emptyLabels).errors).toContain('runner.labels: must be a non-empty array of label strings');
+  });
+
+  it('AC5: rejects unknown / non-boolean advancedCi toggles', () => {
+    const unknown = validCfg(); unknown.runner = { advancedCi: { linuxMatrix: true, bogus: true } };
+    expect(validateConfig(unknown).errors.some((e) => e.includes('runner.advancedCi.bogus'))).toBe(true);
+
+    const nonBool = validCfg(); nonBool.runner = { advancedCi: { nightly: 'on' } };
+    expect(validateConfig(nonBool).errors).toContain('runner.advancedCi.nightly: must be a boolean');
+
+    const notObj = validCfg(); notObj.runner = { advancedCi: [] };
+    expect(validateConfig(notObj).errors).toContain('runner.advancedCi: must be an object');
+  });
+});
+
+describe('normalizeRunner (#226/AC5 defaults)', () => {
+  it('applies the documented defaults for an absent block', () => {
+    expect(normalizeRunner(undefined)).toEqual({
+      enabled: false,
+      labels: ['self-hosted', 'linux', 'forge-local'],
+      sharing: 'repo',
+      windows: 'native',
+      advancedCi: { linuxMatrix: false, deploySmoke: false, nightly: false },
+    });
+    expect(RUNNER_DEFAULTS.sharing).toBe('repo');
+    expect(RUNNER_DEFAULTS.windows).toBe('native');
+  });
+
+  it('fills only the omitted fields, preserving provided valid ones', () => {
+    const out = normalizeRunner({ enabled: true, sharing: 'org' });
+    expect(out.enabled).toBe(true);
+    expect(out.sharing).toBe('org');
+    expect(out.windows).toBe('native'); // default: native, hosted-fallback
+    expect(out.labels).toEqual(['self-hosted', 'linux', 'forge-local']);
+  });
+
+  it('normalizes malformed values back to defaults defensively', () => {
+    const out = normalizeRunner({ enabled: 'yes', sharing: 'nope', windows: 42, labels: 'not-array' });
+    expect(out).toEqual({
+      enabled: false,
+      labels: ['self-hosted', 'linux', 'forge-local'],
+      sharing: 'repo',
+      windows: 'native',
+      advancedCi: { linuxMatrix: false, deploySmoke: false, nightly: false },
+    });
+  });
+
+  it('does not alias the default labels array (no shared mutable state)', () => {
+    const a = normalizeRunner(undefined);
+    a.labels.push('mutated');
+    expect(normalizeRunner(undefined).labels).toEqual(['self-hosted', 'linux', 'forge-local']);
+    expect(RUNNER_DEFAULTS.labels).toEqual(['self-hosted', 'linux', 'forge-local']);
+  });
 });
 
 describe('loadConfig', () => {
@@ -128,5 +215,31 @@ describe('loadConfig', () => {
     const r = await loadConfig(dir);
     expect(r.ok).toBe(true);
     expect(r.config.board.projectNumber).toBe(8);
+  });
+
+  it('AC5: exposes a normalized runner block with defaults when absent', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-cfg-'));
+    await mkdir(join(dir, '.claude'), { recursive: true });
+    await writeFile(join(dir, '.claude', 'forge.json'), JSON.stringify(validCfg()), 'utf8');
+    const r = await loadConfig(dir);
+    expect(r.ok).toBe(true);
+    expect(r.runner).toEqual({
+      enabled: false,
+      labels: ['self-hosted', 'linux', 'forge-local'],
+      sharing: 'repo',
+      windows: 'native',
+      advancedCi: { linuxMatrix: false, deploySmoke: false, nightly: false },
+    });
+  });
+
+  it('AC5: applies documented defaults over a partial runner block on load', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-cfg-'));
+    await mkdir(join(dir, '.claude'), { recursive: true });
+    const cfg = validCfg();
+    cfg.runner = { enabled: true, sharing: 'org' };
+    await writeFile(join(dir, '.claude', 'forge.json'), JSON.stringify(cfg), 'utf8');
+    const r = await loadConfig(dir);
+    expect(r.ok).toBe(true);
+    expect(r.runner).toMatchObject({ enabled: true, sharing: 'org', windows: 'native', labels: ['self-hosted', 'linux', 'forge-local'] });
   });
 });


### PR DESCRIPTION
Closes #226 · Refs #180

Implements **ADR-0005 AC5** (decisions 2/4/5): an optional `runner` block in `.claude/forge.json` that captures local self-hosted-runner config, validated by the zero-dependency config loader with documented defaults applied. Builds on #224's runner scaffold (which added the assets + `init --runner`); this ticket adds the config-block schema those assets are configured by.

## AC5 checklist → tests
| AC5 requirement | where | test |
| --- | --- | --- |
| `runner` block schema: `enabled`, `labels`, `sharing`, `windows` (+ `advancedCi`) | `plugin/scripts/lib/config.mjs` `validateConfig` | `AC5: accepts a well-formed runner block` |
| defaults: `sharing=repo`, `windows=native`, `enabled=false`, standard labels, advancedCi off | `normalizeRunner` + `RUNNER_DEFAULTS` | `normalizeRunner (#226/AC5 defaults)` (4 cases) |
| reject malformed values | `validateConfig` | `AC5: rejects malformed runner values …`, `… non-object runner block …`, `… advancedCi toggles` |
| normalize/defaults applied on load | `loadConfig` returns normalized `runner` | `AC5: exposes a normalized runner block …`, `… applies documented defaults over a partial block` |
| docs: fields+defaults, solo-vs-team boundary, private-only rule | `docs/guides/install.md`, `docs/guides/handbook.md` | n/a (docs) |

## Schema (matches ADR-0005)
- `enabled` (bool, default `false`) — runner off until opted in
- `labels` (non-empty string[], default `["self-hosted","linux","forge-local"]`) — decision 3 routing labels
- `sharing` (`"repo"` default | `"org"`) — decision 2: per-repo solo default, org opt-in
- `windows` (`"native"` default | `"hosted"`) — decision 4: native when a box is present, hosted fallback
- `advancedCi` (`linuxMatrix`/`deploySmoke`/`nightly`, all bool default `false`) — decision 5: owner-gated CI upside

## Alignment with #224
#224's `init --runner` scaffolds files, wires `.gitignore`/gitleaks, and **never writes the PAT or a runner block** — the config block is new here and additive. No fork of shape: the block is validated in the same `validateConfig` that already governs `board`/`conventions`/`features`/`team`; `loadConfig` exposes `runner` (normalized) so #225's doctor can read one well-formed shape. The private-only rule and no-PAT-in-`forge.json` rule are documented consistently with the ADR and `runner/README.md`.

## Verification (honest)
- `pnpm verify` (vitest) — **405 passed** locally (11 new AC5 cases)
- `claude plugin validate ./plugin --strict` — **passed**
- `forge:reviewer` + `forge:security` over the diff — **both pass, 0 findings** (checked prototype-pollution via `advancedCi` keys, config→exec sinks, secret/doc leaks — none; allow-list + hand-built literal close the injection vector)
- **Hosted CI note:** GitHub Actions is currently red on an **account-level billing block** (not a code defect) — local `pnpm verify` + plugin validate are the green signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)