### PR TITLE
feat(runner): service-install tooling (systemd --user + NSSM) [#254]

### DIFF
--- a/docs/guides/runner-adoption.md
+++ b/docs/guides/runner-adoption.md
@@ -62,27 +62,37 @@ Steady state is **JIT + `--ephemeral`**: the supervisor mints a one-hour, single
 
 1. Ensure `docker`, `gh`, `node` are on the WSL PATH and the Docker daemon is reachable (`docker info`).
 2. Put the PAT in `~/.forge/runner.env` (chmod 600).
-3. Start the supervisor:
+3. **Install the durable service (the default):**
    ```bash
    cd runner/linux
-   set -a; . ~/.forge/runner.env; set +a      # foreground test; use systemd EnvironmentFile for a service
+   bash install-service.sh
+   ```
+   It writes a `systemd --user` unit (`EnvironmentFile=%h/.forge/runner.env`, `Environment=FORGE_RUNNER_CONCURRENCY=1`, `ExecStart=/usr/bin/env node <abs>/supervisor.mjs`, `Restart=on-failure`, `RestartSec=10`, `WantedBy=default.target`), runs `systemctl --user daemon-reload` + `enable --now forge-runner`, and attempts `loginctl enable-linger "$USER"` for boot/logout persistence (it prints the `sudo loginctl enable-linger <you>` fallback if that needs privileges, rather than hard-failing). It warns if `~/.forge/runner.env` is missing. Check with `systemctl --user status forge-runner` / `journalctl --user -u forge-runner -f`; remove with `bash install-service.sh --uninstall`.
+4. **Quick test (foreground)** — to sanity-check before installing the service:
+   ```bash
+   cd runner/linux
+   set -a; . ~/.forge/runner.env; set +a
    FORGE_RUNNER_CONCURRENCY=1 node supervisor.mjs
    ```
-   It builds the image on first run, mints a JIT config per job, and runs one ephemeral container per job. Leave it running.
-4. For durability, register it as a `systemd --user` service (`EnvironmentFile=%h/.forge/runner.env`) — see `runner/README.md`.
+   It builds the image on first run, mints a JIT config per job, and runs one ephemeral container per job.
 
 ### Windows leg (native host runner)
 
 1. **Execution policy** blocks unsigned scripts by default: `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` (session-scoped, no admin), or invoke via `powershell -ExecutionPolicy Bypass -File .\setup-runner.ps1 …`.
 2. `cd runner\windows; .\setup-runner.ps1 -Install` — downloads + checksum-verifies + unpacks the runner binary.
-3. Set the PAT and serve:
+3. **Install the durable service (the default).** Needs an **elevated** shell and `nssm` on PATH (`winget install NSSM.NSSM` or `choco install nssm`):
    ```powershell
-   $env:FORGE_RUNNER_PAT = '<token>'   # or pull from WSL: (wsl -d <distro> bash -lc 'grep -oP "(?<=FORGE_RUNNER_PAT=).*" ~/.forge/runner.env')
+   $env:FORGE_RUNNER_PAT = '<token>'   # THIS session only; or pull from WSL: (wsl -d <distro> bash -lc 'grep -oP "(?<=FORGE_RUNNER_PAT=).*" ~/.forge/runner.env')
+   .\setup-runner.ps1 -InstallService
+   ```
+   Registers a `forge-runner` NSSM service running `-Serve` (`AppDirectory=runner\windows`, `Start=SERVICE_AUTO_START`, restart-on-exit) with `AppEnvironmentExtra=FORGE_RUNNER_PAT=<value from $env:FORGE_RUNNER_PAT>` — the PAT is read from the session env at install time and never written to a committed file, `setx /M`, or this repo. It errors clearly if `$env:FORGE_RUNNER_PAT` is unset or the shell isn't elevated. Remove with `.\setup-runner.ps1 -UninstallService` (elevated).
+4. **Quick test (foreground)** — before installing the service:
+   ```powershell
+   $env:FORGE_RUNNER_PAT = '<token>'
    .\setup-runner.ps1 -Serve
    ```
-   It prepends Git Bash to PATH (so `bash`-shebang tools resolve to Git Bash, not WSL), mints a JIT config per job, and runs one ephemeral job at a time. Leave it running.
-4. Route the Windows leg to it: set `test-windows`'s `runs-on` to `[self-hosted, windows, forge-local]` and `forge.json` `runner.windows` to `"native"`. Keep a nightly hosted `windows-latest` run if you want a clean-image drift check.
-5. For durability, register `-Serve` as a Windows service (NSSM `AppEnvironmentExtra=FORGE_RUNNER_PAT=…`).
+   It prepends Git Bash to PATH (so `bash`-shebang tools resolve to Git Bash, not WSL), mints a JIT config per job, and runs one ephemeral job at a time.
+5. Route the Windows leg to it: set `test-windows`'s `runs-on` to `[self-hosted, windows, forge-local]` and `forge.json` `runner.windows` to `"native"`. Keep a nightly hosted `windows-latest` run if you want a clean-image drift check.
 
 ## Moving other workflows onto the runner
 

--- a/plugin/templates/runner/README.md
+++ b/plugin/templates/runner/README.md
@@ -55,20 +55,40 @@ verdict with a fix hint per line. It never reads or prints the PAT. Re-run until
    Docker + `gh` are on PATH. The build needs no JIT config — compose uses a
    build-safe default and the per-job config is required only at run time
    (enforced by `entrypoint.sh`).
-2. Register the supervisor as a **systemd** service that loads the secret as its
-   environment (never an interactive shell):
+2. Put the PAT in `~/.forge/runner.env` (chmod 600) — see "The one secret" above.
+3. **Install the durable service (the default):**
 
-   ```ini
-   # /etc/systemd/system/forge-runner.service
-   [Service]
-   EnvironmentFile=%h/.forge/runner.env
-   ExecStart=/usr/bin/node %h/<repo>/runner/linux/supervisor.mjs
-   Restart=always
+   ```sh
+   cd runner/linux
+   bash install-service.sh
    ```
 
-   `systemctl --user enable --now forge-runner` (or a system unit under the
-   service account). The supervisor reads `FORGE_RUNNER_PAT` from the service
-   environment only.
+   It writes `~/.config/systemd/user/forge-runner.service` with
+   `EnvironmentFile=%h/.forge/runner.env`, `Environment=FORGE_RUNNER_CONCURRENCY=1`,
+   `ExecStart=/usr/bin/env node <abs>/supervisor.mjs`, `Restart=on-failure`,
+   `RestartSec=10`, `WantedBy=default.target`; runs `systemctl --user daemon-reload`
+   then `systemctl --user enable --now forge-runner`; and attempts
+   `loginctl enable-linger "$USER"` so the service survives logout/reboot. If linger
+   needs privileges it prints the exact `sudo loginctl enable-linger <you>` to run
+   (it does not hard-fail). It warns if `~/.forge/runner.env` is missing (the
+   service would fail to start). Check it:
+
+   ```sh
+   systemctl --user status forge-runner
+   journalctl --user -u forge-runner -f
+   ```
+
+   Remove it with `bash install-service.sh --uninstall` (disable --now + delete the
+   unit; your `~/.forge/runner.env` is left untouched).
+4. **Quick test (foreground)** — to sanity-check the supervisor before installing
+   the service:
+
+   ```sh
+   set -a; . ~/.forge/runner.env; set +a
+   FORGE_RUNNER_CONCURRENCY=1 node supervisor.mjs
+   ```
+
+   The supervisor reads `FORGE_RUNNER_PAT` from its process environment only.
 
 ## Enable — native Windows host runner (default when a Windows box is present)
 
@@ -79,11 +99,29 @@ verdict with a fix hint per line. It never reads or prints the PAT. Re-run until
 
 1. `cd runner/windows; .\setup-runner.ps1 -Install` (downloads + checksum-verifies
    the runner binary).
-2. Register a Windows service (e.g. NSSM) that runs `.\setup-runner.ps1 -Serve`
-   with the PAT supplied via the **service environment** — NSSM
-   `AppEnvironmentExtra=FORGE_RUNNER_PAT=<token>` reading your out-of-band store —
-   not `setx`, not this repo.
-3. To route `verify.yml`'s Windows leg to this native runner, change the
+2. **Install the durable service (the default).** Needs an **elevated** shell and
+   `nssm` on PATH (`winget install NSSM.NSSM` or `choco install nssm`):
+
+   ```powershell
+   $env:FORGE_RUNNER_PAT = '<token>'   # THIS session only, from your out-of-band store
+   .\setup-runner.ps1 -InstallService
+   ```
+
+   This registers a `forge-runner` Windows service via NSSM that runs
+   `.\setup-runner.ps1 -Serve` with `AppDirectory = runner\windows`,
+   `Start = SERVICE_AUTO_START`, restart-on-exit, and
+   `AppEnvironmentExtra=FORGE_RUNNER_PAT=<value from $env:FORGE_RUNNER_PAT>`. The PAT
+   is read from the session env at install time and **never** written to a committed
+   file, `setx /M`, or this repo; the command errors if `$env:FORGE_RUNNER_PAT` is
+   unset or the shell isn't elevated. Remove it with
+   `.\setup-runner.ps1 -UninstallService` (elevated).
+3. **Quick test (foreground)** — before installing the service:
+
+   ```powershell
+   $env:FORGE_RUNNER_PAT = '<token>'
+   .\setup-runner.ps1 -Serve
+   ```
+4. To route `verify.yml`'s Windows leg to this native runner, change the
    `test-windows` job's `runs-on` to `[self-hosted, windows, {{LABEL}}]` — that
    makes the per-PR Windows check free too.
 

--- a/plugin/templates/runner/linux/install-service.sh
+++ b/plugin/templates/runner/linux/install-service.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# forge local runner service installer (Linux, systemd --user) - #253 AC1-AC3.
+#
+# Turns the foreground JIT supervisor (runner/linux/supervisor.mjs) into a durable
+# systemd --user service, so the Linux CI leg survives logout/reboot instead of
+# dying with a WSL terminal. Foreground `node supervisor.mjs` is now the quick-test
+# path; this is the durable default.
+#
+# SECRET MODEL (ADR-0005): the PAT is NEVER written here. The generated unit loads
+# it from the gitignored, chmod-600 ~/.forge/runner.env via systemd EnvironmentFile.
+# This script only writes a unit that REFERENCES that store; it never reads, echoes,
+# copies, or hardcodes the token.
+#
+# Usage:
+#   ./install-service.sh              install + enable --now + attempt linger
+#   ./install-service.sh --uninstall  stop + disable --now + remove the unit
+set -euo pipefail
+
+SERVICE=forge-runner
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+UNIT="$UNIT_DIR/${SERVICE}.service"
+ENV_FILE="$HOME/.forge/runner.env"
+
+log() { printf '[forge-runner-install] %s\n' "$1"; }
+
+uninstall() {
+  systemctl --user disable --now "$SERVICE" 2>/dev/null || true
+  rm -f "$UNIT"
+  systemctl --user daemon-reload 2>/dev/null || true
+  log "removed $SERVICE (unit deleted, service disabled)."
+  log "the PAT store $ENV_FILE was left untouched - delete it yourself if retiring the runner."
+  exit 0
+}
+
+case "${1:-}" in
+  --uninstall|-u) uninstall ;;
+  '') ;; # install path
+  *) log "unknown argument: $1 (pass nothing to install, or --uninstall to remove)"; exit 2 ;;
+esac
+
+# Resolve the absolute path to supervisor.mjs relative to THIS script's location
+# (runner/linux/), so the unit's ExecStart is host-independent.
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+SUPERVISOR="$SCRIPT_DIR/supervisor.mjs"
+
+if [ ! -f "$SUPERVISOR" ]; then
+  log "supervisor not found at $SUPERVISOR - run this from the repo's runner/linux/ scaffold."
+  exit 1
+fi
+if ! command -v node >/dev/null 2>&1; then
+  log "node not found on PATH - install Node >= 22.13 before enabling the service."
+  exit 1
+fi
+
+# The service will fail to start without the PAT store. Warn clearly (never write it).
+if [ ! -f "$ENV_FILE" ]; then
+  log "WARNING: $ENV_FILE is missing. The service loads FORGE_RUNNER_PAT from it via"
+  log "  systemd EnvironmentFile= and will FAIL to start until you create it:"
+  log "    mkdir -p ~/.forge && chmod 700 ~/.forge"
+  log "    printf 'FORGE_RUNNER_PAT=<token>\\n' > ~/.forge/runner.env && chmod 600 ~/.forge/runner.env"
+  log "  Create it, then re-run this installer (or: systemctl --user start $SERVICE)."
+fi
+
+mkdir -p "$UNIT_DIR"
+cat > "$UNIT" <<EOF
+[Unit]
+Description=forge local self-hosted runner supervisor (JIT + ephemeral)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# The one secret: loaded from the gitignored, chmod-600 store - NEVER committed,
+# never on argv, never inline in this unit (ADR-0005). The supervisor reads
+# FORGE_RUNNER_PAT from this service environment only.
+EnvironmentFile=%h/.forge/runner.env
+Environment=FORGE_RUNNER_CONCURRENCY=1
+ExecStart=/usr/bin/env node $SUPERVISOR
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+log "wrote $UNIT"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$SERVICE"
+log "enabled + started $SERVICE"
+
+# Boot/logout persistence: linger keeps --user services running while you are not
+# logged in. It may need privileges (polkit/sudo) - degrade gracefully with a note
+# rather than hard-failing an otherwise-successful install.
+if loginctl enable-linger "$USER" >/dev/null 2>&1; then
+  log "linger enabled for $USER - the service survives logout/reboot."
+else
+  log "NOTE: could not enable linger automatically (it usually needs privileges)."
+  log "  For boot/logout persistence, run once:  sudo loginctl enable-linger $USER"
+fi
+
+log "check status:  systemctl --user status $SERVICE"
+log "follow logs:   journalctl --user -u $SERVICE -f"

--- a/plugin/templates/runner/windows/setup-runner.ps1
+++ b/plugin/templates/runner/windows/setup-runner.ps1
@@ -20,14 +20,19 @@
   Enable (run once to install the runner binary, then register the service):
     1. gh auth is NOT used for minting - the service provides $env:FORGE_RUNNER_PAT.
     2. .\setup-runner.ps1 -Install            # downloads + unpacks the runner
-    3. Register a Windows service (e.g. NSSM) that runs:  .\setup-runner.ps1 -Serve
-       with AppEnvironmentExtra=FORGE_RUNNER_PAT=<token from your secret store>
-  See runner/README.md for the full per-OS instructions.
+    3. $env:FORGE_RUNNER_PAT = '<token>'      # this session only, from your store
+       .\setup-runner.ps1 -InstallService     # registers the durable NSSM service
+       (foreground .\setup-runner.ps1 -Serve is now just the quick-test path.)
+  -InstallService reads the PAT from the current session env and hands it to the
+  service as AppEnvironmentExtra=FORGE_RUNNER_PAT - never written to a committed
+  file, setx /M, or this repo. See runner/README.md for the full instructions.
 #>
 [CmdletBinding()]
 param(
   [switch]$Install,
   [switch]$Serve,
+  [switch]$InstallService,
+  [switch]$UninstallService,
   [string]$Owner = '{{OWNER}}',
   [string]$Repo = '{{REPO}}',
   [string]$Label = '{{LABEL}}',
@@ -119,6 +124,66 @@ function Serve-Runner {
   }
 }
 
+$ServiceName = 'forge-runner'
+
+function Assert-Admin {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+  if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Service install/uninstall requires an elevated session. Re-run PowerShell as Administrator.'
+  }
+}
+
+function Get-Nssm {
+  # NSSM (the Non-Sucking Service Manager) wraps a console app as a Windows service
+  # (ADR-0005). Require it on PATH rather than downloading a third-party binary into
+  # the repo tree: one less pinned SHA to keep current, nothing new to gitignore.
+  # Give a concrete install hint when it is absent.
+  $cmd = (Get-Command nssm -ErrorAction SilentlyContinue).Source
+  if (-not $cmd) {
+    throw 'nssm was not found on PATH. Install it (e.g. `winget install NSSM.NSSM` or `choco install nssm`), open a new elevated shell, then re-run. ADR-0005 registers the runner service via NSSM.'
+  }
+  return $cmd
+}
+
+function Install-Service {
+  Assert-Admin
+  # The one secret is read from THIS session's environment at install time and handed
+  # to the service as its own environment (NSSM AppEnvironmentExtra). It is NEVER
+  # written to a committed file, setx /M, or this repo. Error clearly when the session
+  # does not carry it.
+  if (-not $env:FORGE_RUNNER_PAT) {
+    throw 'FORGE_RUNNER_PAT is not set in this session. Set it for THIS install session only (from your out-of-band store): $env:FORGE_RUNNER_PAT = ''<token>'' - never setx /M, never a committed file - then re-run -InstallService.'
+  }
+  $nssm = Get-Nssm
+  $psExe = (Get-Command powershell -ErrorAction SilentlyContinue).Source
+  if (-not $psExe) { $psExe = 'powershell' }
+  $script = Join-Path $PSScriptRoot 'setup-runner.ps1'
+  # Replace any prior registration so re-install is clean.
+  & $nssm stop $ServiceName confirm 2>$null | Out-Null
+  & $nssm remove $ServiceName confirm 2>$null | Out-Null
+  & $nssm install $ServiceName $psExe '-NoProfile' '-ExecutionPolicy' 'Bypass' '-File' $script '-Serve'
+  & $nssm set $ServiceName AppDirectory $PSScriptRoot
+  & $nssm set $ServiceName Start SERVICE_AUTO_START
+  & $nssm set $ServiceName AppExit Default Restart
+  & $nssm set $ServiceName AppRestartDelay 10000
+  # AppEnvironmentExtra = the PAT from the current session env (never a literal, never a file).
+  & $nssm set $ServiceName AppEnvironmentExtra "FORGE_RUNNER_PAT=$env:FORGE_RUNNER_PAT"
+  & $nssm start $ServiceName
+  Write-Log "installed + started service '$ServiceName' (NSSM: auto-start, restart-on-exit)"
+  Write-Log "status:  nssm status $ServiceName   |   stop/edit: nssm stop|edit $ServiceName"
+}
+
+function Uninstall-Service {
+  Assert-Admin
+  $nssm = Get-Nssm
+  & $nssm stop $ServiceName confirm 2>$null | Out-Null
+  & $nssm remove $ServiceName confirm
+  Write-Log "removed service '$ServiceName'"
+}
+
 if ($Install) { Install-Runner }
 elseif ($Serve) { Serve-Runner }
-else { Write-Log 'nothing to do - pass -Install or -Serve (see runner/README.md)' }
+elseif ($InstallService) { Install-Service }
+elseif ($UninstallService) { Uninstall-Service }
+else { Write-Log 'nothing to do - pass -Install, -Serve, -InstallService, or -UninstallService (see runner/README.md)' }

--- a/runner/README.md
+++ b/runner/README.md
@@ -55,20 +55,40 @@ verdict with a fix hint per line. It never reads or prints the PAT. Re-run until
    Docker + `gh` are on PATH. The build needs no JIT config — compose uses a
    build-safe default and the per-job config is required only at run time
    (enforced by `entrypoint.sh`).
-2. Register the supervisor as a **systemd** service that loads the secret as its
-   environment (never an interactive shell):
+2. Put the PAT in `~/.forge/runner.env` (chmod 600) — see "The one secret" above.
+3. **Install the durable service (the default):**
 
-   ```ini
-   # /etc/systemd/system/forge-runner.service
-   [Service]
-   EnvironmentFile=%h/.forge/runner.env
-   ExecStart=/usr/bin/node %h/<repo>/runner/linux/supervisor.mjs
-   Restart=always
+   ```sh
+   cd runner/linux
+   bash install-service.sh
    ```
 
-   `systemctl --user enable --now forge-runner` (or a system unit under the
-   service account). The supervisor reads `FORGE_RUNNER_PAT` from the service
-   environment only.
+   It writes `~/.config/systemd/user/forge-runner.service` with
+   `EnvironmentFile=%h/.forge/runner.env`, `Environment=FORGE_RUNNER_CONCURRENCY=1`,
+   `ExecStart=/usr/bin/env node <abs>/supervisor.mjs`, `Restart=on-failure`,
+   `RestartSec=10`, `WantedBy=default.target`; runs `systemctl --user daemon-reload`
+   then `systemctl --user enable --now forge-runner`; and attempts
+   `loginctl enable-linger "$USER"` so the service survives logout/reboot. If linger
+   needs privileges it prints the exact `sudo loginctl enable-linger <you>` to run
+   (it does not hard-fail). It warns if `~/.forge/runner.env` is missing (the
+   service would fail to start). Check it:
+
+   ```sh
+   systemctl --user status forge-runner
+   journalctl --user -u forge-runner -f
+   ```
+
+   Remove it with `bash install-service.sh --uninstall` (disable --now + delete the
+   unit; your `~/.forge/runner.env` is left untouched).
+4. **Quick test (foreground)** — to sanity-check the supervisor before installing
+   the service:
+
+   ```sh
+   set -a; . ~/.forge/runner.env; set +a
+   FORGE_RUNNER_CONCURRENCY=1 node supervisor.mjs
+   ```
+
+   The supervisor reads `FORGE_RUNNER_PAT` from its process environment only.
 
 ## Enable — native Windows host runner (default when a Windows box is present)
 
@@ -79,11 +99,29 @@ verdict with a fix hint per line. It never reads or prints the PAT. Re-run until
 
 1. `cd runner/windows; .\setup-runner.ps1 -Install` (downloads + checksum-verifies
    the runner binary).
-2. Register a Windows service (e.g. NSSM) that runs `.\setup-runner.ps1 -Serve`
-   with the PAT supplied via the **service environment** — NSSM
-   `AppEnvironmentExtra=FORGE_RUNNER_PAT=<token>` reading your out-of-band store —
-   not `setx`, not this repo.
-3. To route `verify.yml`'s Windows leg to this native runner, change the
+2. **Install the durable service (the default).** Needs an **elevated** shell and
+   `nssm` on PATH (`winget install NSSM.NSSM` or `choco install nssm`):
+
+   ```powershell
+   $env:FORGE_RUNNER_PAT = '<token>'   # THIS session only, from your out-of-band store
+   .\setup-runner.ps1 -InstallService
+   ```
+
+   This registers a `forge-runner` Windows service via NSSM that runs
+   `.\setup-runner.ps1 -Serve` with `AppDirectory = runner\windows`,
+   `Start = SERVICE_AUTO_START`, restart-on-exit, and
+   `AppEnvironmentExtra=FORGE_RUNNER_PAT=<value from $env:FORGE_RUNNER_PAT>`. The PAT
+   is read from the session env at install time and **never** written to a committed
+   file, `setx /M`, or this repo; the command errors if `$env:FORGE_RUNNER_PAT` is
+   unset or the shell isn't elevated. Remove it with
+   `.\setup-runner.ps1 -UninstallService` (elevated).
+3. **Quick test (foreground)** — before installing the service:
+
+   ```powershell
+   $env:FORGE_RUNNER_PAT = '<token>'
+   .\setup-runner.ps1 -Serve
+   ```
+4. To route `verify.yml`'s Windows leg to this native runner, change the
    `test-windows` job's `runs-on` to `[self-hosted, windows, forge-local]` — that
    makes the per-PR Windows check free too.
 

--- a/runner/linux/install-service.sh
+++ b/runner/linux/install-service.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# forge local runner service installer (Linux, systemd --user) - #253 AC1-AC3.
+#
+# Turns the foreground JIT supervisor (runner/linux/supervisor.mjs) into a durable
+# systemd --user service, so the Linux CI leg survives logout/reboot instead of
+# dying with a WSL terminal. Foreground `node supervisor.mjs` is now the quick-test
+# path; this is the durable default.
+#
+# SECRET MODEL (ADR-0005): the PAT is NEVER written here. The generated unit loads
+# it from the gitignored, chmod-600 ~/.forge/runner.env via systemd EnvironmentFile.
+# This script only writes a unit that REFERENCES that store; it never reads, echoes,
+# copies, or hardcodes the token.
+#
+# Usage:
+#   ./install-service.sh              install + enable --now + attempt linger
+#   ./install-service.sh --uninstall  stop + disable --now + remove the unit
+set -euo pipefail
+
+SERVICE=forge-runner
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+UNIT="$UNIT_DIR/${SERVICE}.service"
+ENV_FILE="$HOME/.forge/runner.env"
+
+log() { printf '[forge-runner-install] %s\n' "$1"; }
+
+uninstall() {
+  systemctl --user disable --now "$SERVICE" 2>/dev/null || true
+  rm -f "$UNIT"
+  systemctl --user daemon-reload 2>/dev/null || true
+  log "removed $SERVICE (unit deleted, service disabled)."
+  log "the PAT store $ENV_FILE was left untouched - delete it yourself if retiring the runner."
+  exit 0
+}
+
+case "${1:-}" in
+  --uninstall|-u) uninstall ;;
+  '') ;; # install path
+  *) log "unknown argument: $1 (pass nothing to install, or --uninstall to remove)"; exit 2 ;;
+esac
+
+# Resolve the absolute path to supervisor.mjs relative to THIS script's location
+# (runner/linux/), so the unit's ExecStart is host-independent.
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+SUPERVISOR="$SCRIPT_DIR/supervisor.mjs"
+
+if [ ! -f "$SUPERVISOR" ]; then
+  log "supervisor not found at $SUPERVISOR - run this from the repo's runner/linux/ scaffold."
+  exit 1
+fi
+if ! command -v node >/dev/null 2>&1; then
+  log "node not found on PATH - install Node >= 22.13 before enabling the service."
+  exit 1
+fi
+
+# The service will fail to start without the PAT store. Warn clearly (never write it).
+if [ ! -f "$ENV_FILE" ]; then
+  log "WARNING: $ENV_FILE is missing. The service loads FORGE_RUNNER_PAT from it via"
+  log "  systemd EnvironmentFile= and will FAIL to start until you create it:"
+  log "    mkdir -p ~/.forge && chmod 700 ~/.forge"
+  log "    printf 'FORGE_RUNNER_PAT=<token>\\n' > ~/.forge/runner.env && chmod 600 ~/.forge/runner.env"
+  log "  Create it, then re-run this installer (or: systemctl --user start $SERVICE)."
+fi
+
+mkdir -p "$UNIT_DIR"
+cat > "$UNIT" <<EOF
+[Unit]
+Description=forge local self-hosted runner supervisor (JIT + ephemeral)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# The one secret: loaded from the gitignored, chmod-600 store - NEVER committed,
+# never on argv, never inline in this unit (ADR-0005). The supervisor reads
+# FORGE_RUNNER_PAT from this service environment only.
+EnvironmentFile=%h/.forge/runner.env
+Environment=FORGE_RUNNER_CONCURRENCY=1
+ExecStart=/usr/bin/env node $SUPERVISOR
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+log "wrote $UNIT"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$SERVICE"
+log "enabled + started $SERVICE"
+
+# Boot/logout persistence: linger keeps --user services running while you are not
+# logged in. It may need privileges (polkit/sudo) - degrade gracefully with a note
+# rather than hard-failing an otherwise-successful install.
+if loginctl enable-linger "$USER" >/dev/null 2>&1; then
+  log "linger enabled for $USER - the service survives logout/reboot."
+else
+  log "NOTE: could not enable linger automatically (it usually needs privileges)."
+  log "  For boot/logout persistence, run once:  sudo loginctl enable-linger $USER"
+fi
+
+log "check status:  systemctl --user status $SERVICE"
+log "follow logs:   journalctl --user -u $SERVICE -f"

