### PR TITLE
test(ci): raise vitest timeout for the slower self-hosted runner (#251)

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -4,5 +4,11 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.mjs'],
     watch: false,
+    // CI runs on self-hosted runners of variable speed (the ephemeral container
+    // runner is ~1.3x slower than a dev box), so the default 5s timeout flakes on
+    // borderline tests (e.g. the graph reindex test, ~6.6s on the runner). Give
+    // generous headroom — still far below any real hang. See #251.
+    testTimeout: 30000,
+    hookTimeout: 30000,
   },
 });


### PR DESCRIPTION
The ephemeral container runner is ~1.3× slower than a dev box, so the default 5s `testTimeout` flaked the AC-8.7 graph reindex test (~6.6s on `forge-local`) — 450/451, all runner tests green. Raise `testTimeout`/`hookTimeout` to 30s: generous headroom for variable self-hosted hardware, still far below any real hang.

Closes #251. Refs #180
