### PR TITLE
fix(runner): back off on build/container failure, not just mint (#234)

### DIFF
--- a/plugin/templates/runner/linux/supervisor.mjs
+++ b/plugin/templates/runner/linux/supervisor.mjs
@@ -24,8 +24,8 @@
  */
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const OWNER = process.env.FORGE_RUNNER_OWNER || '{{OWNER}}';
 const REPO = process.env.FORGE_RUNNER_REPO || '{{REPO}}';
@@ -42,6 +42,29 @@ for (const sig of ['SIGINT', 'SIGTERM']) {
 function log(msg) {
   // Never interpolate PAT / JIT config into a log line.
   process.stdout.write(`[forge-runner ${new Date().toISOString()}] ${msg}\n`);
+}
+
+// Escalating, capped back-off for consecutive job failures — mint OR build/
+// container (#234). A persistent build error must NOT become a tight
+// mint→build→fail loop that hammers generate-jitconfig and litters orphaned JIT
+// registrations. Start at 10s, double each straight failure, cap at 5 min;
+// reset on any success.
+const BACKOFF_BASE_MS = 10_000;
+const BACKOFF_CAP_MS = 300_000;
+
+/** Pure: next back-off (ms) from the previous one — 0 means no prior failure. */
+export function nextBackoff(prev = 0) {
+  const next = prev > 0 ? prev * 2 : BACKOFF_BASE_MS;
+  return Math.min(next, BACKOFF_CAP_MS);
+}
+
+/** Sleep in <=1s slices so a drain (SIGINT/SIGTERM) interrupts a long back-off. */
+async function backoffSleep(ms) {
+  const deadline = Date.now() + ms;
+  while (!stopping && Date.now() < deadline) {
+    const slice = Math.min(1000, deadline - Date.now());
+    await new Promise((r) => setTimeout(r, slice));
+  }
 }
 
 /** Run a command, capturing stdout. Extra env is merged into the child only. */
@@ -88,14 +111,22 @@ async function runOneJob() {
     env: { ENCODED_JIT_CONFIG: minted.jit },
   });
   log(`container for ${minted.name} exited (code ${res.code})`);
-  return true;
+  return res.ok; // #234: a non-zero container exit is a failure → worker backs off.
 }
 
 /** One worker slot: keep taking single jobs until asked to stop. */
 async function worker(slot) {
+  let backoff = 0;
+  let failures = 0;
   while (!stopping) {
     const ok = await runOneJob();
-    if (!ok) await new Promise((r) => setTimeout(r, 10_000)); // back off on mint failure
+    if (ok) { backoff = 0; failures = 0; continue; }
+    // #234: back off on ANY job failure (mint OR build/container), escalating and
+    // capped, so a misconfigured host can't churn the GitHub API in a tight loop.
+    failures += 1;
+    backoff = nextBackoff(backoff);
+    log(`worker ${slot}: ${failures} consecutive failure(s) — backing off ${Math.round(backoff / 1000)}s before retry`);
+    await backoffSleep(backoff);
   }
   log(`worker ${slot} drained`);
 }
@@ -114,4 +145,7 @@ async function main() {
   log('all workers drained — exiting');
 }
 
-main().catch((err) => { log(`fatal: ${err.message}`); process.exit(1); });
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  main().catch((err) => { log(`fatal: ${err.message}`); process.exit(1); });
+}

--- a/runner/linux/supervisor.mjs
+++ b/runner/linux/supervisor.mjs
@@ -24,8 +24,8 @@
  */
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const OWNER = process.env.FORGE_RUNNER_OWNER || 'dngioidev';
 const REPO = process.env.FORGE_RUNNER_REPO || 'forge';