--- a/runner/windows/setup-runner.ps1
+++ b/runner/windows/setup-runner.ps1
@@ -20,14 +20,19 @@
   Enable (run once to install the runner binary, then register the service):
     1. gh auth is NOT used for minting - the service provides $env:FORGE_RUNNER_PAT.
     2. .\setup-runner.ps1 -Install            # downloads + unpacks the runner
-    3. Register a Windows service (e.g. NSSM) that runs:  .\setup-runner.ps1 -Serve
-       with AppEnvironmentExtra=FORGE_RUNNER_PAT=<token from your secret store>
-  See runner/README.md for the full per-OS instructions.
+    3. $env:FORGE_RUNNER_PAT = '<token>'      # this session only, from your store
+       .\setup-runner.ps1 -InstallService     # registers the durable NSSM service
+       (foreground .\setup-runner.ps1 -Serve is now just the quick-test path.)
+  -InstallService reads the PAT from the current session env and hands it to the
+  service as AppEnvironmentExtra=FORGE_RUNNER_PAT - never written to a committed
+  file, setx /M, or this repo. See runner/README.md for the full instructions.
 #>
 [CmdletBinding()]
 param(
   [switch]$Install,
   [switch]$Serve,
+  [switch]$InstallService,
+  [switch]$UninstallService,
   [string]$Owner = 'dngioidev',
   [string]$Repo = 'forge',
   [string]$Label = 'forge-local',
@@ -116,6 +121,66 @@ function Serve-Runner {
   }
 }
 
