### PR TITLE
fix(runner): auto-pin current actions/runner version + SHA at scaffold, warn on staleness (#233)

### DIFF
--- a/plugin/scripts/doctor.mjs
+++ b/plugin/scripts/doctor.mjs
@@ -8,6 +8,7 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import { run, makeGh } from './lib/exec.mjs';
 import { loadConfig, CONFIG_RELPATH } from './lib/config.mjs';
+import { fetchRunnerPin, parsePinnedVersion, compareVersions } from './lib/runner-release.mjs';
 import { readJson } from './lib/jsonfile.mjs';
 import { getRepoInfo, getProjectFields } from './lib/board.mjs';
 
@@ -69,6 +70,34 @@ async function checkRunner({ gh, cwd, runner, results }) {
   }
 
   await checkRunnerSecretStore({ cwd, results });
+  await checkRunnerVersion({ gh, cwd, results });
+}
+
+/**
+ * Runner staleness (#233): GitHub DEPRECATES old actions/runner versions ("Runner
+ * version vX is deprecated and cannot receive messages") and the ephemeral/JIT
+ * runner can't auto-update, so a fixed pin silently stops receiving jobs. Parse the
+ * scaffolded RUNNER_VERSION (Dockerfile, then setup-runner.ps1) and WARN when it is
+ * behind the latest release. Degrades to a SILENT skip when the runner files are
+ * absent (nothing scaffolded yet) or the gh lookup fails (can't determine latest) —
+ * never a crash, never a fail.
+ */
+async function checkRunnerVersion({ gh, cwd, results }) {
+  const dockerfile = await readFile(join(cwd, 'runner', 'linux', 'Dockerfile'), 'utf8').catch(() => null);
+  const ps1 = await readFile(join(cwd, 'runner', 'windows', 'setup-runner.ps1'), 'utf8').catch(() => null);
+  const pinned = parsePinnedVersion(dockerfile) ?? parsePinnedVersion(ps1);
+  if (!pinned) return; // no scaffolded runner files → silent skip
+
+  const latest = await fetchRunnerPin(gh); // no log — doctor is read-only/quiet here
+  if (latest.source !== 'live') return; // gh unreachable → can't judge staleness → silent skip
+
+  if (compareVersions(pinned, latest.version) < 0) {
+    results.push(warn('runner-version',
+      `pinned actions-runner v${pinned} is behind the latest v${latest.version} — GitHub deprecates old runners; the ephemeral runner will stop receiving jobs`,
+      're-run /forge:init --runner (or bump RUNNER_VERSION + SHA-256 in runner/linux/Dockerfile and runner/windows/setup-runner.ps1)'));
+  } else {
+    results.push(ok('runner-version', `pinned actions-runner v${pinned} is current`));
+  }
 }
 
 /**

--- a/plugin/scripts/lib/runner-release.mjs
+++ b/plugin/scripts/lib/runner-release.mjs
@@ -1,0 +1,78 @@
+/**
+ * actions/runner release pinning (#233). One source of truth for BOTH:
+ *  - init --runner scaffold-time pinning (Dockerfile + setup-runner.ps1), and
+ *  - doctor's staleness check (is the scaffolded pin behind the latest release?).
+ *
+ * GitHub DEPRECATES old runner versions ("Runner version vX is deprecated and
+ * cannot receive messages"), and an ephemeral/JIT runner can't auto-update — so a
+ * fixed pin silently stops receiving jobs. Scaffolding must pin the CURRENT
+ * release, and doctor must warn when a pin falls behind.
+ *
+ * The published SHA-256 for each asset lives in the release BODY between
+ * `<!-- BEGIN SHA <arch> -->…<!-- END SHA <arch> -->` markers.
+ */
+
+/**
+ * Last-known-good pin — a REAL, buildable release (v2.336.0), never a REPLACE-ME.
+ * Used only when the live gh lookup fails, so a fresh scaffold still builds offline.
+ * Keep current-ish; doctor stays silent (never warns) against this fallback.
+ */
+export const FALLBACK_RUNNER_PIN = Object.freeze({
+  version: '2.336.0',
+  linux: '04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d',
+  win: 'd59123a43003e357b0805b5d0f611d0bd2f65ab67d51bd070dd4e7a0f685c162',
+});
+
+const shaMarker = (arch) =>
+  new RegExp(`<!--\\s*BEGIN SHA ${arch}\\s*-->\\s*([0-9a-fA-F]{64})\\s*<!--\\s*END SHA ${arch}\\s*-->`);
+
+/**
+ * Parse a release tag + body into a pin ({version, linux, win}) or null when the
+ * version or either SHA can't be extracted (caller falls back).
+ */
+export function parseRunnerRelease(tagName, body) {
+  const version = String(tagName ?? '').trim().replace(/^v/, '');
+  const linux = shaMarker('linux-x64').exec(String(body ?? ''))?.[1];
+  const win = shaMarker('win-x64').exec(String(body ?? ''))?.[1];
+  if (!/^\d+\.\d+\.\d+/.test(version) || !linux || !win) return null;
+  return { version, linux: linux.toLowerCase(), win: win.toLowerCase() };
+}
+
+/**
+ * Fetch the CURRENT actions/runner release pin (version + linux-x64/win-x64 SHA).
+ * Degrades to FALLBACK_RUNNER_PIN (a real, buildable pin — NEVER a REPLACE-ME) with
+ * a warning when the gh call fails or the release can't be parsed. `source` is
+ * 'live' on a successful fetch, 'fallback' otherwise, so callers (doctor) can stay
+ * silent rather than warn against a stale fallback.
+ */
+export async function fetchRunnerPin(gh, log = () => {}) {
+  const res = await gh(['api', 'repos/actions/runner/releases/latest'], { parseJson: true });
+  if (res.ok && res.json) {
+    const pin = parseRunnerRelease(res.json.tag_name, res.json.body);
+    if (pin) return { ...pin, source: 'live' };
+  }
+  const why = res.ok ? 'release body missing SHA markers' : (res.stderr?.split(/\r?\n/).find((l) => l.trim()) || 'gh api failed');
+  log(`warning: could not resolve the current actions/runner release (${why}) — pinning last-known-good v${FALLBACK_RUNNER_PIN.version}. Re-run once gh is reachable, or bump the pin if it has since deprecated (#233).`);
+  return { ...FALLBACK_RUNNER_PIN, source: 'fallback' };
+}
+
+/** Parse the pinned RUNNER_VERSION from a scaffolded Dockerfile / setup-runner.ps1. */
+export function parsePinnedVersion(text) {
+  if (!text) return null;
+  // Dockerfile:  ARG RUNNER_VERSION=2.336.0
+  // ps1:         [string]$RunnerVersion = '2.336.0',
+  const m = /ARG\s+RUNNER_VERSION=([0-9]+\.[0-9]+\.[0-9]+)/.exec(text)
+    || /\$RunnerVersion\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+)'/.exec(text);
+  return m ? m[1] : null;
+}
+
+/** Semver-ish compare of two dotted versions: <0, 0, >0. Non-numeric parts → 0. */
+export function compareVersions(a, b) {
+  const pa = String(a).split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}

