### PR TITLE
ci(runner): route Windows leg to the native self-hosted runner (#227)

### DIFF
--- a/.claude/forge.json
+++ b/.claude/forge.json
@@ -55,6 +55,6 @@
     "enabled": true,
     "labels": ["self-hosted", "linux", "forge-local"],
     "sharing": "repo",
-    "windows": "hosted"
+    "windows": "native"
   }
 }

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,13 +40,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify
 
-  # Windows leg — a normal per-PR check on hosted windows-latest (every push +
-  # PR, same as Linux). Flip runs-on to the native self-hosted Windows runner
-  # when a box is present to make it free too.
+  # Windows leg - runs natively on the self-hosted Windows runner (forge-local),
+  # every push + PR, so it's free like the Linux legs. If no native Windows runner
+  # is running, set forge.json runner.windows to "hosted" and flip this back to
+  # windows-latest (billed per-PR).
   test-windows:
     permissions:
       contents: read
-    runs-on: windows-latest
+    runs-on: [self-hosted, windows, forge-local]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .claude/settings.local.json
 runner.env
 *.runner.env
+runner/windows/actions-runner/

--- a/plugin/templates/runner/README.md
+++ b/plugin/templates/runner/README.md
@@ -59,6 +59,11 @@ committed. `forge:doctor` (ticket #225) asserts it is gitignored, untracked, and
 
 ## Enable — native Windows host runner (default when a Windows box is present)
 
+> Windows PowerShell blocks unsigned scripts by default (`Restricted` policy). Run
+> the steps in a session that allows them:
+> `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` (session-scoped, no
+> admin), or invoke via `powershell -ExecutionPolicy Bypass -File .\setup-runner.ps1 …`.
+
 1. `cd runner/windows; .\setup-runner.ps1 -Install` (downloads + checksum-verifies
    the runner binary).
 2. Register a Windows service (e.g. NSSM) that runs `.\setup-runner.ps1 -Serve`

--- a/plugin/templates/runner/windows/setup-runner.ps1
+++ b/plugin/templates/runner/windows/setup-runner.ps1
@@ -84,6 +84,15 @@ function Serve-Runner {
     throw 'FORGE_RUNNER_PAT is not set - the service must supply it (NSSM AppEnvironmentExtra). Refusing to start.'
   }
   if ($Owner -like '{{*') { throw 'owner/repo not substituted - re-run forge:init --runner in the target repo.' }
+  # Prefer Git Bash's bash over WSL's System32 bash.exe. forge ships a bash-script
+  # dispatcher (plugin/bin/forge) and its tests shell out to `bash`; if WSL bash wins
+  # on PATH it can't run a C:\ path and those jobs fail (hosted windows-latest uses
+  # Git Bash). Prepend Git's bin so this native runner matches hosted behaviour.
+  $gitCmd = (Get-Command git -ErrorAction SilentlyContinue).Source
+  if ($gitCmd) {
+    $gitBin = Join-Path (Split-Path (Split-Path $gitCmd -Parent) -Parent) 'bin'
+    if (Test-Path (Join-Path $gitBin 'bash.exe')) { $env:PATH = "$gitBin;$env:PATH" }
+  }
   Write-Log "serving $Owner/$Repo on label `"$Label`" (native ephemeral, one job per registration)"
   Push-Location $RunnerDir
   try {

--- a/plugin/templates/runner/windows/setup-runner.ps1
+++ b/plugin/templates/runner/windows/setup-runner.ps1
@@ -97,6 +97,13 @@ function Serve-Runner {
   Push-Location $RunnerDir
   try {
     while ($true) {
+      # Clear config remnants from a previous interrupted job (a Ctrl-C mid-job
+      # leaves .runner/.credentials*, and the next run.cmd --jitconfig then fails
+      # with "Access to the path '...\.runner' is denied"). Start every job clean.
+      foreach ($f in '.runner', '.credentials', '.credentials_rsaparams') {
+        $p = Join-Path $RunnerDir $f
+        if (Test-Path $p) { Remove-Item $p -Force -ErrorAction SilentlyContinue }
+      }
       $jit = New-JitConfig
       Write-Log 'minted JIT config - running one job'
       # --jitconfig implies a single ephemeral job; the runner auto-deregisters after.

--- a/plugin/templates/runner/windows/setup-runner.ps1
+++ b/plugin/templates/runner/windows/setup-runner.ps1
@@ -12,13 +12,13 @@
   SECRET HANDLING (critical): the Administration-only PAT is read ONLY from this
   process's environment ($env:FORGE_RUNNER_PAT), which the Windows *service*
   supplies (the service's own environment, or NSSM `AppEnvironmentExtra`) from an
-  out-of-band store — NEVER from this script, `forge.json`, a machine-level
+  out-of-band store - NEVER from this script, `forge.json`, a machine-level
   `setx /M`, or an interactive-shell-global var. This script never writes the
   secret. It is handed to `gh` via the child env (GH_TOKEN), never on argv, and
   never logged.
 
   Enable (run once to install the runner binary, then register the service):
-    1. gh auth is NOT used for minting — the service provides $env:FORGE_RUNNER_PAT.
+    1. gh auth is NOT used for minting - the service provides $env:FORGE_RUNNER_PAT.
     2. .\setup-runner.ps1 -Install            # downloads + unpacks the runner
     3. Register a Windows service (e.g. NSSM) that runs:  .\setup-runner.ps1 -Serve
        with AppEnvironmentExtra=FORGE_RUNNER_PAT=<token from your secret store>
@@ -31,9 +31,10 @@ param(
   [string]$Owner = '{{OWNER}}',
   [string]$Repo = '{{REPO}}',
   [string]$Label = '{{LABEL}}',
-  [string]$RunnerVersion = '2.328.0',
-  # Pin the published SHA-256 for actions-runner-win-x64-<version>.zip before enabling (#227).
-  [string]$RunnerSha256 = 'REPLACE-ME-with-the-published-actions-runner-win-x64-sha256'
+  [string]$RunnerVersion = '2.336.0',
+  # Pin the published SHA-256 for actions-runner-win-x64-<version>.zip. Keep current
+  # (GitHub deprecates old runner versions); see #233 for auto-pinning at scaffold time.
+  [string]$RunnerSha256 = 'd59123a43003e357b0805b5d0f611d0bd2f65ab67d51bd070dd4e7a0f685c162'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -52,7 +53,7 @@ function Install-Runner {
   Invoke-WebRequest -Uri $url -OutFile $zip
   $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash
   if ($actual -ne $RunnerSha256.ToUpper()) {
-    throw "runner checksum mismatch: got $actual, expected $RunnerSha256 (supply-chain guard — refusing to install)"
+    throw "runner checksum mismatch: got $actual, expected $RunnerSha256 (supply-chain guard - refusing to install)"
   }
   Expand-Archive -Path $zip -DestinationPath $RunnerDir -Force
   Remove-Item $zip -Force
@@ -80,15 +81,15 @@ function New-JitConfig {
 
 function Serve-Runner {
   if (-not $env:FORGE_RUNNER_PAT) {
-    throw 'FORGE_RUNNER_PAT is not set — the service must supply it (NSSM AppEnvironmentExtra). Refusing to start.'
+    throw 'FORGE_RUNNER_PAT is not set - the service must supply it (NSSM AppEnvironmentExtra). Refusing to start.'
   }
-  if ($Owner -like '{{*') { throw 'owner/repo not substituted — re-run forge:init --runner in the target repo.' }
+  if ($Owner -like '{{*') { throw 'owner/repo not substituted - re-run forge:init --runner in the target repo.' }
   Write-Log "serving $Owner/$Repo on label `"$Label`" (native ephemeral, one job per registration)"
   Push-Location $RunnerDir
   try {
     while ($true) {
       $jit = New-JitConfig
-      Write-Log 'minted JIT config — running one job'
+      Write-Log 'minted JIT config - running one job'
       # --jitconfig implies a single ephemeral job; the runner auto-deregisters after.
       & .\run.cmd --jitconfig $jit
       # Wipe the workspace between jobs (no per-job container teardown on native).
@@ -102,4 +103,4 @@ function Serve-Runner {
 
 if ($Install) { Install-Runner }
 elseif ($Serve) { Serve-Runner }
-else { Write-Log 'nothing to do — pass -Install or -Serve (see runner/README.md)' }
+else { Write-Log 'nothing to do - pass -Install or -Serve (see runner/README.md)' }

--- a/runner/README.md
+++ b/runner/README.md
@@ -59,6 +59,11 @@ committed. `forge:doctor` (ticket #225) asserts it is gitignored, untracked, and
 
 ## Enable — native Windows host runner (default when a Windows box is present)
 
+> Windows PowerShell blocks unsigned scripts by default (`Restricted` policy). Run
+> the steps in a session that allows them:
+> `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` (session-scoped, no
+> admin), or invoke via `powershell -ExecutionPolicy Bypass -File .\setup-runner.ps1 …`.
+
 1. `cd runner/windows; .\setup-runner.ps1 -Install` (downloads + checksum-verifies
    the runner binary).
 2. Register a Windows service (e.g. NSSM) that runs `.\setup-runner.ps1 -Serve`

--- a/runner/windows/setup-runner.ps1
+++ b/runner/windows/setup-runner.ps1
@@ -96,6 +96,13 @@ function Serve-Runner {
   Push-Location $RunnerDir
   try {
     while ($true) {
+      # Clear config remnants from a previous interrupted job (a Ctrl-C mid-job
+      # leaves .runner/.credentials*, and the next run.cmd --jitconfig then fails
+      # with "Access to the path '...\.runner' is denied"). Start every job clean.
+      foreach ($f in '.runner', '.credentials', '.credentials_rsaparams') {
+        $p = Join-Path $RunnerDir $f
+        if (Test-Path $p) { Remove-Item $p -Force -ErrorAction SilentlyContinue }
+      }
       $jit = New-JitConfig
       Write-Log 'minted JIT config - running one job'
       # --jitconfig implies a single ephemeral job; the runner auto-deregisters after.

--- a/runner/windows/setup-runner.ps1
+++ b/runner/windows/setup-runner.ps1
@@ -83,6 +83,15 @@ function Serve-Runner {
     throw 'FORGE_RUNNER_PAT is not set - the service must supply it (NSSM AppEnvironmentExtra). Refusing to start.'
   }
   if ($Owner -like '{{*') { throw 'owner/repo not substituted - re-run forge:init --runner in the target repo.' }
+  # Prefer Git Bash's bash over WSL's System32 bash.exe. forge ships a bash-script
+  # dispatcher (plugin/bin/forge) and its tests shell out to `bash`; if WSL bash wins
+  # on PATH it can't run a C:\ path and those jobs fail (hosted windows-latest uses
+  # Git Bash). Prepend Git's bin so this native runner matches hosted behaviour.
+  $gitCmd = (Get-Command git -ErrorAction SilentlyContinue).Source
+  if ($gitCmd) {
+    $gitBin = Join-Path (Split-Path (Split-Path $gitCmd -Parent) -Parent) 'bin'
+    if (Test-Path (Join-Path $gitBin 'bash.exe')) { $env:PATH = "$gitBin;$env:PATH" }
+  }
   Write-Log "serving $Owner/$Repo on label `"$Label`" (native ephemeral, one job per registration)"
   Push-Location $RunnerDir
   try {

--- a/runner/windows/setup-runner.ps1
+++ b/runner/windows/setup-runner.ps1
@@ -12,13 +12,13 @@
   SECRET HANDLING (critical): the Administration-only PAT is read ONLY from this
   process's environment ($env:FORGE_RUNNER_PAT), which the Windows *service*
   supplies (the service's own environment, or NSSM `AppEnvironmentExtra`) from an
-  out-of-band store — NEVER from this script, `forge.json`, a machine-level
+  out-of-band store - NEVER from this script, `forge.json`, a machine-level
   `setx /M`, or an interactive-shell-global var. This script never writes the
   secret. It is handed to `gh` via the child env (GH_TOKEN), never on argv, and
   never logged.
 
   Enable (run once to install the runner binary, then register the service):
-    1. gh auth is NOT used for minting — the service provides $env:FORGE_RUNNER_PAT.
+    1. gh auth is NOT used for minting - the service provides $env:FORGE_RUNNER_PAT.
     2. .\setup-runner.ps1 -Install            # downloads + unpacks the runner
     3. Register a Windows service (e.g. NSSM) that runs:  .\setup-runner.ps1 -Serve
        with AppEnvironmentExtra=FORGE_RUNNER_PAT=<token from your secret store>
@@ -31,9 +31,9 @@ param(
   [string]$Owner = 'dngioidev',
   [string]$Repo = 'forge',
   [string]$Label = 'forge-local',
-  [string]$RunnerVersion = '2.328.0',
+  [string]$RunnerVersion = '2.336.0',
   # Pin the published SHA-256 for actions-runner-win-x64-<version>.zip before enabling (#227).
-  [string]$RunnerSha256 = 'REPLACE-ME-with-the-published-actions-runner-win-x64-sha256'
+  [string]$RunnerSha256 = 'd59123a43003e357b0805b5d0f611d0bd2f65ab67d51bd070dd4e7a0f685c162'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -52,7 +52,7 @@ function Install-Runner {
   Invoke-WebRequest -Uri $url -OutFile $zip
   $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash
   if ($actual -ne $RunnerSha256.ToUpper()) {
-    throw "runner checksum mismatch: got $actual, expected $RunnerSha256 (supply-chain guard — refusing to install)"
+    throw "runner checksum mismatch: got $actual, expected $RunnerSha256 (supply-chain guard - refusing to install)"
   }
   Expand-Archive -Path $zip -DestinationPath $RunnerDir -Force
   Remove-Item $zip -Force
@@ -80,15 +80,15 @@ function New-JitConfig {
 
 function Serve-Runner {
   if (-not $env:FORGE_RUNNER_PAT) {
-    throw 'FORGE_RUNNER_PAT is not set — the service must supply it (NSSM AppEnvironmentExtra). Refusing to start.'
+    throw 'FORGE_RUNNER_PAT is not set - the service must supply it (NSSM AppEnvironmentExtra). Refusing to start.'
   }
-  if ($Owner -like '{{*') { throw 'owner/repo not substituted — re-run forge:init --runner in the target repo.' }
+  if ($Owner -like '{{*') { throw 'owner/repo not substituted - re-run forge:init --runner in the target repo.' }
   Write-Log "serving $Owner/$Repo on label `"$Label`" (native ephemeral, one job per registration)"
   Push-Location $RunnerDir
   try {
     while ($true) {
       $jit = New-JitConfig
-      Write-Log 'minted JIT config — running one job'
+      Write-Log 'minted JIT config - running one job'
       # --jitconfig implies a single ephemeral job; the runner auto-deregisters after.
       & .\run.cmd --jitconfig $jit
       # Wipe the workspace between jobs (no per-job container teardown on native).
@@ -102,4 +102,4 @@ function Serve-Runner {
 
 if ($Install) { Install-Runner }
 elseif ($Serve) { Serve-Runner }
-else { Write-Log 'nothing to do — pass -Install or -Serve (see runner/README.md)' }
+else { Write-Log 'nothing to do - pass -Install or -Serve (see runner/README.md)' }

--- a/tests/runner.test.mjs
+++ b/tests/runner.test.mjs
@@ -84,6 +84,10 @@ describe('AC2 — private-repo scaffold', () => {
     const ps1 = await readFile(join(cwd, 'runner', 'windows', 'setup-runner.ps1'), 'utf8');
     expect(ps1).toContain('Get-FileHash'); // checksum-verified windows runner download
     expect(ps1).toContain('forge-local');
+    // #240: the generated .ps1 must be ASCII-only — Windows PowerShell 5.1 reads
+    // BOM-less scripts as ANSI, so a non-ASCII char (e.g. an em-dash) mojibakes and
+    // breaks parsing. Guard against reintroducing one.
+    expect(/^[\x00-\x7F]*$/.test(ps1)).toBe(true);
 
     await stat(join(cwd, 'runner', 'README.md'));
 


### PR DESCRIPTION
Routes the Windows CI leg onto the **native `forge-local` Windows runner** — the whole `verify` matrix now runs at **$0 hosted minutes** (Linux already on the runner, Windows joins it).

## Change
- `verify.yml`: `test-windows` `runs-on` → `[self-hosted, windows, forge-local]`
- `forge.json`: `runner.windows` `"hosted"` → `"native"`

## Windows scaffold fixes (surfaced by the #227 dogfood — the native path was DOA without these)
- **#240:** `setup-runner.ps1` (instance + template) is now **ASCII-only** — Windows PowerShell 5.1 reads BOM-less scripts as ANSI and mojibakes em-dashes into a parse failure. Added an ASCII-guard test.
- **#233 (Windows):** pinned actions-runner **v2.336.0** + published SHA (the placeholder/`2.328.0` default was deprecated + unusable).
- gitignore the installed runner binary (`runner/windows/actions-runner/`).
- README (instance + template): PowerShell **execution-policy** note (`Set-ExecutionPolicy -Scope Process Bypass`).

## Verification
- Local: `pnpm verify` 418/418, `plugin validate --strict` ✓.
- Native Windows runner is **online** (`forge-local-win-*`); this PR's `test-windows` will run on it — verified green before merge.

Fixes #240. Refs #233, #227, #180