+$ServiceName = 'forge-runner'
+
+function Assert-Admin {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+  if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Service install/uninstall requires an elevated session. Re-run PowerShell as Administrator.'
+  }
+}
+
+function Get-Nssm {
+  # NSSM (the Non-Sucking Service Manager) wraps a console app as a Windows service
+  # (ADR-0005). Require it on PATH rather than downloading a third-party binary into
+  # the repo tree: one less pinned SHA to keep current, nothing new to gitignore.
+  # Give a concrete install hint when it is absent.
+  $cmd = (Get-Command nssm -ErrorAction SilentlyContinue).Source
+  if (-not $cmd) {
+    throw 'nssm was not found on PATH. Install it (e.g. `winget install NSSM.NSSM` or `choco install nssm`), open a new elevated shell, then re-run. ADR-0005 registers the runner service via NSSM.'
+  }
+  return $cmd
+}
+
+function Install-Service {
+  Assert-Admin
+  # The one secret is read from THIS session's environment at install time and handed
+  # to the service as its own environment (NSSM AppEnvironmentExtra). It is NEVER
+  # written to a committed file, setx /M, or this repo. Error clearly when the session
+  # does not carry it.
+  if (-not $env:FORGE_RUNNER_PAT) {
+    throw 'FORGE_RUNNER_PAT is not set in this session. Set it for THIS install session only (from your out-of-band store): $env:FORGE_RUNNER_PAT = ''<token>'' - never setx /M, never a committed file - then re-run -InstallService.'
+  }
+  $nssm = Get-Nssm
+  $psExe = (Get-Command powershell -ErrorAction SilentlyContinue).Source
+  if (-not $psExe) { $psExe = 'powershell' }
+  $script = Join-Path $PSScriptRoot 'setup-runner.ps1'
+  # Replace any prior registration so re-install is clean.
+  & $nssm stop $ServiceName confirm 2>$null | Out-Null
+  & $nssm remove $ServiceName confirm 2>$null | Out-Null
+  & $nssm install $ServiceName $psExe '-NoProfile' '-ExecutionPolicy' 'Bypass' '-File' $script '-Serve'
+  & $nssm set $ServiceName AppDirectory $PSScriptRoot
+  & $nssm set $ServiceName Start SERVICE_AUTO_START
+  & $nssm set $ServiceName AppExit Default Restart
+  & $nssm set $ServiceName AppRestartDelay 10000
+  # AppEnvironmentExtra = the PAT from the current session env (never a literal, never a file).
+  & $nssm set $ServiceName AppEnvironmentExtra "FORGE_RUNNER_PAT=$env:FORGE_RUNNER_PAT"
+  & $nssm start $ServiceName
+  Write-Log "installed + started service '$ServiceName' (NSSM: auto-start, restart-on-exit)"
+  Write-Log "status:  nssm status $ServiceName   |   stop/edit: nssm stop|edit $ServiceName"
+}
+
+function Uninstall-Service {
+  Assert-Admin
+  $nssm = Get-Nssm
+  & $nssm stop $ServiceName confirm 2>$null | Out-Null
+  & $nssm remove $ServiceName confirm
+  Write-Log "removed service '$ServiceName'"
+}
+
 if ($Install) { Install-Runner }
 elseif ($Serve) { Serve-Runner }