--- a/plugin/scripts/runner/init.mjs
+++ b/plugin/scripts/runner/init.mjs
@@ -14,6 +14,7 @@ import { join, dirname, resolve, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { run, makeGh } from '../lib/exec.mjs';
 import { loadConfig } from '../lib/config.mjs';
+import { fetchRunnerPin } from '../lib/runner-release.mjs';
 
 const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const DEFAULT_LABEL = 'forge-local';
@@ -106,11 +107,20 @@ export async function runRunnerInit(ctx, args = parseArgs([]), log = console.log
   const verify = cfg.config?.conventions?.verify ?? 'pnpm verify';
   const label = args.label || DEFAULT_LABEL;
 
+  // Auto-pin the actions/runner version + published SHA-256 (linux-x64 + win-x64)
+  // to the CURRENT release (#233): a hardcoded/placeholder pin either fails the
+  // build (REPLACE-ME) or silently deprecates. Degrades to a real last-known-good
+  // pin (never a REPLACE-ME) with a warning if the gh lookup fails.
+  const pin = await fetchRunnerPin(gh, log);
+
   const substitute = (text) => text
     .replaceAll('{{OWNER}}', repo.owner)
     .replaceAll('{{REPO}}', repo.name)
     .replaceAll('{{LABEL}}', label)
-    .replaceAll('{{VERIFY}}', verify);
+    .replaceAll('{{VERIFY}}', verify)
+    .replaceAll('{{RUNNER_VERSION}}', pin.version)
+    .replaceAll('{{RUNNER_SHA256_LINUX}}', pin.linux)
+    .replaceAll('{{RUNNER_SHA256_WIN}}', pin.win);
 
   const runnerTemplates = join(PLUGIN_ROOT, 'templates', 'runner');
   const CANONICAL_VERIFY = join('.github', 'workflows', 'verify.yml');
@@ -179,6 +189,8 @@ export async function runRunnerInit(ctx, args = parseArgs([]), log = console.log
 
   for (const p of placed) log(`placed: ${p}`);
   for (const s of skipped) log(`kept existing: ${s}`);
+  // #233: surface what was pinned so the operator knows the build is ready to go.
+  log(`runner pinned to actions/runner v${pin.version}${pin.source === 'live' ? ' (current release)' : ' (last-known-good fallback — gh was unreachable)'} — Dockerfile + setup-runner.ps1 SHA-256 verified; forge:doctor warns if it later deprecates.`);
   for (const r of review) {
     log(`REVIEW: ${r} (an existing verify.yml was kept — compare and swap in the runner variant to move CI onto the local runner)`);
     log(`  NOTE: verify.yml and ${RUNNER_VARIANT} are both \`name: verify\`. The runner variant uses a distinct concurrency group (verify-runner-*) so it will NOT cancel your incumbent verify.yml if you commit both during review — but GitHub still runs two "verify" checks until you swap. Finish the swap (replace verify.yml with the runner variant) to land on one workflow (see #236).`);

--- a/plugin/templates/runner/linux/Dockerfile
+++ b/plugin/templates/runner/linux/Dockerfile
@@ -19,10 +19,13 @@
 # never ships a fabricated/unresolvable digest.)
 FROM node:22-bookworm-slim AS base
 
-# Pin these before enabling (ADR-0005 / #227 dogfood): the runner release + its
-# published SHA-256. See https://github.com/actions/runner/releases
-ARG RUNNER_VERSION=2.328.0
-ARG RUNNER_SHA256=REPLACE-ME-with-the-published-actions-runner-linux-x64-sha256
+# The runner release + its published SHA-256, auto-pinned at scaffold time by
+# forge:init --runner to the CURRENT actions/runner release (#233). GitHub
+# deprecates old runner versions and the ephemeral runner can't auto-update, so
+# re-run forge:init --runner (or forge:doctor warns) when this falls behind.
+# See https://github.com/actions/runner/releases
+ARG RUNNER_VERSION={{RUNNER_VERSION}}
+ARG RUNNER_SHA256={{RUNNER_SHA256_LINUX}}
 ARG TARGETARCH=x64
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/plugin/templates/runner/windows/setup-runner.ps1
+++ b/plugin/templates/runner/windows/setup-runner.ps1
@@ -31,10 +31,12 @@ param(
   [string]$Owner = '{{OWNER}}',
   [string]$Repo = '{{REPO}}',
   [string]$Label = '{{LABEL}}',
-  [string]$RunnerVersion = '2.336.0',
-  # Pin the published SHA-256 for actions-runner-win-x64-<version>.zip. Keep current
-  # (GitHub deprecates old runner versions); see #233 for auto-pinning at scaffold time.
-  [string]$RunnerSha256 = 'd59123a43003e357b0805b5d0f611d0bd2f65ab67d51bd070dd4e7a0f685c162'
+  [string]$RunnerVersion = '{{RUNNER_VERSION}}',
+  # Published SHA-256 for actions-runner-win-x64-<version>.zip, auto-pinned at
+  # scaffold time by forge:init --runner to the CURRENT release (#233). GitHub
+  # deprecates old runner versions; re-run forge:init --runner (forge:doctor warns)
+  # to bump when it falls behind.
+  [string]$RunnerSha256 = '{{RUNNER_SHA256_WIN}}'
 )
 
 $ErrorActionPreference = 'Stop'

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -44,17 +44,33 @@ const PUBLIC_VIEW = { stdout: JSON.stringify({ isPrivate: false, owner: { login:
 const runnersResponse = (runners) => ({ stdout: JSON.stringify({ total_count: runners.length, runners }) });
 const FORGE_LABELS = [{ name: 'self-hosted' }, { name: 'linux' }, { name: 'forge-local' }];
 
+// #233: an actions/runner release response for the staleness check. SHA markers
+// live in the release body; only tag_name matters for version comparison.
+const releaseResponse = (version) => ({
+  stdout: JSON.stringify({
+    tag_name: `v${version}`,
+    body: `<!-- BEGIN SHA linux-x64 -->${'a'.repeat(64)}<!-- END SHA linux-x64 -->\n<!-- BEGIN SHA win-x64 -->${'b'.repeat(64)}<!-- END SHA win-x64 -->`,
+  }),
+});
+
 // Routes shared by the runner tests: auth ok, isPrivate view first, then generic
 // repo view + a catch-all so unrelated checks (board/security) don't throw.
-function runnerRoutes({ view = PRIVATE_VIEW, runners } = {}) {
+function runnerRoutes({ view = PRIVATE_VIEW, runners, release } = {}) {
   const routes = [
     ['auth status', AUTH_OK],
     [(j) => j.startsWith('repo view') && j.includes('isPrivate'), view],
     ['repo view', REPO_VIEW],
   ];
+  if (release !== undefined) routes.push([(j) => j.startsWith('api repos/actions/runner/releases/latest'), release]);
   if (runners !== undefined) routes.push([(j) => j.startsWith('api ') && j.includes('actions/runners'), runners]);
   routes.push([() => true, { ok: false, stderr: 'x' }]);
   return routes;
+}
+
+/** Write a scaffolded runner Dockerfile pinning RUNNER_VERSION for the staleness check. */
+async function writeRunnerDockerfile(cwd, version) {
+  await mkdir(join(cwd, 'runner', 'linux'), { recursive: true });
+  await writeFile(join(cwd, 'runner', 'linux', 'Dockerfile'), `FROM node:22\nARG RUNNER_VERSION=${version}\nARG RUNNER_SHA256=${'a'.repeat(64)}\n`, 'utf8');
 }
 
 describe('runDoctor — runner health (AC-225.4)', () => {
@@ -179,6 +195,61 @@ describe('runDoctor — runner health (AC-225.4)', () => {
     const res = await runDoctor({ gh, cwd, log: noop });
     expect(byName(res, 'runner-secret')[0].level).toBe('warn');
     expect(byName(res, 'runner-secret')[0].msg).toMatch(/gitignore/i);
+  });
+
+  it('#233: pinned runner version BEHIND latest → warn (deprecation staleness)', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true });
+    await writeRunnerDockerfile(cwd, '2.300.0'); // stale pin
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+      release: releaseResponse('2.340.0'),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    const r = byName(res, 'runner-version')[0];
+    expect(r.level).toBe('warn');
+    expect(r.msg).toMatch(/2\.300\.0/);
+    expect(r.msg).toMatch(/2\.340\.0/);
+    expect(r.msg).toMatch(/deprecat/i);
+    // staleness is advisory, never a hard failure
+    expect(res.results.filter((x) => x.level === 'fail').map((x) => x.name)).not.toContain('runner-version');
+  });
+
+  it('#233: pinned runner version CURRENT (== latest) → ok', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true });
+    await writeRunnerDockerfile(cwd, '2.340.0');
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+      release: releaseResponse('2.340.0'),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner-version')[0].level).toBe('ok');
+  });
+
+  it('#233: release lookup fails → staleness check is a silent skip (no runner-version result)', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true });
+    await writeRunnerDockerfile(cwd, '2.300.0');
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+      release: { ok: false, stderr: 'network is unreachable' },
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner-version')).toEqual([]); // silent — can't judge staleness
+    expect(res.results.filter((x) => x.level === 'fail').map((x) => x.name)).not.toContain('runner-version');
+  });
+
+  it('#233: no scaffolded runner files → staleness check is a silent skip', async () => {
+    const cwd = await gitRepo({ gitignore: '.forge/\nrunner.env\n' });
+    await writeCfg(cwd, { enabled: true });
+    // no runner/linux/Dockerfile written
+    const { gh } = fakeGh(runnerRoutes({
+      runners: runnersResponse([{ id: 1, name: 'box', status: 'online', labels: FORGE_LABELS }]),
+      release: releaseResponse('2.340.0'),
+    }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner-version')).toEqual([]);
   });
 
   it('label matching is case-insensitive (FORGE-LOCAL registered, forge-local configured) → ok', async () => {

--- a/tests/lib/runner-release.test.mjs
+++ b/tests/lib/runner-release.test.mjs
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseRunnerRelease,
+  parsePinnedVersion,
+  compareVersions,
+  fetchRunnerPin,
+  FALLBACK_RUNNER_PIN,
+} from '../../plugin/scripts/lib/runner-release.mjs';
+import { fakeGh } from '../helpers/fakegh.mjs';
+
+const LINUX = 'a'.repeat(64);
+const WIN = 'b'.repeat(64);
+const body = (v = '2.340.0') =>
+  `- actions-runner-linux-x64-${v}.tar.gz <!-- BEGIN SHA linux-x64 -->${LINUX}<!-- END SHA linux-x64 -->\n` +
+  `- actions-runner-win-x64-${v}.zip <!-- BEGIN SHA win-x64 -->${WIN}<!-- END SHA win-x64 -->`;
+
+describe('runner-release — #233 parsing + pinning', () => {
+  it('parseRunnerRelease strips the v prefix and extracts both SHAs (lowercased)', () => {
+    // uppercase SHAs (markers stay lowercase, as GitHub publishes them) → lowercased out
+    const upper = `<!-- BEGIN SHA linux-x64 -->${LINUX.toUpperCase()}<!-- END SHA linux-x64 -->\n` +
+      `<!-- BEGIN SHA win-x64 -->${WIN.toUpperCase()}<!-- END SHA win-x64 -->`;
+    const pin = parseRunnerRelease('v2.340.0', upper);
+    expect(pin).toEqual({ version: '2.340.0', linux: LINUX, win: WIN });
+  });
+
+  it('parseRunnerRelease → null when a SHA marker or a valid version is missing', () => {
+    expect(parseRunnerRelease('v2.340.0', 'no markers here')).toBe(null);
+    expect(parseRunnerRelease('not-a-version', body())).toBe(null);
+  });
+
+  it('parsePinnedVersion reads the Dockerfile ARG and the ps1 param', () => {
+    expect(parsePinnedVersion('FROM node\nARG RUNNER_VERSION=2.336.0\n')).toBe('2.336.0');
+    expect(parsePinnedVersion("[string]$RunnerVersion = '2.328.0',")).toBe('2.328.0');
+    expect(parsePinnedVersion(null)).toBe(null);
+    expect(parsePinnedVersion('nothing pinned')).toBe(null);
+  });
+
+  it('compareVersions orders semver-ish versions', () => {
+    expect(compareVersions('2.300.0', '2.340.0')).toBe(-1);
+    expect(compareVersions('2.340.0', '2.340.0')).toBe(0);
+    expect(compareVersions('2.341.0', '2.340.0')).toBe(1);
+    expect(compareVersions('2.9.0', '2.10.0')).toBe(-1); // numeric, not lexical
+  });
+
+  it('fetchRunnerPin returns a live pin from the release endpoint', async () => {
+    const { gh } = fakeGh([
+      [(j) => j.startsWith('api repos/actions/runner/releases/latest'),
+        { stdout: JSON.stringify({ tag_name: 'v2.340.0', body: body('2.340.0') }) }],
+    ]);
+    const pin = await fetchRunnerPin(gh);
+    expect(pin).toMatchObject({ version: '2.340.0', linux: LINUX, win: WIN, source: 'live' });
+  });
+
+  it('fetchRunnerPin degrades to the real fallback pin (never a placeholder) + warns on gh failure', async () => {
+    const logs = [];
+    const { gh } = fakeGh([
+      [(j) => j.startsWith('api repos/actions/runner/releases/latest'), { ok: false, stderr: 'boom' }],
+    ]);
+    const pin = await fetchRunnerPin(gh, (m) => logs.push(String(m)));
+    expect(pin).toMatchObject({ ...FALLBACK_RUNNER_PIN, source: 'fallback' });
+    expect(pin.linux).toMatch(/^[0-9a-f]{64}$/);
+    expect(pin.win).toMatch(/^[0-9a-f]{64}$/);
+    expect(logs.join('\n')).toMatch(/could not resolve the current actions\/runner release/);
+  });
+});

--- a/tests/runner.test.mjs
+++ b/tests/runner.test.mjs
@@ -12,8 +12,26 @@ const noop = () => {};
 const PRIVATE = { stdout: JSON.stringify({ isPrivate: true, owner: { login: 'dngioidev' }, name: 'forge' }) };
 const PUBLIC = { stdout: JSON.stringify({ isPrivate: false, owner: { login: 'dngioidev' }, name: 'forge' }) };
 
+// #233: the current actions/runner release init pins at scaffold time. The
+// published linux-x64 / win-x64 SHA-256 live between markers in the release body.
+const REL_VERSION = '2.340.0';
+const REL_LINUX = 'a'.repeat(64);
+const REL_WIN = 'b'.repeat(64);
+const RELEASE = {
+  stdout: JSON.stringify({
+    tag_name: `v${REL_VERSION}`,
+    body: [
+      `- actions-runner-linux-x64-${REL_VERSION}.tar.gz <!-- BEGIN SHA linux-x64 -->${REL_LINUX}<!-- END SHA linux-x64 -->`,
+      `- actions-runner-win-x64-${REL_VERSION}.zip <!-- BEGIN SHA win-x64 -->${REL_WIN}<!-- END SHA win-x64 -->`,
+    ].join('\n'),
+  }),
+};
+
 function privateRoutes() {
-  return [[(j) => j.startsWith('repo view'), PRIVATE]];
+  return [
+    [(j) => j.startsWith('api repos/actions/runner/releases/latest'), RELEASE],
+    [(j) => j.startsWith('repo view'), PRIVATE],
+  ];
 }
 
 async function tmpCwd() {
@@ -67,6 +85,13 @@ describe('AC2 — private-repo scaffold', () => {
     expect(dockerfile).toContain('corepack enable'); // pnpm
     expect(dockerfile).toContain('gh'); // gh baked in
     expect(dockerfile).toContain('sha256sum -c'); // checksum-verified download (supply chain)
+    // #233: version + SHA auto-pinned to the current release — no placeholder left.
+    expect(dockerfile).toContain(`ARG RUNNER_VERSION=${REL_VERSION}`);
+    expect(dockerfile).toContain(`ARG RUNNER_SHA256=${REL_LINUX}`);
+    expect(dockerfile).not.toContain('REPLACE-ME');
+    expect(dockerfile).not.toContain('{{RUNNER_VERSION}}');
+    expect(dockerfile).not.toContain('{{RUNNER_SHA256_LINUX}}');
+    expect(dockerfile).toMatch(/ARG RUNNER_SHA256=[0-9a-f]{64}\b/); // real 64-hex SHA
 
     const compose = await readFile(join(cwd, 'runner', 'linux', 'docker-compose.yml'), 'utf8');
     expect(compose).toContain('/var/run/docker.sock:/var/run/docker.sock'); // socket mount for actionlint
@@ -97,6 +122,13 @@ describe('AC2 — private-repo scaffold', () => {
     const ps1 = await readFile(join(cwd, 'runner', 'windows', 'setup-runner.ps1'), 'utf8');
     expect(ps1).toContain('Get-FileHash'); // checksum-verified windows runner download
     expect(ps1).toContain('forge-local');
+    // #233: win-x64 version + SHA auto-pinned; no placeholder left.
+    expect(ps1).toContain(`$RunnerVersion = '${REL_VERSION}'`);
+    expect(ps1).toContain(`$RunnerSha256 = '${REL_WIN}'`);
+    expect(ps1).not.toContain('REPLACE-ME');
+    expect(ps1).not.toContain('{{RUNNER_VERSION}}');
+    expect(ps1).not.toContain('{{RUNNER_SHA256_WIN}}');
+    expect(ps1).toMatch(/\$RunnerSha256 = '[0-9a-f]{64}'/); // real 64-hex SHA
     // #240: the generated .ps1 must be ASCII-only — Windows PowerShell 5.1 reads
     // BOM-less scripts as ANSI, so a non-ASCII char (e.g. an em-dash) mojibakes and
     // breaks parsing. Guard against reintroducing one.
@@ -177,6 +209,27 @@ describe('AC2 — private-repo scaffold', () => {
     expect(blob).toMatch(/verify\.runner\.yml/);
     expect(blob).toMatch(/concurrency group/i);
     expect(blob).toMatch(/#236/);
+  });
+
+  it('#233: degrades to a real pinned fallback (no REPLACE-ME / placeholder) when the release lookup fails', async () => {
+    const cwd = await tmpCwd();
+    const logs = [];
+    // release endpoint errors; repo view still private → scaffold proceeds with fallback pin
+    const { gh } = fakeGh([
+      [(j) => j.startsWith('api repos/actions/runner/releases/latest'), { ok: false, stderr: 'network is unreachable' }],
+      [(j) => j.startsWith('repo view'), PRIVATE],
+    ]);
+    const res = await runRunnerInit({ gh, cwd }, parseArgs([]), (m) => logs.push(String(m)));
+    expect(res.ok).toBe(true);
+    const dockerfile = await readFile(join(cwd, 'runner', 'linux', 'Dockerfile'), 'utf8');
+    const ps1 = await readFile(join(cwd, 'runner', 'windows', 'setup-runner.ps1'), 'utf8');
+    for (const body of [dockerfile, ps1]) {
+      expect(body).not.toContain('REPLACE-ME');
+      expect(body).not.toMatch(/\{\{RUNNER_/); // no placeholder left
+    }
+    expect(dockerfile).toMatch(/ARG RUNNER_SHA256=[0-9a-f]{64}\b/); // real fallback SHA
+    expect(ps1).toMatch(/\$RunnerSha256 = '[0-9a-f]{64}'/);
+    expect(logs.join('\n')).toMatch(/warning: could not resolve the current actions\/runner release/);
   });
 
   it('re-run is a no-op — all assets kept, none re-placed', async () => {


### PR DESCRIPTION
Closes #233. Refs #180.

## The bug (two dimensions)

**1. Scaffold-time build break.** `forge:init --runner` shipped a placeholder `RUNNER_SHA256=REPLACE-ME-...` in `runner/linux/Dockerfile` and a hardcoded win-x64 SHA in `setup-runner.ps1`. A fresh scaffold failed cryptically at the checksum step (`sha256sum: no properly formatted checksum lines found`) until an operator manually pinned the version + SHA — and nothing surfaced that requirement.

**2. Ongoing staleness.** Even a valid pin deprecates: GitHub hard-rejects old runners (`Runner version vX is deprecated and cannot receive messages`) and the ephemeral/JIT runner can't auto-update, so a fixed pin silently stops receiving jobs (surfaced in the #227 dogfood).

## The fix

- **Scaffold-time** — `init.mjs` + templates: fetch the CURRENT `actions/runner` release and its published linux-x64/win-x64 SHA-256 (parsed from the release-body `<!-- BEGIN SHA <arch> -->` markers) and substitute `{{RUNNER_VERSION}}` / `{{RUNNER_SHA256_LINUX}}` / `{{RUNNER_SHA256_WIN}}` into the generated Dockerfile + `setup-runner.ps1` (same pattern as `{{OWNER}}`/`{{LABEL}}`). Degrades to a real last-known-good pin (never a `REPLACE-ME`) with a warning if the `gh` lookup fails. The `sha256sum -c` / `Get-FileHash` supply-chain guards are untouched.
- **Staleness** — `doctor.mjs`: when `runner.enabled`, parse the scaffolded `RUNNER_VERSION` (Dockerfile, then ps1) and **WARN** (never fail) when it's behind the latest release, with a re-scaffold / bump hint. Silent skip when the runner files are absent or `gh` is unreachable.
- New shared lib `plugin/scripts/lib/runner-release.mjs` is the single source of truth for both paths.

## Tests

- `tests/runner.test.mjs`: scaffolded Dockerfile + ps1 carry a real pinned version + 64-hex SHA (no `REPLACE-ME`, no `{{...}}` left), via a mocked release response; graceful fallback when the release lookup fails.
- `tests/doctor.test.mjs`: staleness warns when behind, ok when current, silent skip on gh failure / absent files.
- `tests/lib/runner-release.test.mjs`: unit coverage for parse / compare / live+fallback pin.
- `fakegh` gains a route for the releases endpoint.

`pnpm verify` green (435/435). `claude plugin validate ./plugin --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SATRHKa6mDHDuirhP6QuwL