@@ -42,6 +42,29 @@ for (const sig of ['SIGINT', 'SIGTERM']) {
 function log(msg) {
   // Never interpolate PAT / JIT config into a log line.
   process.stdout.write(`[forge-runner ${new Date().toISOString()}] ${msg}\n`);
+}
+
+// Escalating, capped back-off for consecutive job failures — mint OR build/
+// container (#234). A persistent build error must NOT become a tight
+// mint→build→fail loop that hammers generate-jitconfig and litters orphaned JIT
+// registrations. Start at 10s, double each straight failure, cap at 5 min;
+// reset on any success.
+const BACKOFF_BASE_MS = 10_000;
+const BACKOFF_CAP_MS = 300_000;
+
+/** Pure: next back-off (ms) from the previous one — 0 means no prior failure. */
+export function nextBackoff(prev = 0) {
+  const next = prev > 0 ? prev * 2 : BACKOFF_BASE_MS;
+  return Math.min(next, BACKOFF_CAP_MS);
+}
+
+/** Sleep in <=1s slices so a drain (SIGINT/SIGTERM) interrupts a long back-off. */
+async function backoffSleep(ms) {
+  const deadline = Date.now() + ms;
+  while (!stopping && Date.now() < deadline) {
+    const slice = Math.min(1000, deadline - Date.now());
+    await new Promise((r) => setTimeout(r, slice));
+  }
 }
 
 /** Run a command, capturing stdout. Extra env is merged into the child only. */
@@ -88,14 +111,22 @@ async function runOneJob() {
     env: { ENCODED_JIT_CONFIG: minted.jit },
   });
   log(`container for ${minted.name} exited (code ${res.code})`);
-  return true;
+  return res.ok; // #234: a non-zero container exit is a failure → worker backs off.
 }
 
 /** One worker slot: keep taking single jobs until asked to stop. */
 async function worker(slot) {
+  let backoff = 0;
+  let failures = 0;
   while (!stopping) {
     const ok = await runOneJob();
-    if (!ok) await new Promise((r) => setTimeout(r, 10_000)); // back off on mint failure
+    if (ok) { backoff = 0; failures = 0; continue; }
+    // #234: back off on ANY job failure (mint OR build/container), escalating and
+    // capped, so a misconfigured host can't churn the GitHub API in a tight loop.
+    failures += 1;
+    backoff = nextBackoff(backoff);
+    log(`worker ${slot}: ${failures} consecutive failure(s) — backing off ${Math.round(backoff / 1000)}s before retry`);
+    await backoffSleep(backoff);
   }
   log(`worker ${slot} drained`);
 }
@@ -114,4 +145,7 @@ async function main() {
   log('all workers drained — exiting');
 }
 
-main().catch((err) => { log(`fatal: ${err.message}`); process.exit(1); });
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  main().catch((err) => { log(`fatal: ${err.message}`); process.exit(1); });
+}

