### PR TITLE
feat(doctor): runner-health check (ADR-0005 AC4) — Closes #225

### DIFF
--- a/plugin/scripts/doctor.mjs
+++ b/plugin/scripts/doctor.mjs
@@ -16,6 +16,88 @@ const warn = (name, msg, hint) => ({ name, level: 'warn', msg, hint });
 const fail = (name, msg, hint) => ({ name, level: 'fail', msg, hint });
 const skip = (name, msg) => ({ name, level: 'skip', msg }); // not applicable — never a failure (#89)
 
+const firstLine = (s) => String(s ?? '').split(/\r?\n/).find((l) => l.trim()) ?? '';
+
+// PAT shapes for the secret-store scan (ADR-0005 decision 1): classic
+// gh{p,o,s,u}_ + 36 chars, and fine-grained github_pat_ tokens. Assembled from
+// parts so this literal never itself matches (no self-flagging in a git grep).
+const RUNNER_PAT_RE = ['gh', '[opsu]_', '[A-Za-z0-9]{36}', '|', 'github', '_pat_', '[A-Za-z0-9_]{22,}'].join('');
+
+/**
+ * Local self-hosted-runner health (ADR-0005 decisions 1 & 3, #225/AC4). Appends
+ * results ONLY when `runner.enabled` — an absent/disabled block is fully silent
+ * (no noise for the majority who don't run a local runner). Every gh/git call is
+ * argv-only (no shell), degrades to a warn (never a crash) when gh lacks scope or
+ * the API 4xxs, and never echoes a discovered secret's value into the output.
+ */
+async function checkRunner({ gh, cwd, runner, results }) {
+  // Private-only guard (decision 3): a self-hosted runner on a PUBLIC repo is a
+  // fork-PR RCE. Belt-and-suspenders with init's refusal (#224). Resolved first,
+  // but the registration probe is the only gh-dependent leg — the secret-store
+  // scan below is git-only and always runs (a committed PAT is unsafe on any repo).
+  const view = await gh(['repo', 'view', '--json', 'isPrivate,owner,name'], { parseJson: true });
+  if (!view.ok) {
+    results.push(warn('runner', `enabled, but repo visibility could not be determined (${firstLine(view.stderr) || 'gh repo view failed'})`, 'run inside the repo with gh authenticated'));
+  } else if (view.json?.isPrivate !== true) {
+    results.push(fail('runner', 'runner.enabled on a PUBLIC repo — forks can run untrusted code on your machine (fork-PR RCE)', 'set runner.enabled=false, or keep the repo private (ADR-0005 decision 3)'));
+  } else {
+    const owner = view.json.owner?.login;
+    const name = view.json.name;
+
+    // Registered + online? (decision 3 label routing). Repo endpoint by default;
+    // the org runners endpoint when sharing:"org" (decision 2). per_page=100 so a
+    // box with many registrations isn't truncated to a false "not registered".
+    const isOrg = runner.sharing === 'org';
+    const base = isOrg ? `orgs/${owner}/actions/runners` : `repos/${owner}/${name}/actions/runners`;
+    const api = await gh(['api', `${base}?per_page=100`], { parseJson: true });
+    const wanted = runner.labels.map((l) => l.toLowerCase()); // GitHub matches labels case-insensitively
+    if (!api.ok) {
+      results.push(warn('runner', `enabled, but could not query ${isOrg ? 'org' : 'repo'} runners (${firstLine(api.stderr) || 'gh api failed'})`, "grant the token repo/admin:org scope, or confirm the runner is registered"));
+    } else {
+      const list = Array.isArray(api.json?.runners) ? api.json.runners : [];
+      const labelNames = (r) => new Set((r.labels ?? []).map((l) => (typeof l === 'string' ? l : l?.name)).filter(Boolean).map((s) => s.toLowerCase()));
+      const matches = list.filter((r) => { const ns = labelNames(r); return wanted.every((w) => ns.has(w)); });
+      if (matches.length === 0) {
+        results.push(warn('runner', `no self-hosted runner registered with labels [${runner.labels.join(', ')}]`, 'register the local runner (/forge:init --runner, then the printed enable steps)'));
+      } else if (matches.some((r) => r.status === 'online')) {
+        const online = matches.filter((r) => r.status === 'online').length;
+        results.push(ok('runner', `registered + online (${online}/${matches.length} matching runner${matches.length === 1 ? '' : 's'} online)`));
+      } else {
+        results.push(warn('runner', `runner registered but offline (labels [${runner.labels.join(', ')}])`, 'start the runner service on the host'));
+      }
+    }
+  }
+
+  await checkRunnerSecretStore({ cwd, results });
+}
+
+/**
+ * Secret-store assertion (ADR-0005 decision 1): the ~/.forge/runner.env PAT store
+ * must be gitignored + untracked, and no PAT may sit in a committed file. gh-free
+ * (git-only) so it runs regardless of the registration probe's outcome. All calls
+ * are argv-only; a non-git cwd simply degrades to a warn, never a throw. Only file
+ * NAMES are ever surfaced — a discovered secret's value is never echoed.
+ */
+async function checkRunnerSecretStore({ cwd, results }) {
+  const trackedRes = await run('git', ['-C', cwd, 'ls-files']);
+  const tracked = (trackedRes.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const storeTracked = tracked.filter((p) => /(^|\/)runner\.env$/.test(p) || /(^|\/)[^/]*\.runner\.env$/.test(p) || /(^|\/)\.forge\//.test(p));
+  const grep = await run('git', ['-C', cwd, 'grep', '-I', '-l', '-E', RUNNER_PAT_RE]);
+  // git grep: exit 0 = matches, 1 = clean (no match), anything else = real error.
+  const patHits = grep.code === 0 ? (grep.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean) : [];
+  const ignored = await run('git', ['-C', cwd, 'check-ignore', '-q', 'runner.env']);
+
+  if (storeTracked.length) {
+    results.push(fail('runner-secret', `runner secret store is tracked in git: ${storeTracked.slice(0, 3).join(', ')}`, 'git rm --cached it; the PAT belongs only in ~/.forge/runner.env (ADR-0005 decision 1)'));
+  } else if (patHits.length) {
+    results.push(fail('runner-secret', `PAT-looking secret found in committed file(s): ${patHits.slice(0, 3).join(', ')}`, 'rotate the token and purge it from git history (never commit a PAT)'));
+  } else if (!ignored.ok) {
+    results.push(warn('runner-secret', 'runner.env is not gitignored', 'add runner.env / **/.forge/ to .gitignore (/forge:init --runner does this)'));
+  } else {
+    results.push(ok('runner-secret', 'runner.env gitignored + untracked; no PAT in committed files'));
+  }
+}
+
 export async function runDoctor(ctx) {
   const { gh, cwd, log } = ctx;
   const results = [];
@@ -131,6 +213,11 @@ export async function runDoctor(ctx) {
         else results.push(warn('graph', 'graph.db not built yet', 'node plugin/scripts/graph/graphctl.mjs rebuild'));
       }
     }
+  }
+
+  // local self-hosted runner (ADR-0005 / #225 AC4) — silent unless runner.enabled
+  if (cfg.ok && cfg.runner?.enabled === true) {
+    await checkRunner({ gh, cwd, runner: cfg.runner, results });
   }
 
   // statusline wired (info-level) — local settings first (that's where init writes it)

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runDoctor } from '../plugin/scripts/doctor.mjs';
+import { run } from '../plugin/scripts/lib/exec.mjs';
 import { fakeGh, fieldsResponse, REPO_VIEW, AUTH_OK } from './helpers/fakegh.mjs';
 
 const noop = () => {};
