### PR TITLE
fix(runner-win): give the LocalSystem NSSM service gh on PATH + logging (#258)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 runner.env
 *.runner.env
 runner/windows/actions-runner/
+runner/windows/logs/

--- a/plugin/templates/runner/windows/setup-runner.ps1
+++ b/plugin/templates/runner/windows/setup-runner.ps1
@@ -159,6 +159,22 @@ function Install-Service {
   $psExe = (Get-Command powershell -ErrorAction SilentlyContinue).Source
   if (-not $psExe) { $psExe = 'powershell' }
   $script = Join-Path $PSScriptRoot 'setup-runner.ps1'
+  # An NSSM service runs as LocalSystem by default, which does NOT inherit the user's
+  # PATH - so a user-scoped `gh` (e.g. %LOCALAPPDATA%\gh-cli) is invisible and the JIT
+  # mint fails, the process exits, and NSSM throttles the service to Paused. Prepend
+  # gh's dir (resolved now) to the machine PATH for the service.
+  $ghSrc = (Get-Command gh -ErrorAction SilentlyContinue).Source
+  $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+  if ($ghSrc) {
+    $svcPath = "$(Split-Path $ghSrc);$machinePath"
+  } else {
+    Write-Log "WARNING: gh not found on PATH now - the LocalSystem service likely won't find it either. Put gh on the machine PATH."
+    $svcPath = $machinePath
+  }
+  # Capture the service's output so a fast-exit is diagnosable (dir is gitignored).
+  $logDir = Join-Path $PSScriptRoot 'logs'
+  New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
   # NSSM writes progress to stderr; under $ErrorActionPreference='Stop' that native
   # stderr becomes a terminating error (PS 5.1 NativeCommandError). Run the nssm calls
   # non-terminating and verify the result explicitly. Only pre-clean when the service
@@ -176,16 +192,29 @@ function Install-Service {
     & $nssm set $ServiceName Start SERVICE_AUTO_START
     & $nssm set $ServiceName AppExit Default Restart
     & $nssm set $ServiceName AppRestartDelay 10000
-    # AppEnvironmentExtra = the PAT from the current session env (never a literal, never a file).
-    & $nssm set $ServiceName AppEnvironmentExtra "FORGE_RUNNER_PAT=$env:FORGE_RUNNER_PAT"
+    & $nssm set $ServiceName AppStdout (Join-Path $logDir 'service.out.log')
+    & $nssm set $ServiceName AppStderr (Join-Path $logDir 'service.err.log')
+    # AppEnvironmentExtra = the PAT (from this session env) + a PATH that carries gh to
+    # LocalSystem. Never a literal token, never a committed file.
+    & $nssm set $ServiceName AppEnvironmentExtra "FORGE_RUNNER_PAT=$env:FORGE_RUNNER_PAT" "PATH=$svcPath"
     & $nssm start $ServiceName
   } finally {
     $ErrorActionPreference = $prevEAP
   }
-  Start-Sleep -Seconds 2
-  $svc = Get-Service $ServiceName -ErrorAction SilentlyContinue
+  # NSSM pauses an app that exits too fast (throttle) - poll briefly for Running.
+  $svc = $null
+  for ($i = 0; $i -lt 6; $i++) {
+    Start-Sleep -Seconds 2
+    $svc = Get-CimInstance Win32_Service -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue
+    if ($svc -and $svc.State -eq 'Running') { break }
+  }
   if (-not $svc) { throw "service '$ServiceName' was not created - run 'nssm install $ServiceName ...' manually to see the error." }
-  Write-Log "installed service '$ServiceName' (NSSM: auto-start, restart-on-exit); status: $($svc.Status)"
+  if ($svc.State -eq 'Running') {
+    Write-Log "installed + started service '$ServiceName' (Running; auto-start, restart-on-exit)"
+  } else {
+    Write-Log "WARNING: '$ServiceName' state is '$($svc.State)' - NSSM throttles a fast-exiting app."
+    Write-Log "  Check the service log: $logDir\service.err.log  (common cause: a tool like gh not on the LocalSystem PATH)."
+  }
   Write-Log "status:  nssm status $ServiceName   |   stop/edit: nssm stop|edit $ServiceName"
 }
 

--- a/runner/windows/setup-runner.ps1
+++ b/runner/windows/setup-runner.ps1
@@ -156,6 +156,22 @@ function Install-Service {
   $psExe = (Get-Command powershell -ErrorAction SilentlyContinue).Source
   if (-not $psExe) { $psExe = 'powershell' }
   $script = Join-Path $PSScriptRoot 'setup-runner.ps1'
+  # An NSSM service runs as LocalSystem by default, which does NOT inherit the user's
+  # PATH - so a user-scoped `gh` (e.g. %LOCALAPPDATA%\gh-cli) is invisible and the JIT
+  # mint fails, the process exits, and NSSM throttles the service to Paused. Prepend
+  # gh's dir (resolved now) to the machine PATH for the service.
+  $ghSrc = (Get-Command gh -ErrorAction SilentlyContinue).Source
+  $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+  if ($ghSrc) {
+    $svcPath = "$(Split-Path $ghSrc);$machinePath"
+  } else {
+    Write-Log "WARNING: gh not found on PATH now - the LocalSystem service likely won't find it either. Put gh on the machine PATH."
+    $svcPath = $machinePath
+  }
+  # Capture the service's output so a fast-exit is diagnosable (dir is gitignored).
+  $logDir = Join-Path $PSScriptRoot 'logs'
+  New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
   # NSSM writes progress to stderr; under $ErrorActionPreference='Stop' that native
   # stderr becomes a terminating error (PS 5.1 NativeCommandError). Run the nssm calls
   # non-terminating and verify the result explicitly. Only pre-clean when the service
@@ -173,16 +189,29 @@ function Install-Service {
     & $nssm set $ServiceName Start SERVICE_AUTO_START
     & $nssm set $ServiceName AppExit Default Restart
     & $nssm set $ServiceName AppRestartDelay 10000
-    # AppEnvironmentExtra = the PAT from the current session env (never a literal, never a file).
-    & $nssm set $ServiceName AppEnvironmentExtra "FORGE_RUNNER_PAT=$env:FORGE_RUNNER_PAT"
+    & $nssm set $ServiceName AppStdout (Join-Path $logDir 'service.out.log')
+    & $nssm set $ServiceName AppStderr (Join-Path $logDir 'service.err.log')
+    # AppEnvironmentExtra = the PAT (from this session env) + a PATH that carries gh to
+    # LocalSystem. Never a literal token, never a committed file.
+    & $nssm set $ServiceName AppEnvironmentExtra "FORGE_RUNNER_PAT=$env:FORGE_RUNNER_PAT" "PATH=$svcPath"
     & $nssm start $ServiceName
   } finally {
     $ErrorActionPreference = $prevEAP
   }
-  Start-Sleep -Seconds 2
-  $svc = Get-Service $ServiceName -ErrorAction SilentlyContinue
+  # NSSM pauses an app that exits too fast (throttle) - poll briefly for Running.
+  $svc = $null
+  for ($i = 0; $i -lt 6; $i++) {
+    Start-Sleep -Seconds 2
+    $svc = Get-CimInstance Win32_Service -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue
+    if ($svc -and $svc.State -eq 'Running') { break }
+  }
   if (-not $svc) { throw "service '$ServiceName' was not created - run 'nssm install $ServiceName ...' manually to see the error." }
-  Write-Log "installed service '$ServiceName' (NSSM: auto-start, restart-on-exit); status: $($svc.Status)"
+  if ($svc.State -eq 'Running') {
+    Write-Log "installed + started service '$ServiceName' (Running; auto-start, restart-on-exit)"
+  } else {
+    Write-Log "WARNING: '$ServiceName' state is '$($svc.State)' - NSSM throttles a fast-exiting app."
+    Write-Log "  Check the service log: $logDir\service.err.log  (common cause: a tool like gh not on the LocalSystem PATH)."
+  }
   Write-Log "status:  nssm status $ServiceName   |   stop/edit: nssm stop|edit $ServiceName"
 }
 

--- a/tests/runner.test.mjs
+++ b/tests/runner.test.mjs
@@ -409,6 +409,11 @@ describe('#254 — service install tooling (structural)', () => {
     expect(ps1).toMatch(/if \(Get-Service \$ServiceName -ErrorAction SilentlyContinue\)/);
     expect(ps1).toContain("$ErrorActionPreference = 'Continue'");
     expect(ps1).not.toMatch(/nssm[^\n]*stop[^\n]*2>\$null/i); // the old terminating pattern is gone
+    // #258: the LocalSystem service needs gh on its PATH (user-scoped gh is invisible
+    // to LocalSystem), carried via AppEnvironmentExtra PATH; and its output is logged.
+    expect(ps1).toMatch(/Get-Command gh/);
+    expect(ps1).toContain('PATH=$svcPath');
+    expect(ps1).toMatch(/AppStderr/);
   });
 
   it('windows setup-runner.ps1 stays ASCII-only with the new service code (#240 guard)', async () => {


### PR DESCRIPTION
The NSSM service runs as **LocalSystem**, which doesn't inherit the user PATH — so a user-scoped `gh` (`%LOCALAPPDATA%\gh-cli`) was invisible, `-Serve` couldn't mint JIT, exited, and NSSM throttled the service to **Paused** (no output captured). Fix: `-InstallService` resolves gh's dir at install time and carries it to the service via `AppEnvironmentExtra PATH`, sets `AppStdout`/`AppStderr` to `runner/windows/logs/` (gitignored), and polls for **Running** (warns + points at the log if Paused). Instance + template, ASCII/parse verified, tests + gitignore updated.

Closes #258. Refs #253