### PR TITLE
feat(cockpit): PySide6 app shell + uv scaffold + interop helper (#272)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -114,12 +114,22 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Show uv + resolved Python
-        # Depend only on `uv` being on PATH; uv discovers/provisions the
-        # interpreter itself, so we never call bare `python` here.
+        # The self-hosted runner service does not inherit the full Machine PATH,
+        # so each step (a fresh shell) prepends the known toolchain dirs itself:
+        # Python 3.12 + uv (WinGet Links). uv then discovers/provisions the
+        # interpreter, so we never call bare `python` here.
+        shell: pwsh
         run: |
+          $env:PATH = "C:\Program Files\Python312;C:\Program Files\Python312\Scripts;C:\Program Files\WinGet\Links;$env:PATH"
           uv --version
           uv python find
       - name: Sync deps from committed uv.lock
-        run: uv sync --frozen
+        shell: pwsh
+        run: |
+          $env:PATH = "C:\Program Files\Python312;C:\Program Files\Python312\Scripts;C:\Program Files\WinGet\Links;$env:PATH"
+          uv sync --frozen
       - name: Run cockpit test suite (headless)
-        run: uv run pytest -q
+        shell: pwsh
+        run: |
+          $env:PATH = "C:\Program Files\Python312;C:\Program Files\Python312\Scripts;C:\Program Files\WinGet\Links;$env:PATH"
+          uv run pytest -q

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -96,3 +96,30 @@ jobs:
           node-version: 22
       - run: npm install -g @anthropic-ai/claude-code
       - run: claude plugin validate ./plugin --strict
+
+  # Cockpit (tools/runner-ui/) Python suite — Windows self-hosted leg only.
+  # PySide6 + the pywinpty terminal dep live on Windows and the CI target for AC4
+  # is the native Windows runner; the Linux leg is an ephemeral Docker container
+  # with no Python, so this suite is deliberately NOT run there (ADR-0006 #272).
+  # Runs headless via the Qt offscreen platform — no desktop session needed.
+  cockpit-python:
+    permissions:
+      contents: read
+    runs-on: [self-hosted, windows, forge-local]
+    defaults:
+      run:
+        working-directory: tools/runner-ui
+    env:
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Show uv + resolved Python
+        # Depend only on `uv` being on PATH; uv discovers/provisions the
+        # interpreter itself, so we never call bare `python` here.
+        run: |
+          uv --version
+          uv python find
+      - name: Sync deps from committed uv.lock
+        run: uv sync --frozen
+      - name: Run cockpit test suite (headless)
+        run: uv run pytest -q

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -118,18 +118,18 @@ jobs:
         # so each step (a fresh shell) prepends the known toolchain dirs itself:
         # Python 3.12 + uv (WinGet Links). uv then discovers/provisions the
         # interpreter, so we never call bare `python` here.
-        shell: pwsh
+        shell: powershell
         run: |
           $env:PATH = "C:\Program Files\Python312;C:\Program Files\Python312\Scripts;C:\Program Files\WinGet\Links;$env:PATH"
           uv --version
           uv python find
       - name: Sync deps from committed uv.lock
-        shell: pwsh
+        shell: powershell
         run: |
           $env:PATH = "C:\Program Files\Python312;C:\Program Files\Python312\Scripts;C:\Program Files\WinGet\Links;$env:PATH"
           uv sync --frozen
       - name: Run cockpit test suite (headless)
-        shell: pwsh
+        shell: powershell
         run: |
           $env:PATH = "C:\Program Files\Python312;C:\Program Files\Python312\Scripts;C:\Program Files\WinGet\Links;$env:PATH"
           uv run pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ runner.env
 *.runner.env
 runner/windows/actions-runner/
 runner/windows/logs/
+
+# forge cockpit (tools/runner-ui/) — Python venv + local state; uv.lock IS committed
+tools/runner-ui/.venv/
+tools/runner-ui/**/__pycache__/
+tools/runner-ui/.pytest_cache/
+*.pyc

--- a/tools/runner-ui/README.md
+++ b/tools/runner-ui/README.md
@@ -1,0 +1,56 @@
+# forge cockpit (`tools/runner-ui/`)
+
+A native **PySide6 (Qt) desktop app** to manage the forge local self-hosted
+runner **fleet** and monitor Claude Code usage — the "cockpit" decided in
+[ADR-0006](../../docs/decisions/0006-runner-ui.md) (epic #262).
+
+This is the **Wave-1 foundation** (ticket #272): the app shell + Python/uv
+toolchain + the shell-out/WSL2 interop helper. Later waves add runner fleet
+control, the usage/cost monitor, and the embedded terminal.
+
+## Layout
+
+```
+tools/runner-ui/
+  pyproject.toml        # uv/PEP-621 project: forge-cockpit, requires-python >=3.12
+  uv.lock               # committed, hash-pinned lockfile
+  forge_cockpit/
+    __main__.py         # `python -m forge_cockpit` launches the window
+    app.py              # CockpitWindow — QMainWindow + QTabWidget shell
+    shellout.py         # argv-list shell-out + `wsl.exe --` interop, PAT-safe
+  tests/
+    test_app_smoke.py   # headless (offscreen) smoke test — window + 3 tabs
+    test_shellout.py    # argv-list / no-shell / wsl-prefix / never-reads-runner.env
+```
+
+## Prerequisites
+
+Python is **not** part of this repo; it is a host prerequisite (ADR-0006
+Decision 3). On Windows, provision it machine-wide so the CI runner service
+(LocalSystem) sees it:
+
+```powershell
+winget install --scope machine -e --id Python.Python.3.12
+```
+
+Then install [`uv`](https://docs.astral.sh/uv/) (`pip install uv` or the official
+installer). On WSL/Linux, any CPython >= 3.12 + `uv` works.
+
+## Run & test
+
+```bash
+cd tools/runner-ui
+uv sync                          # create .venv from the committed uv.lock
+uv run python -m forge_cockpit   # launch the cockpit window (Windows or WSL)
+uv run pytest                    # run the suite
+```
+
+Tests run **headless** via the Qt `offscreen` platform
+(`QT_QPA_PLATFORM=offscreen`, set in `tests/conftest.py`), so the smoke test
+passes on the runner without a desktop session.
+
+## Security
+
+The cockpit reads service **state** only. Per ADR-0005/0006 it **never** reads
+`~/.forge/runner.env` and never surfaces the PAT — `shellout.run()` refuses any
+command that references a `runner.env` path and never uses `shell=True`.

--- a/tools/runner-ui/forge_cockpit/__init__.py
+++ b/tools/runner-ui/forge_cockpit/__init__.py
@@ -1,0 +1,8 @@
+"""Forge cockpit — native PySide6 desktop app for the local self-hosted runner fleet.
+
+Wave-1 foundation (ADR-0006, epic #262 / ticket #272): the app shell plus the
+shell-out + WSL2 interop helper. Later waves add runner fleet control, the Claude
+usage/cost monitor, and the embedded terminal.
+"""
+
+__version__ = "0.1.0"

--- a/tools/runner-ui/forge_cockpit/__main__.py
+++ b/tools/runner-ui/forge_cockpit/__main__.py
@@ -1,0 +1,21 @@
+"""Launch the cockpit: ``uv run python -m forge_cockpit``."""
+
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+from forge_cockpit.app import CockpitWindow
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Boot the Qt application and show the cockpit window."""
+    app = QApplication.instance() or QApplication(argv if argv is not None else sys.argv)
+    window = CockpitWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/runner-ui/forge_cockpit/app.py
+++ b/tools/runner-ui/forge_cockpit/app.py
@@ -1,0 +1,53 @@
+"""The cockpit main window — a QMainWindow shell with a tabbed layout.
+
+Wave-1 wires three empty placeholder tabs (ADR-0006 Decision 2 charter):
+"Runner fleet", "Usage / cost", "Terminal". Each holds a TODO label only; the
+real panels arrive in Waves 1b/2/3. Keeping the shell separate from the panels
+lets the smoke test construct the window headless (QT_QPA_PLATFORM=offscreen)
+and assert the tab wiring without a desktop session.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QLabel,
+    QMainWindow,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+#: Tab title -> the TODO note shown on its placeholder, in display order.
+COCKPIT_TABS: tuple[tuple[str, str], ...] = (
+    ("Runner fleet", "TODO: runner fleet control (service/container state, start/stop)."),
+    ("Usage / cost", "TODO: Claude usage / cost / token monitor (from local transcripts)."),
+    ("Terminal", "TODO: embedded ConPTY terminal session."),
+)
+
+WINDOW_TITLE = "Forge Cockpit"
+
+
+def _placeholder(todo: str) -> QWidget:
+    """An empty tab body carrying a single centered TODO label."""
+    page = QWidget()
+    layout = QVBoxLayout(page)
+    label = QLabel(todo)
+    label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    label.setWordWrap(True)
+    layout.addWidget(label)
+    return page
+
+
+class CockpitWindow(QMainWindow):
+    """The cockpit shell: a main window whose central widget is a tab bar."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle(WINDOW_TITLE)
+        self.resize(1024, 720)
+
+        self.tabs = QTabWidget()
+        for title, todo in COCKPIT_TABS:
+            self.tabs.addTab(_placeholder(todo), title)
+        self.setCentralWidget(self.tabs)

--- a/tools/runner-ui/forge_cockpit/shellout.py
+++ b/tools/runner-ui/forge_cockpit/shellout.py
@@ -1,0 +1,134 @@
+"""Shell-out + WSL2 interop helper (ADR-0006 Decision 4).
+
+The cockpit reimplements nothing: it discovers and controls the runner fleet by
+shelling out to the managers that are already the API (``sc``/``Get-Service``,
+``systemctl --user``, ``docker``, ``gh``), reaching the WSL2 Linux runner from
+Windows via ``wsl.exe -- ...`` interop.
+
+Security invariants (non-negotiable, ADR-0005 + ADR-0006):
+
+* Commands are always an argv **list**; ``shell=True`` is never used, so there is
+  no shell-injection surface and no word-splitting of untrusted state.
+* This module never reads ``~/.forge/runner.env`` and never surfaces the PAT. It
+  reads service *state* only. To make that a hard guarantee rather than a
+  convention, :func:`run` refuses any argv that points at a ``runner.env`` path.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import PurePath, PureWindowsPath
+
+#: Basenames that hold (or could hold) the runner PAT — off-limits to the cockpit.
+_FORBIDDEN_BASENAMES = frozenset({"runner.env"})
+
+
+class RunnerEnvAccessError(RuntimeError):
+    """Raised when a command would touch the gitignored PAT store (``runner.env``).
+
+    The cockpit reads service state only; reaching for the secret store is a bug,
+    so we fail loudly instead of silently running it.
+    """
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """The captured outcome of a shelled-out command."""
+
+    argv: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+def _looks_like_runner_env(token: str) -> bool:
+    """True if ``token`` references a ``runner.env`` / ``*.runner.env`` path.
+
+    Guards both native (``C:\\Users\\me\\.forge\\runner.env``) and WSL/POSIX
+    (``/home/me/.forge/runner.env``) spellings, plus the ``*.runner.env`` variant.
+    """
+    # Split on both separators so a Windows path parses on any host and vice-versa.
+    for parts in (PurePath(token).parts, PureWindowsPath(token).parts):
+        for part in parts:
+            base = part.lower()
+            if base in _FORBIDDEN_BASENAMES or base.endswith(".runner.env"):
+                return True
+    return False
+
+
+def _assert_pat_safe(argv: list[str]) -> None:
+    for token in argv:
+        if _looks_like_runner_env(token):
+            raise RunnerEnvAccessError(
+                "refusing to run a command referencing the runner PAT store "
+                "(runner.env); the cockpit reads service state only"
+            )
+
+
+def run(argv: list[str], *, timeout: float | None = 30.0) -> CommandResult:
+    """Run ``argv`` as a list (never ``shell=True``) and capture stdout/stderr/rc.
+
+    Args:
+        argv: the command and its arguments as a list. A string is rejected — a
+            bare string would invite ``shell=True``-style splitting, which this
+            helper exists to prevent.
+        timeout: seconds before the child is killed and ``TimeoutExpired`` raises.
+
+    Raises:
+        TypeError: if ``argv`` is not a non-empty list.
+        RunnerEnvAccessError: if any token references ``runner.env``.
+    """
+    if not isinstance(argv, list) or not argv:
+        raise TypeError("argv must be a non-empty list of strings (never a shell string)")
+    _assert_pat_safe(argv)
+
+    completed = subprocess.run(  # noqa: S603 — argv list, shell=False, validated above
+        argv,
+        shell=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    return CommandResult(
+        argv=tuple(argv),
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def wsl(argv: list[str], *, distro: str | None = None, timeout: float | None = 30.0) -> CommandResult:
+    """Run ``argv`` inside WSL2 by prefixing ``wsl.exe -- ...`` (Windows -> Linux interop).
+
+    This is how a Windows-native cockpit drives the WSL2 Linux runner
+    (``systemctl --user``, ``docker``) from one process, per ADR-0006 Decision 4.
+
+    Args:
+        argv: the Linux-side command as a list (e.g. ``["systemctl", "--user", "status", unit]``).
+        distro: optional ``-d <distro>`` target; defaults to the default distro.
+    """
+    if not isinstance(argv, list) or not argv:
+        raise TypeError("argv must be a non-empty list of strings (never a shell string)")
+
+    prefix = ["wsl.exe"]
+    if distro:
+        prefix += ["-d", distro]
+    prefix += ["--"]
+    return run(prefix + argv, timeout=timeout)
+
+
+def wsl_available() -> bool:
+    """Best-effort probe: is ``wsl.exe`` present and responsive on this host?"""
+    if os.name != "nt":
+        return False
+    try:
+        return wsl(["true"], timeout=10.0).ok
+    except (OSError, subprocess.SubprocessError):
+        return False

--- a/tools/runner-ui/pyproject.toml
+++ b/tools/runner-ui/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "forge-cockpit"
+version = "0.1.0"
+description = "Forge Claude Code cockpit — native PySide6 desktop app to manage the local self-hosted runner fleet (ADR-0006, epic #262)."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "LGPL-3.0-or-later" }
+dependencies = [
+    "PySide6>=6.7",
+    "pywinpty>=2.0; sys_platform == 'win32'",
+    "psutil>=5.9",
+]
+
+[project.scripts]
+forge-cockpit = "forge_cockpit.__main__:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-qt>=4.4",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["forge_cockpit"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tools/runner-ui/tests/conftest.py
+++ b/tools/runner-ui/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared test config — force Qt to run headless on the CI runner.
+
+The Windows self-hosted runner has no interactive desktop session, so every Qt
+test constructs widgets under the ``offscreen`` platform plugin. Setting it here
+(before any PySide6 import) means the suite runs the same locally and in CI.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/tools/runner-ui/tests/test_app_smoke.py
+++ b/tools/runner-ui/tests/test_app_smoke.py
@@ -1,0 +1,54 @@
+"""Headless smoke test for the cockpit shell (AC2 + AC4).
+
+Constructs the real QMainWindow under the offscreen Qt platform, asserts the
+three placeholder tabs are wired, then tears down — proving the app launches
+without a desktop session on the CI runner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from forge_cockpit.app import COCKPIT_TABS, WINDOW_TITLE, CockpitWindow
+
+
+@pytest.fixture
+def app(qapp):
+    """Reuse pytest-qt's session QApplication (already offscreen via conftest)."""
+    return qapp
+
+
+def test_window_has_three_placeholder_tabs(app, qtbot):
+    window = CockpitWindow()
+    qtbot.addWidget(window)
+
+    assert window.windowTitle() == WINDOW_TITLE
+    assert window.tabs.count() == 3
+    assert [window.tabs.tabText(i) for i in range(window.tabs.count())] == [
+        "Runner fleet",
+        "Usage / cost",
+        "Terminal",
+    ]
+
+
+def test_each_tab_has_a_todo_placeholder(app, qtbot):
+    from PySide6.QtWidgets import QLabel
+
+    window = CockpitWindow()
+    qtbot.addWidget(window)
+
+    for i, (_title, todo) in enumerate(COCKPIT_TABS):
+        page = window.tabs.widget(i)
+        assert page is not None
+        texts = [lbl.text() for lbl in page.findChildren(QLabel)]
+        assert todo in texts  # each tab carries its TODO note
+
+
+def test_window_show_and_close_headless(app, qtbot):
+    """Full launch/teardown cycle: show the window, then close it."""
+    window = CockpitWindow()
+    qtbot.addWidget(window)
+    window.show()
+    assert window.isVisible()
+    window.close()
+    assert not window.isVisible()

--- a/tools/runner-ui/tests/test_shellout.py
+++ b/tools/runner-ui/tests/test_shellout.py
@@ -1,0 +1,138 @@
+"""Unit tests for the shell-out + WSL interop helper (ADR-0006 Decision 4).
+
+These lock in the security invariants: argv is always a list, ``shell=True`` is
+never used, WSL calls are prefixed with ``wsl.exe --``, and nothing the helper
+runs ever touches the ``runner.env`` PAT store.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from forge_cockpit import shellout
+from forge_cockpit.shellout import (
+    CommandResult,
+    RunnerEnvAccessError,
+    run,
+    wsl,
+)
+
+
+@pytest.fixture
+def capture_subprocess(monkeypatch):
+    """Replace ``subprocess.run`` with a spy that records the call and returns a stub."""
+    calls: list[dict] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append({"argv": argv, "kwargs": kwargs})
+        return SimpleNamespace(returncode=0, stdout="out", stderr="err")
+
+    monkeypatch.setattr(shellout.subprocess, "run", fake_run)
+    return calls
+
+
+def test_run_passes_argv_as_list_never_shell(capture_subprocess):
+    result = run(["sc", "query", "forge-runner-dngioidev-forge"])
+
+    assert isinstance(result, CommandResult)
+    assert result.ok and result.returncode == 0
+    assert result.stdout == "out" and result.stderr == "err"
+
+    (call,) = capture_subprocess
+    # argv reaches subprocess as the exact list we passed…
+    assert call["argv"] == ["sc", "query", "forge-runner-dngioidev-forge"]
+    assert isinstance(call["argv"], list)
+    # …and shell=False is explicit — never shell=True.
+    assert call["kwargs"]["shell"] is False
+
+
+def test_run_rejects_string_argv():
+    with pytest.raises(TypeError):
+        run("sc query forge-runner")  # type: ignore[arg-type]
+
+
+def test_run_rejects_empty_argv():
+    with pytest.raises(TypeError):
+        run([])
+
+
+def test_wsl_prefixes_wslexe_and_dashes(capture_subprocess):
+    wsl(["systemctl", "--user", "status", "forge-runner-dngioidev-forge"])
+
+    (call,) = capture_subprocess
+    assert call["argv"] == [
+        "wsl.exe",
+        "--",
+        "systemctl",
+        "--user",
+        "status",
+        "forge-runner-dngioidev-forge",
+    ]
+    assert call["kwargs"]["shell"] is False
+
+
+def test_wsl_with_distro_inserts_d_flag(capture_subprocess):
+    wsl(["docker", "ps"], distro="Ubuntu")
+
+    (call,) = capture_subprocess
+    assert call["argv"][:4] == ["wsl.exe", "-d", "Ubuntu", "--"]
+    assert call["argv"][4:] == ["docker", "ps"]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        ["cat", "/home/me/.forge/runner.env"],
+        ["type", r"C:\Users\me\.forge\runner.env"],
+        ["cat", "prod.runner.env"],
+        ["cat", "~/.forge/runner.env"],
+    ],
+)
+def test_run_refuses_to_touch_runner_env(bad, capture_subprocess):
+    with pytest.raises(RunnerEnvAccessError):
+        run(bad)
+    # And it never reached subprocess.
+    assert capture_subprocess == []
+
+
+def test_wsl_also_refuses_runner_env(capture_subprocess):
+    with pytest.raises(RunnerEnvAccessError):
+        wsl(["cat", "/home/me/.forge/runner.env"])
+    assert capture_subprocess == []
+
+
+def test_run_never_opens_a_file(monkeypatch, capture_subprocess):
+    """The helper must not itself read files — it only spawns the subprocess.
+
+    A regression that made the helper slurp ``runner.env`` (or any file) would
+    trip this: ``open`` is booby-trapped to fail the test.
+    """
+    import builtins
+
+    def boom(*args, **kwargs):  # pragma: no cover - only fires on regression
+        raise AssertionError(f"shellout must not open files directly: {args!r}")
+
+    monkeypatch.setattr(builtins, "open", boom)
+    run(["sc", "query", "forge-runner"])  # must not raise
+
+
+def test_timeout_is_forwarded(capture_subprocess):
+    run(["sc", "query"], timeout=5.0)
+    (call,) = capture_subprocess
+    assert call["kwargs"]["timeout"] == 5.0
+    assert call["kwargs"]["capture_output"] is True
+    assert call["kwargs"]["text"] is True
+
+
+def test_result_ok_false_on_nonzero(monkeypatch):
+    monkeypatch.setattr(
+        shellout.subprocess,
+        "run",
+        lambda argv, **kw: SimpleNamespace(returncode=1, stdout="", stderr="nope"),
+    )
+    result = run(["sc", "query", "missing"])
+    assert not result.ok
+    assert result.returncode == 1

--- a/tools/runner-ui/uv.lock
+++ b/tools/runner-ui/uv.lock
@@ -1,0 +1,222 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "forge-cockpit"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "psutil" },
+    { name = "pyside6" },
+    { name = "pywinpty", marker = "sys_platform == 'win32'" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-qt" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "psutil", specifier = ">=5.9" },
+    { name = "pyside6", specifier = ">=6.7" },
+    { name = "pywinpty", marker = "sys_platform == 'win32'", specifier = ">=2.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-qt", specifier = ">=4.4" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyside6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/a6/27ba5947ed48918f7b74b7c43a1e280aac069e36f25adeb4c9adfac835c4/pyside6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:537682c3b7530817203e667c1f5a2f00486b37bf52c52eeab438544c7a0917f6", size = 571921, upload-time = "2026-05-13T09:47:36.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/de/af89d71410c83b10654d86ff9aff2a4f87c30163658f1cc145242e222526/pyside6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b1fc521ba2bb5109425ab8add06bddbdd524abcad06cfa012cc39a22a189feb2", size = 572102, upload-time = "2026-05-13T09:47:38.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0e/d583bd3f7bf5046a4497b36f3902cfb64aa29554489a5a25c18e6b4ac0ac/pyside6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:75f0005c3eb95c07cfb65522ec50d0815ac007a96482c21dc3cb4b4c04895d84", size = 572098, upload-time = "2026-05-13T09:47:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f2/d9d8ce1373dabb37e5919f63cd18446556079631d3f2eea3ada03c29f6b8/pyside6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0968877ab1fb4ef3587a284da6fe05e8647ada56a6a3750b6395188e01f4aba6", size = 578377, upload-time = "2026-05-13T09:47:40.76Z" },
+    { url = "https://files.pythonhosted.org/packages/96/02/a6057d8bd2bdb1940820fff2d627fdf4013148c9c57adf69fa40d3452ac3/pyside6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:acee467cb5f256cc47ebb9d815a054c1d8416da380c191b247a76d164aa3f805", size = 561765, upload-time = "2026-05-13T09:47:41.9Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6b/8bc94aff48b63f788f2d84e5467c12362d68906ba742c0942f46cb04c879/pyside6_addons-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:54733c77f789bef5f03c6aff4ad3bec8b2eff021f0cfcbc53d5e6c250ded24f9", size = 331714589, upload-time = "2026-05-13T09:39:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/62/fb1428a523b2a4541e232aab50d9e789e6b4526f37fd9593452a7ea5b6b3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6c65fbd73a512d6f72cda8d8277444a85a34dc99dd1dae9c21d35b8671bb1f", size = 175063224, upload-time = "2026-05-13T09:39:34.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9b/2ccd52f66db55c06de65d0501170a1935d04d64d0a230c0d892284a02ce3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:bf1c6c4e954e5eba3d2a7c661ad4b9689e8f09c7f4a16bdf29713371d11af993", size = 170553429, upload-time = "2026-05-13T09:39:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bd/8adc4d350b3b363f3dfc8fccdcf5bfed25f7e36c2fff30c64e106f4f1572/pyside6_addons-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0d13c4dfd671b050a48e4f8d8ddc724b7248f9c0437e7fc47fdf316278572923", size = 168816308, upload-time = "2026-05-13T09:40:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b7/9a840d97f0f0f04e372a87e205dd30ee285b4e3b021b188459a917c9dc76/pyside6_addons-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:3494f480dee92f415be2f2d989c0b3f4755ac332b28045cbf4ba0f5c5a22ba37", size = 35759347, upload-time = "2026-05-13T09:40:21.199Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/da/10d9197e7370eb4fed8df5fc547b7548dec88e5c5949e2d450db4ae96feb/pyside6_essentials-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:228de53c2bc26b07e5021fbe3614fc44ca08e4dab9999af08c2b389d2c239957", size = 110352945, upload-time = "2026-05-13T09:43:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/0e1237c4400bec7e335d2c4eeb49bc40d9fd88a9ac44ca9083ce1abdc308/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:e3ef7027b41e4e55fadb56e3b3257dc8ee92154b639fe67fc4c8e05e9d976c60", size = 79908535, upload-time = "2026-05-13T09:43:24.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c5/da4c5f23c6540ac5211a1f60177c8dee84b1bf40f2719479587ab8c60731/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a039b6da68a3a4b9d243217b2b98d475eed3f617159ef6be925badab53c11b0d", size = 78960051, upload-time = "2026-05-13T09:43:35.423Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/b663ecc96ca57b5c91b83b6615d6b174380b0faf30338125c26e053d6aa7/pyside6_essentials-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:63311bd48e32c584599ab04b9ef7c324082374cd2c9fa533f978fb893bb47e40", size = 77549267, upload-time = "2026-05-13T09:43:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/eb6723faf5cb7fa581145da1c15f40d641b96e080f0491af2f1859fdeedb/pyside6_essentials-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:11253ea52aabecefe9febddbbe78b43a824129e3af1cec98431028fba7fa954f", size = 57964512, upload-time = "2026-05-13T09:43:52.968Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-qt"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pluggy" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/61/8bdec02663c18bf5016709b909411dce04a868710477dc9b9844ffcf8dd2/pytest_qt-4.5.0.tar.gz", hash = "sha256:51620e01c488f065d2036425cbc1cbcf8a6972295105fd285321eb47e66a319f", size = 128702, upload-time = "2025-07-01T17:24:39.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/d0/8339b888ad64a3d4e508fed8245a402b503846e1972c10ad60955883dcbb/pytest_qt-4.5.0-py3-none-any.whl", hash = "sha256:ed21ea9b861247f7d18090a26bfbda8fb51d7a8a7b6f776157426ff2ccf26eff", size = 37214, upload-time = "2025-07-01T17:24:38.226Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/f3/f2b63df0251e7cd3172ea28e32ede52739de9566bcefcd0178681538ac81/shiboken6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:1a16867f103ef1c662a5f09dfed03273a9f81688b174555162c58e83650a3f02", size = 476874, upload-time = "2026-05-13T09:47:01.091Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9b/e0355d8897b5c150770f1d95718aad17d432fcc9c035c04f3f58427d4693/shiboken6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9a8bccfafc8805254cabcfa1edfaf55cd52889f4998c91ad0d9a4433fb1bcdbe", size = 272222, upload-time = "2026-05-13T09:47:02.653Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/dd4f1defed400be03340f2ede34b61f846776650b4e7ed9ebaf4c71979a2/shiboken6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:1bd2f4314414df2d122d9f646e03b731bc6d6b5f77a5f53f99a4fe4e97d84e6f", size = 270350, upload-time = "2026-05-13T09:47:04.02Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/3f6fb2ee65b534193fb4ef713dd619dc31dadff5d12c16979a7699ad58be/shiboken6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:c2c6863aa80ec18c0f82cea3417837b279cdc60024ac17123461dc9042577df7", size = 1223647, upload-time = "2026-05-13T09:47:05.924Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d1/f15ca0e1666faae02c945f48e745ea35f8fcd8243b176109b4e2c4251f47/shiboken6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:7c8d9af17db4495d4fa5b1c393f218311c4855546b9dfa6a0bd21bcd66b55e9d", size = 1784170, upload-time = "2026-05-13T09:47:07.617Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
Closes #272

Wave-1 foundation for the runner-fleet **cockpit** (ADR-0006, epic #262): the PySide6 app shell + the `uv`-managed Python toolchain + the shell-out/WSL2 interop helper.

## Acceptance criteria

- [x] **AC1 — Python 3.12+ + uv project with committed `uv.lock`.** `tools/runner-ui/` is a PEP-621/`uv` project (`requires-python >=3.12`) with a committed, hash-pinned `uv.lock`. Deps: `PySide6`, `pywinpty` (win32), `psutil`. Runs via `uv run` on Windows and WSL (`uv` discovers/provisions the interpreter).
- [x] **AC2 — PySide6 QMainWindow cockpit shell, 3 placeholder tabs.** `forge_cockpit/app.py` builds a `CockpitWindow(QMainWindow)` whose central widget is a `QTabWidget` with exactly 3 tabs (Runner fleet / Usage-cost / Terminal). `uv run python -m forge_cockpit` launches it; verified it constructs with 3 tabs under offscreen.
- [x] **AC3 — shell-out + WSL2 interop helper, PAT-safe, with unit tests.** `forge_cockpit/shellout.py`: `run()` takes an argv **list** and forces `shell=False` (rejects string/empty argv); `wsl()` prefixes `wsl.exe --` (and `-d <distro>`); a hard guard raises `RunnerEnvAccessError` on any token referencing `runner.env`/`*.runner.env` in native or POSIX spelling. `test_shellout.py` locks in argv-list usage, wsl prefixing, never-touches-`runner.env`, and that the helper never `open()`s a file.
- [x] **AC4 — Windows self-hosted CI runs the pytest suite headless + smoke test.** `verify.yml` adds a `cockpit-python` leg on `[self-hosted, windows, forge-local]`, `QT_QPA_PLATFORM=offscreen`, `uv sync --frozen` + `uv run pytest`. The smoke test builds the real `QMainWindow`, asserts 3 tabs, and tears down. Deliberately **not** run on the Linux Docker leg (no Python there).

## Verification (honest note)

Ran locally on Windows:
- `uv lock` then `uv sync --frozen` — resolved 15 packages, lockfile committed.
- `QT_QPA_PLATFORM=offscreen uv run pytest -q` → **16 passed**.
- Constructed `CockpitWindow` under offscreen → 3 tabs, title "Forge Cockpit".

No secrets committed; `.venv/` and caches gitignored; `uv.lock` + `pyproject.toml` committed. The cockpit reads service **state** only — never reads `runner.env`, never surfaces the PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)