### PR TITLE
fix(runner): docker compose build/config succeed without a JIT config (#232)

### DIFF
--- a/plugin/templates/runner/README.md
+++ b/plugin/templates/runner/README.md
@@ -41,7 +41,10 @@ committed. `forge:doctor` (ticket #225) asserts it is gitignored, untracked, and
 
 ## Enable — Linux / WSL2 (containerized runner)
 
-1. Build the image and confirm Docker + `gh` are on PATH.
+1. Build the image (`cd runner/linux && docker compose build`) and confirm
+   Docker + `gh` are on PATH. The build needs no JIT config — compose uses a
+   build-safe default and the per-job config is required only at run time
+   (enforced by `entrypoint.sh`).
 2. Register the supervisor as a **systemd** service that loads the secret as its
    environment (never an interactive shell):
 

--- a/plugin/templates/runner/linux/docker-compose.yml
+++ b/plugin/templates/runner/linux/docker-compose.yml
@@ -16,8 +16,12 @@ services:
       dockerfile: Dockerfile
     image: forge-local-runner:latest
     # One job, then gone. The supervisor passes ENCODED_JIT_CONFIG per invocation.
+    # Build-safe default (`:-`) so `docker compose build`/`config` parse on a fresh
+    # scaffold with no JIT config (#232). The hard "must be injected" guarantee is
+    # enforced at RUN time by entrypoint.sh, which fails fast if it's empty when a
+    # job actually starts — the guard survives without breaking build/config.
     environment:
-      ENCODED_JIT_CONFIG: ${ENCODED_JIT_CONFIG:?supervisor must inject a per-job JIT config}
+      ENCODED_JIT_CONFIG: ${ENCODED_JIT_CONFIG:-}
     # actionlint / other docker:// steps need the host docker daemon. The socket
     # is a powerful grant (root-equivalent on the host) — private-repo, trusted-
     # collaborator code only (enforced by the private-only refusal). See README.

--- a/plugin/templates/runner/linux/entrypoint.sh
+++ b/plugin/templates/runner/linux/entrypoint.sh
@@ -7,6 +7,10 @@
 # needed — a JIT runner auto-deregisters after its single job.
 set -euo pipefail
 
+# Run-time required-variable guard (#232). docker-compose.yml uses a build-safe
+# default (`${ENCODED_JIT_CONFIG:-}`) so `build`/`config` parse without a JIT
+# config; the hard "must be injected" guarantee lives HERE, at the one moment a
+# job actually starts. Fail fast (do NOT echo the value) if it's empty.
 if [[ -z "${ENCODED_JIT_CONFIG:-}" ]]; then
   echo "forge-runner: ENCODED_JIT_CONFIG is empty — the supervisor must mint a JIT config per job" >&2
   exit 1

--- a/runner/README.md
+++ b/runner/README.md
@@ -41,7 +41,10 @@ committed. `forge:doctor` (ticket #225) asserts it is gitignored, untracked, and
 
 ## Enable — Linux / WSL2 (containerized runner)
 
-1. Build the image and confirm Docker + `gh` are on PATH.
+1. Build the image (`cd runner/linux && docker compose build`) and confirm
+   Docker + `gh` are on PATH. The build needs no JIT config — compose uses a
+   build-safe default and the per-job config is required only at run time
+   (enforced by `entrypoint.sh`).
 2. Register the supervisor as a **systemd** service that loads the secret as its
    environment (never an interactive shell):
 

--- a/runner/linux/docker-compose.yml
+++ b/runner/linux/docker-compose.yml
@@ -16,8 +16,12 @@ services:
       dockerfile: Dockerfile
     image: forge-local-runner:latest
     # One job, then gone. The supervisor passes ENCODED_JIT_CONFIG per invocation.
+    # Build-safe default (`:-`) so `docker compose build`/`config` parse on a fresh
+    # scaffold with no JIT config (#232). The hard "must be injected" guarantee is
+    # enforced at RUN time by entrypoint.sh, which fails fast if it's empty when a
+    # job actually starts — the guard survives without breaking build/config.
     environment:
-      ENCODED_JIT_CONFIG: ${ENCODED_JIT_CONFIG:?supervisor must inject a per-job JIT config}
+      ENCODED_JIT_CONFIG: ${ENCODED_JIT_CONFIG:-}
     # actionlint / other docker:// steps need the host docker daemon. The socket
     # is a powerful grant (root-equivalent on the host) — private-repo, trusted-
     # collaborator code only (enforced by the private-only refusal). See README.

--- a/runner/linux/entrypoint.sh
+++ b/runner/linux/entrypoint.sh
@@ -7,6 +7,10 @@
 # needed — a JIT runner auto-deregisters after its single job.
 set -euo pipefail
 
+# Run-time required-variable guard (#232). docker-compose.yml uses a build-safe
+# default (`${ENCODED_JIT_CONFIG:-}`) so `build`/`config` parse without a JIT
+# config; the hard "must be injected" guarantee lives HERE, at the one moment a
+# job actually starts. Fail fast (do NOT echo the value) if it's empty.
 if [[ -z "${ENCODED_JIT_CONFIG:-}" ]]; then
   echo "forge-runner: ENCODED_JIT_CONFIG is empty — the supervisor must mint a JIT config per job" >&2
   exit 1

--- a/tests/runner.test.mjs
+++ b/tests/runner.test.mjs
@@ -73,6 +73,19 @@ describe('AC2 — private-repo scaffold', () => {
     expect(compose).toContain('ENCODED_JIT_CONFIG'); // JIT config injected per job
     expect(compose).not.toContain('FORGE_RUNNER_PAT'); // no PAT in compose
     expect(compose).not.toMatch(/^\s*secrets:/m); // no compose secrets block
+    // #232: build-safe — the `:?` required-variable form trips `docker compose
+    // build`/`config` on a fresh scaffold (no JIT config yet). Must use the
+    // default form (`:-`) so build/config parse; the run-time guard moves to
+    // entrypoint.sh.
+    expect(compose).not.toMatch(/ENCODED_JIT_CONFIG:\?/); // no required-var guard in compose
+    expect(compose).toContain('${ENCODED_JIT_CONFIG:-}'); // build-safe default
+
+    // #232: the hard "must be injected" guarantee is enforced at RUN time in the
+    // entrypoint — fail fast (non-zero exit) if the config is empty when a job
+    // starts, without echoing the secret value.
+    const entrypoint = await readFile(join(cwd, 'runner', 'linux', 'entrypoint.sh'), 'utf8');
+    expect(entrypoint).toMatch(/-z\s+"\$\{ENCODED_JIT_CONFIG:-\}"/); // empty-check guard
+    expect(entrypoint).toContain('exit 1'); // fail fast on empty config
 
     const supervisor = await readFile(join(cwd, 'runner', 'linux', 'supervisor.mjs'), 'utf8');
     expect(supervisor).toContain('generate-jitconfig'); // mints 1h JIT per job


### PR DESCRIPTION
## What & why

`docker compose build` in `runner/linux/` failed on a fresh scaffold before building:

```
required variable ENCODED_JIT_CONFIG is missing a value: supervisor must inject a per-job JIT config
```

Root cause: the compose `${ENCODED_JIT_CONFIG:?...}` required-variable guard is evaluated during **any** command that interpolates the file (`build`, `config`), not just `run`. The supervisor only sets `ENCODED_JIT_CONFIG` at `docker compose run` time, so the documented step-1 standalone build hit a wall.

## Fix

- **compose (instance + template):** switch to a build-safe default `${ENCODED_JIT_CONFIG:-}` so `build`/`config` parse cleanly with no JIT config.
- **entrypoint.sh (instance + template):** the hard "must be injected" guarantee moves to **run time** — the existing empty-check fails fast with a clear message (without echoing the value) if the config is empty when a job actually starts. Comment now documents it as the run-time counterpart to the compose default.
- **README (instance + template):** step 1 documents the standalone `docker compose build` and notes the config is required only at run time.
- **tests:** assert the scaffolded compose is build-safe (no `:?` form, uses `:-`) and the entrypoint enforces a non-empty config at run. Existing assertions (`ENCODED_JIT_CONFIG` present, no PAT, no secrets block) kept intact.

Instance (`runner/linux/*`) and template (`plugin/templates/runner/linux/*`) stay byte-identical. No secret/supply-chain change — the JIT config is still never printed.

## Verification

- `pnpm verify` — 418/418 passing (43 files)
- `claude plugin validate ./plugin --strict` — passed

Closes #232
Refs #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)