--- a/tests/runner-supervisor.test.mjs
+++ b/tests/runner-supervisor.test.mjs
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runRunnerInit, parseArgs } from '../plugin/scripts/runner/init.mjs';
+import { fakeGh } from './helpers/fakegh.mjs';
+import { nextBackoff } from '../runner/linux/supervisor.mjs';
+
+const noop = () => {};
+const PRIVATE = { stdout: JSON.stringify({ isPrivate: true, owner: { login: 'dngioidev' }, name: 'forge' }) };
+const privateRoutes = () => [[(j) => j.startsWith('repo view'), PRIVATE]];
+
+async function scaffoldSupervisor() {
+  const cwd = await mkdtemp(join(tmpdir(), 'forge-sup-'));
+  const { gh } = fakeGh(privateRoutes());
+  const res = await runRunnerInit({ gh, cwd }, parseArgs([]), noop);
+  expect(res.ok).toBe(true);
+  return readFile(join(cwd, 'runner', 'linux', 'supervisor.mjs'), 'utf8');
+}
+
+// #234 — a persistent build/container failure must trigger a bounded back-off,
+// not a per-attempt JIT mint. These assert on the SCAFFOLDED supervisor (the
+// asset an operator actually runs) that a non-zero container exit is treated as
+// a failure and that a back-off applies to ALL failures, not just mint failure.
+describe('#234 — supervisor backs off on build/container failure', () => {
+  it('a non-zero container exit is wired to failure (return res.ok, not return true)', async () => {
+    const sup = await scaffoldSupervisor();
+    // runOneJob returns the container result's ok, so a non-zero exit == failure.
+    expect(sup).toContain('return res.ok');
+    // the old unconditional success is gone (isolate runOneJob's container tail).
+    const runOne = sup.slice(sup.indexOf('async function runOneJob'), sup.indexOf('async function worker'));
+    expect(runOne).not.toMatch(/return true;/);
+  });
+
+  it('the worker backs off on ANY failure, escalating and capped — not only on mint failure', async () => {
+    const sup = await scaffoldSupervisor();
+    // back-off is escalating via the pure helper and reset on success.
+    expect(sup).toContain('nextBackoff');
+    expect(sup).toContain('BACKOFF_CAP_MS');
+    // the old comment scoping back-off to mint failure only is gone.
+    expect(sup).not.toContain('back off on mint failure');
+    // a consecutive-failure log line so the operator sees it is stuck.
+    expect(sup).toMatch(/consecutive failure/i);
+    // secret handling preserved: PAT/JIT never logged.
+    expect(sup).not.toMatch(/log\([^)]*\$\{(PAT|minted\.jit|jit)\}/);
+  });
+});
+
+// The back-off refactored into a pure helper is unit-tested directly.
+describe('#234 — nextBackoff (pure)', () => {
+  it('starts at 10s from no prior failure', () => {
+    expect(nextBackoff(0)).toBe(10_000);
+    expect(nextBackoff()).toBe(10_000);
+  });
+
+  it('doubles each consecutive failure', () => {
+    expect(nextBackoff(10_000)).toBe(20_000);
+    expect(nextBackoff(20_000)).toBe(40_000);
+    expect(nextBackoff(40_000)).toBe(80_000);
+  });
+
+  it('is capped at 5 minutes so a stuck host cannot churn the API', () => {
+    expect(nextBackoff(200_000)).toBe(300_000);
+    expect(nextBackoff(300_000)).toBe(300_000);
+    expect(nextBackoff(10_000_000)).toBe(300_000);
+  });
+
+  it('grows monotonically to the cap and never exceeds it', () => {
+    let b = 0;
+    for (let i = 0; i < 20; i++) {
+      const next = nextBackoff(b);
+      expect(next).toBeGreaterThanOrEqual(b);
+      expect(next).toBeLessThanOrEqual(300_000);
+      b = next;
+    }
+    expect(b).toBe(300_000);
+  });
+});


### PR DESCRIPTION
## What

`runner/linux/supervisor.mjs` (and its `plugin/templates/...` source) had no back-off on build/container failure. `runOneJob()` returned `true` even when `docker compose run` exited non-zero, so `worker()` only backed off on JIT-**mint** failure. A persistent build/container error became a tight mint→build→fail loop that hammered `generate-jitconfig` and littered orphaned 1h JIT registrations — observed live in the #227 dogfood (a fresh JIT config every ~18s).

## Fix

- `runOneJob()` returns `res.ok` — a non-zero container exit is now a failure, so the existing back-off applies to build/container errors too.
- Escalating, capped back-off via a pure `nextBackoff(prev)` helper: 10s → double → cap 5m, **reset on any success**, so a misconfigured host can't churn the GitHub API. A consecutive-failure log line makes a stuck host visible.
- `backoffSleep` sleeps in ≤1s slices so SIGINT/SIGTERM drain still interrupts a long back-off promptly.
- Secret handling (PAT/JIT never logged), the drain, and the concurrency model are unchanged. `main()` is guarded behind an `isMain` check so `nextBackoff` is unit-testable by import.
- Applied identically to the instance and the plugin template.

## Tests

New `tests/runner-supervisor.test.mjs`:
- structural checks on the **scaffolded** supervisor: non-zero container exit wired to failure (`return res.ok`, no `return true` in `runOneJob`), back-off no longer scoped to mint-only, consecutive-failure log present, no PAT/JIT in log lines;
- direct unit tests of `nextBackoff` (10s start, doubling, 5m cap, monotonic-to-cap).

`pnpm verify` → 424/424 green. `claude plugin validate ./plugin --strict` → passed.

Closes #234
Refs #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)