@@ -11,6 +12,196 @@ const byName = (res, name) => res.results.filter((r) => r.name === name);
 async function tmpCwd() {
   return mkdtemp(join(tmpdir(), 'forge-doc-'));
 }
+
+/** Init a real git repo in a tmp dir with the given tracked files + .gitignore, committed. */
+async function gitRepo({ gitignore = '.forge/\n', files = {}, force = [] } = {}) {
+  const cwd = await tmpCwd();
+  await run('git', ['-C', cwd, 'init', '-q']);
+  await writeFile(join(cwd, '.gitignore'), gitignore, 'utf8');
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(cwd, rel);
+    await mkdir(join(abs, '..'), { recursive: true });
+    await writeFile(abs, body, 'utf8');
+  }
+  await run('git', ['-C', cwd, 'add', '-A']);
+  for (const rel of force) await run('git', ['-C', cwd, 'add', '-f', '--', rel]);
+  await run('git', ['-C', cwd, '-c', 'user.email=t@t.dev', '-c', 'user.name=t', 'commit', '-q', '-m', 'init']);
+  return cwd;
+}
+
+/** Write a valid forge.json (based on the committed one) with a runner block into cwd. */
+async function writeCfg(cwd, runner) {
+  const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+  if (runner !== undefined) committed.runner = runner;
+  await mkdir(join(cwd, '.claude'), { recursive: true });
+  await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed), 'utf8');
+}
+
+const PRIVATE_VIEW = { stdout: JSON.stringify({ isPrivate: true, owner: { login: 'dngioidev' }, name: 'forge' }) };
+const PUBLIC_VIEW = { stdout: JSON.stringify({ isPrivate: false, owner: { login: 'dngioidev' }, name: 'forge' }) };
+const runnersResponse = (runners) => ({ stdout: JSON.stringify({ total_count: runners.length, runners }) });
+const FORGE_LABELS = [{ name: 'self-hosted' }, { name: 'linux' }, { name: 'forge-local' }];
+
+// Routes shared by the runner tests: auth ok, isPrivate view first, then generic
+// repo view + a catch-all so unrelated checks (board/security) don't throw.
+function runnerRoutes({ view = PRIVATE_VIEW, runners } = {}) {
+  const routes = [
+    ['auth status', AUTH_OK],
+    [(j) => j.startsWith('repo view') && j.includes('isPrivate'), view],
+    ['repo view', REPO_VIEW],
+  ];
+  if (runners !== undefined) routes.push([(j) => j.startsWith('api ') && j.includes('actions/runners'), runners]);
+  routes.push([() => true, { ok: false, stderr: 'x' }]);
+  return routes;
+}
+
+describe('runDoctor — runner health (AC-225.4)', () => {
+  it('feature off (no runner block) → runner checks are absent, no noise', async () => {
+    const cwd = await gitRepo();
+    await writeCfg(cwd); // no runner block
+    const { gh } = fakeGh(runnerRoutes());
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')).toEqual([]);
+    expect(byName(res, 'runner-secret')).toEqual([]);
+  });
+
+  it('runner.enabled:false → still silent', async () => {
+    const cwd = await gitRepo();
+    await writeCfg(cwd, { enabled: false });
+    const { gh } = fakeGh(runnerRoutes());
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')).toEqual([]);
+    expect(byName(res, 'runner-secret')).toEqual([]);
+  });
+
+  it('enabled + a matching runner online → ok', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')[0].level).toBe('ok');
+    expect(byName(res, 'runner')[0].msg).toMatch(/online/);
+    // secret store: gitignored + untracked + no PAT → ok
+    expect(byName(res, 'runner-secret')[0].level).toBe('ok');
+    expect(res.results.filter((r) => r.level === 'fail').map((r) => r.name)).not.toContain('runner');
+  });
+
+  it('enabled + matching runner OFFLINE → warn (not a crash, not ok)', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'offline', labels: FORGE_LABELS }]),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')[0].level).toBe('warn');
+    expect(byName(res, 'runner')[0].msg).toMatch(/offline/);
+  });
+
+  it('enabled + NO matching runner registered → warn', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({
+      // an online runner but WITHOUT the forge-local label → not a match
+      runners: runnersResponse([{ id: 9, name: 'other', status: 'online', labels: [{ name: 'self-hosted' }, { name: 'linux' }] }]),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')[0].level).toBe('warn');
+    expect(byName(res, 'runner')[0].msg).toMatch(/no self-hosted runner|not registered|register/i);
+  });
+
+  it('enabled + gh api lacks scope / 403 → degrades to warn, does not crash', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({
+      runners: { ok: false, stderr: 'HTTP 403: Resource not accessible by personal access token' },
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')[0].level).toBe('warn');
+  });
+
+  it('enabled + sharing:org → queries the ORG runners endpoint', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true, sharing: 'org' });
+    const { gh, calls } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')[0].level).toBe('ok');
+    expect(calls.some((c) => c.includes('api orgs/dngioidev/actions/runners'))).toBe(true);
+  });
+
+  it('enabled on a PUBLIC repo → FAIL with the fork-PR RCE message', async () => {
+    const cwd = await tmpCwd();
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({ view: PUBLIC_VIEW }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    const r = byName(res, 'runner')[0];
+    expect(r.level).toBe('fail');
+    expect(r.msg).toMatch(/public|fork/i);
+    expect(res.ok).toBe(false);
+  });
+
+  it('secret store TRACKED in git → FAIL', async () => {
+    // runner.env committed (not ignored) → tracked → fail
+    const cwd = await gitRepo({ gitignore: '.forge/\n', files: { 'runner.env': 'FORGE_RUNNER_PAT=redacted\n' } });
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    const r = byName(res, 'runner-secret')[0];
+    expect(r.level).toBe('fail');
+    expect(r.msg).toMatch(/track/i);
+  });
+
+  it('secret-store scan is git-only and still runs when gh repo view fails', async () => {
+    const token = 'ghp_' + 'y'.repeat(36);
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n', files: { 'src/leak.js': `const t = "${token}";\n` } });
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({ view: { ok: false, stderr: 'network is unreachable' } }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    // registration probe degrades to warn (visibility unknown)…
+    expect(byName(res, 'runner')[0].level).toBe('warn');
+    // …but the gh-independent secret scan still fires and catches the committed PAT
+    expect(byName(res, 'runner-secret')[0].level).toBe('fail');
+  });
+
+  it('enabled + store present but runner.env NOT gitignored → warn', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\n' }); // runner.env pattern absent
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner-secret')[0].level).toBe('warn');
+    expect(byName(res, 'runner-secret')[0].msg).toMatch(/gitignore/i);
+  });
+
+  it('label matching is case-insensitive (FORGE-LOCAL registered, forge-local configured) → ok', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true, labels: ['self-hosted', 'linux', 'forge-local'] });
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: [{ name: 'Self-Hosted' }, { name: 'Linux' }, { name: 'FORGE-LOCAL' }] }]),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')[0].level).toBe('ok');
+  });
+
+  it('PAT-looking secret in a committed file → FAIL', async () => {
+    const token = 'ghp_' + 'x'.repeat(36); // shape-valid classic PAT, not a real secret
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n', files: { 'src/leak.js': `const t = "${token}";\n` } });
+    await writeCfg(cwd, { enabled: true });
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    const r = byName(res, 'runner-secret')[0];
+    expect(r.level).toBe('fail');
+    expect(r.msg).toMatch(/PAT|secret/i);
+  });
+});
 
 describe('runDoctor — failure classes (AC-1.4)', () => {
   it('missing gh auth is a distinct ✗', async () => {


### PR DESCRIPTION
## What

`forge:doctor` now reports **local self-hosted-runner health** (ADR-0005 decision 1, AC4). The check is **gated on `runner.enabled`** in the loaded config — when the runner feature is off (block absent or `enabled:false`), doctor emits **nothing** for it (no noise for the majority who don't run a local runner).

Scope is **only AC4** — no changes to the #224 scaffold or the #226 `forge.json` `runner` schema.

## AC4 → behaviour → test

| AC4 requirement | Behaviour | Test (`tests/doctor.test.mjs`) |
|---|---|---|
| Silent / n-a when feature off | no `runner`/`runner-secret` results | `feature off (no runner block) → absent`; `runner.enabled:false → still silent` |
| Enabled + registered + **online** → healthy | `runner` = ok, probed via `gh api repos/{o}/{r}/actions/runners` matching configured labels | `enabled + a matching runner online → ok` |
| Enabled + **offline** runner | `runner` = warn | `enabled + matching runner OFFLINE → warn` |
| Enabled + **missing** runner | `runner` = warn | `enabled + NO matching runner registered → warn` |
| `sharing:"org"` → org endpoint | queries `orgs/{owner}/actions/runners` | `sharing:org → queries the ORG runners endpoint` |
| Degrade gracefully on scope/403/404 | `runner` = warn, no crash | `gh api lacks scope / 403 → degrades to warn` |
| Secret store gitignored + untracked | `runner-secret` = ok / warn (`git ls-files` + `check-ignore`) | `store present but runner.env NOT gitignored → warn` |
| Secret store **tracked** → fail | `runner-secret` = fail | `secret store TRACKED in git → FAIL` |
| **PAT** in a committed file → fail | `runner-secret` = fail (`git grep`, filenames only) | `PAT-looking secret in a committed file → FAIL` |
| Private-only reminder: public + enabled | `runner` = **FAIL** with fork-PR RCE message | `enabled on a PUBLIC repo → FAIL` |

Plus hardening from review: secret-store scan is **gh-independent and always runs** even when the `gh repo view` probe fails (`secret-store scan is git-only and still runs when gh repo view fails`), and **case-insensitive label matching** (`FORGE-LOCAL` vs `forge-local`). 12 new cases; 21 in the file; **418** repo-wide.

## Security / injection

- Every `gh`/`git` call is **argv-only** (`shell:false` via `lib/exec.mjs`) — no shell-string interpolation; `owner`/`name`/endpoint are single argv tokens.
- Doctor output **never echoes a secret value** — `git grep -l` lists filenames only; all messages are filenames/counts/fixed strings.
- `RUNNER_PAT_RE` is assembled from string parts so it **never self-matches** doctor's own source.
- Independent `forge:reviewer` + `forge:security` passes run over the diff. Security: **pass**. Reviewer majors addressed (secret-scan now unconditional; case-insensitive labels; `per_page=100`).

## Deferred (called out honestly)

ADR-0005 decision 1 also lists a **chmod-600** assertion on `~/.forge/runner.env`. It is **not** included here: the store is a POSIX home-dir file outside the repo, a no-op on the owner's native-Windows box, and typically absent at doctor time (it lives on the runner host). The AC4 contract for this ticket scopes the secret-store assertion to gitignored + untracked + PAT-scan. Suggest a small follow-up ticket for a POSIX-only, best-effort perms check if wanted.

## Verification

- `pnpm verify` — **418 passed** (local gate). ✅
- `claude plugin validate ./plugin --strict` — **passed**. ✅
- Git-based secret-store logic exercised end-to-end with **real `git`** (real repos/commits) on Windows in the test suite.
- Hosted CI is red on an **account Actions billing block** (not a code defect) — local verify + validate are the green signal; billing untouched.

Closes #225
Refs #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)