-else { Write-Log 'nothing to do - pass -Install or -Serve (see runner/README.md)' }
+elseif ($InstallService) { Install-Service }
+elseif ($UninstallService) { Uninstall-Service }
+else { Write-Log 'nothing to do - pass -Install, -Serve, -InstallService, or -UninstallService (see runner/README.md)' }

--- a/tests/runner.test.mjs
+++ b/tests/runner.test.mjs
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { mkdtemp, mkdir, writeFile, readFile, readdir, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { runRunnerInit, parseArgs, ensureGitleaksAllowlist } from '../plugin/scripts/runner/init.mjs';
 import { runInit, parseArgs as parseInitArgs } from '../plugin/scripts/init.mjs';
 import { fakeGh } from './helpers/fakegh.mjs';
@@ -118,10 +119,18 @@ describe('AC2 — private-repo scaffold', () => {
     expect(supervisor).toContain('dngioidev'); // owner substituted
     expect(supervisor).toContain('forge-local'); // label substituted
 
+    // #254: the durable systemd --user installer is scaffolded alongside the supervisor.
+    const installSh = await readFile(join(cwd, 'runner', 'linux', 'install-service.sh'), 'utf8');
+    expect(installSh).toContain('EnvironmentFile=%h/.forge/runner.env');
+    expect(installSh).toContain('WantedBy=default.target');
+
     await stat(join(cwd, 'runner', 'linux', 'entrypoint.sh'));
     const ps1 = await readFile(join(cwd, 'runner', 'windows', 'setup-runner.ps1'), 'utf8');
     expect(ps1).toContain('Get-FileHash'); // checksum-verified windows runner download
     expect(ps1).toContain('forge-local');
+    // #254: the NSSM service registration flags are scaffolded into the same script.
+    expect(ps1).toContain('[switch]$InstallService');
+    expect(ps1).toContain('[switch]$UninstallService');
     // #233: win-x64 version + SHA auto-pinned; no placeholder left.
     expect(ps1).toContain(`$RunnerVersion = '${REL_VERSION}'`);
     expect(ps1).toContain(`$RunnerSha256 = '${REL_WIN}'`);
@@ -338,5 +347,66 @@ describe('AC3 — secret-store guards, no secret committed', () => {
       expect(body).not.toMatch(/github_pat_[A-Za-z0-9_]{20,}/);
       expect(body).not.toMatch(/ghp_[A-Za-z0-9]{30,}/);
     }
+  });
+});
+
+describe('#254 — service install tooling (structural)', () => {
+  const tpl = (p) => fileURLToPath(new URL(`../plugin/templates/runner/${p}`, import.meta.url));
+
+  it('linux install-service.sh writes a systemd --user unit, PAT via EnvironmentFile only', async () => {
+    const sh = await readFile(tpl('linux/install-service.sh'), 'utf8');
+    // secret model: PAT loaded from the out-of-band store, never inlined into the unit
+    expect(sh).toContain('EnvironmentFile=%h/.forge/runner.env');
+    expect(sh).toContain('Environment=FORGE_RUNNER_CONCURRENCY=1');
+    expect(sh).toContain('Restart=on-failure');
+    expect(sh).toContain('RestartSec=10');
+    expect(sh).toContain('WantedBy=default.target');
+    // ExecStart runs node against the resolved supervisor path
+    expect(sh).toMatch(/ExecStart=\/usr\/bin\/env node /);
+    // install lifecycle: reload + enable --now + boot persistence
+    expect(sh).toContain('systemctl --user daemon-reload');
+    expect(sh).toContain('systemctl --user enable --now');
+    expect(sh).toContain('loginctl enable-linger');
+    // uninstall counterpart
+    expect(sh).toContain('--uninstall');
+    expect(sh).toContain('disable --now');
+    // status/logs guidance
+    expect(sh).toContain('systemctl --user status');
+    expect(sh).toContain('journalctl --user -u');
+    // no hardcoded PAT anywhere
+    expect(sh).not.toMatch(/github_pat_[A-Za-z0-9_]{20,}/);
+    expect(sh).not.toMatch(/ghp_[A-Za-z0-9]{30,}/);
+  });
+
+  it('linux install-service.sh is ASCII-only', async () => {
+    const sh = await readFile(tpl('linux/install-service.sh'), 'utf8');
+    expect(/^[\x00-\x7F]*$/.test(sh)).toBe(true);
+  });
+
+  it('windows -InstallService uses AppEnvironmentExtra from env, never a literal or a file', async () => {
+    const ps1 = await readFile(tpl('windows/setup-runner.ps1'), 'utf8');
+    expect(ps1).toContain('[switch]$InstallService');
+    expect(ps1).toContain('[switch]$UninstallService');
+    // PAT sourced from THIS session env, handed to the service via AppEnvironmentExtra
+    expect(ps1).toContain('AppEnvironmentExtra');
+    expect(ps1).toContain('FORGE_RUNNER_PAT=$env:FORGE_RUNNER_PAT');
+    // errors clearly when the session PAT is unset
+    expect(ps1).toMatch(/if \(-not \$env:FORGE_RUNNER_PAT\)/);
+    // requires elevation + NSSM (graceful hints)
+    expect(ps1).toContain('Assert-Admin');
+    expect(ps1).toMatch(/nssm/i);
+    // service config: auto-start + restart-on-exit, args run -Serve
+    expect(ps1).toContain('SERVICE_AUTO_START');
+    expect(ps1).toContain('AppExit Default Restart');
+    expect(ps1).toMatch(/'-File'[^\n]*'-Serve'/);
+    // never persists the PAT to a file (no Out-File/Set-Content/Add-Content carrying it)
+    expect(ps1).not.toMatch(/FORGE_RUNNER_PAT[^\n]*(Out-File|Set-Content|Add-Content)/);
+    // no literal PAT
+    expect(ps1).not.toMatch(/github_pat_[A-Za-z0-9_]{20,}/);
+  });
+
+  it('windows setup-runner.ps1 stays ASCII-only with the new service code (#240 guard)', async () => {
+    const ps1 = await readFile(tpl('windows/setup-runner.ps1'), 'utf8');
+    expect(/^[\x00-\x7F]*$/.test(ps1)).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Turns the runner README's systemd/NSSM *prose* into real, runnable install tooling so both supervisors run as durable services instead of foreground terminals (AC1-AC3 of #253). The install on this box is AC4, done after merge.

### Linux (systemd --user)
- New `runner/linux/install-service.sh` (+ identical template) writes `~/.config/systemd/user/forge-runner.service` with `EnvironmentFile=%h/.forge/runner.env`, `Environment=FORGE_RUNNER_CONCURRENCY=1`, `ExecStart=/usr/bin/env node <abs supervisor.mjs>` (resolved relative to the script), `Restart=on-failure`, `RestartSec=10`, `WantedBy=default.target`.
- Runs `daemon-reload` + `enable --now`, then attempts `loginctl enable-linger` for boot/logout persistence — prints the `sudo loginctl enable-linger` fallback instead of hard-failing.
- Warns clearly if `~/.forge/runner.env` is missing; prints status/logs commands. `--uninstall` = `disable --now` + remove the unit.

### Windows (NSSM)
- `setup-runner.ps1` gains `-InstallService` / `-UninstallService`: register a `forge-runner` NSSM service running `-Serve` (`AppDirectory`, `Start=SERVICE_AUTO_START`, restart-on-exit) with `AppEnvironmentExtra=FORGE_RUNNER_PAT=<value from $env:FORGE_RUNNER_PAT>`.
- **Design fork resolved:** require `nssm` on PATH (with a `winget`/`choco` hint) rather than vendoring a pinned binary — no extra SHA to keep current, nothing new to gitignore. Detects non-elevated + missing nssm + unset PAT, each with a clear message.
- `-Install` / `-Serve` behaviour and the ASCII-only (#240) discipline are intact.

## Secret model (unchanged)
The PAT lives **only** in the service environment (systemd `EnvironmentFile`; NSSM `AppEnvironmentExtra` read from the session env at install time) — never in a committed file, `setx /M`, the supervisor's argv, or a log line.

## Tests & docs
- `tests/runner.test.mjs`: structural assertions on the generated systemd unit + NSSM wiring, PAT-never-in-a-file/literal, and the ASCII guard extended over the new PS code. Full suite green (455/455).
- `runner/README.md` + `docs/guides/runner-adoption.md` (+ templates): service install is now the durable default; foreground `node supervisor.mjs` / `-Serve` is the quick-test path.
- `pnpm verify` 455/455, `claude plugin validate ./plugin --strict` passed, both `.ps1` parse-clean under Windows PowerShell 5.1.

Closes #254 · Refs #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)