### PR TITLE
feat(cockpit): fleet discovery + status core (#264)

### DIFF
--- a/tools/runner-ui/forge_cockpit/discovery.py
+++ b/tools/runner-ui/forge_cockpit/discovery.py
@@ -1,0 +1,393 @@
+"""Fleet discovery + status core (ticket #264) — the data layer the UI renders.
+
+This module *enumerates* the local self-hosted runner fleet, *resolves* each
+entry's target ``owner/repo``, *cross-references* GitHub's online-runner list, and
+returns a **normalized, typed fleet model**. It reimplements nothing: it drives
+the managers that are already the API — ``sc query`` (Windows NSSM), ``systemctl
+--user`` (Linux systemd, reached over ``wsl.exe --`` interop), ``docker ps``, and
+``gh api`` — all through the argv-list shell-out helper in :mod:`forge_cockpit.shellout`.
+
+Security invariants (non-negotiable — ADR-0005 + ADR-0006):
+
+* The **target** ``owner/repo`` is derived from the service *NAME*
+  (``forge-runner-<owner>-<repo>``, per #260 repo-scoped naming), **never** from
+  the service ENVIRONMENT — the environment carries the runner PAT, and reading it
+  would leak the one secret this UI must never touch. The legacy bare
+  ``forge-runner`` (no suffix) resolves to an "unknown/legacy" target.
+* Every command run here reads service *state* only (``sc query``, ``systemctl
+  list-units``, ``docker ps``, ``gh api .../actions/runners``). Nothing reads
+  ``~/.forge/runner.env`` or ``sc qc`` / ``systemctl show ...Environment`` /
+  ``docker inspect``, and nothing logs a token. :mod:`shellout` refuses any argv
+  that references ``runner.env`` as a hard backstop.
+* Every mechanism is **tolerant** when absent: a missing ``docker``, no WSL, or no
+  matching services yields an empty slice, never a crash; a ``gh`` error marks the
+  online count *unknown* rather than raising.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
+
+from forge_cockpit import shellout
+from forge_cockpit.shellout import CommandResult, RunnerEnvAccessError
+
+# Errors that mean "this mechanism is simply absent on this box" — swallowed into
+# an empty result rather than propagated, so one missing manager never crashes a
+# fleet scan.
+_TOLERATED = (OSError, subprocess.SubprocessError, RunnerEnvAccessError)
+
+#: Repo-scoped service/unit name prefix (ADR-0005 / #260).
+_SERVICE_PREFIX = "forge-runner"
+
+# Mechanism tags for the normalized model.
+NSSM = "nssm"
+SYSTEMD = "systemd"
+DOCKER = "docker"
+
+# Type aliases for the injectable shell-out seams (defaulted to the real helper;
+# overridden with fakes in tests so the suite stays hermetic).
+Runner = Callable[..., CommandResult]
+Probe = Callable[[], bool]
+
+
+@dataclass(frozen=True)
+class Target:
+    """The ``owner/repo`` a runner serves, resolved from its NAME (never its env)."""
+
+    owner: str | None
+    repo: str | None
+
+    @property
+    def known(self) -> bool:
+        """True when both owner and repo were parsed from the service name."""
+        return self.owner is not None and self.repo is not None
+
+    @property
+    def slug(self) -> str:
+        """``owner/repo`` for a resolved target, else the ``unknown/legacy`` sentinel."""
+        return f"{self.owner}/{self.repo}" if self.known else "unknown/legacy"
+
+
+#: The sentinel target for the legacy bare ``forge-runner`` service and for any
+#: runner (e.g. an ephemeral docker job container) whose name carries no owner/repo.
+UNKNOWN_TARGET = Target(owner=None, repo=None)
+
+
+@dataclass(frozen=True)
+class OnlineStatus:
+    """GitHub's online/offline runner count for a repo — or *unknown* on gh error."""
+
+    online: int | None
+    offline: int | None
+    total: int | None
+    known: bool
+
+    @classmethod
+    def unknown(cls) -> OnlineStatus:
+        """The result when gh could not tell us (no network / not authed / 404)."""
+        return cls(online=None, offline=None, total=None, known=False)
+
+
+@dataclass(frozen=True)
+class RunnerEntry:
+    """One normalized fleet entry — the typed row the UI renders (AC4)."""
+
+    name: str
+    mechanism: str  # NSSM | SYSTEMD | DOCKER
+    service_state: str  # normalized lowercase: running | stopped | exited | dead | ...
+    target: Target
+    online: OnlineStatus
+
+    @property
+    def repo(self) -> str:
+        """The ``owner/repo`` slug (or ``unknown/legacy``)."""
+        return self.target.slug
+
+    @property
+    def online_count(self) -> int | None:
+        """Online runner count for this entry's repo, or ``None`` when unknown."""
+        return self.online.online
+
+
+@dataclass(frozen=True)
+class Fleet:
+    """The whole normalized fleet — the discovery module's public product."""
+
+    runners: tuple[RunnerEntry, ...]
+
+
+# --------------------------------------------------------------------------- #
+# Target resolution — from the NAME only (AC2 CRITICAL SAFETY).
+# --------------------------------------------------------------------------- #
+def parse_target(name: str) -> Target:
+    """Resolve ``owner/repo`` from a service/unit/container NAME — never its env.
+
+    ``forge-runner-<owner>-<repo>`` -> ``Target(owner, repo)``. The bare legacy
+    ``forge-runner`` (optionally ``.service``), and any name that does not match
+    the repo-scoped shape, resolve to :data:`UNKNOWN_TARGET`.
+
+    Owner is the first ``-``-delimited token after the prefix; the remainder is the
+    repo (so hyphenated repos like ``my-repo`` parse correctly). Hyphenated *owners*
+    are ambiguous under this scheme and are not attempted — a deliberate limitation
+    of the repo-scoped naming convention, not a bug here.
+    """
+    stem = name.strip()
+    if stem.endswith(".service"):
+        stem = stem[: -len(".service")]
+
+    if stem == _SERVICE_PREFIX:  # legacy bare name
+        return UNKNOWN_TARGET
+
+    prefix = _SERVICE_PREFIX + "-"
+    if not stem.startswith(prefix):
+        return UNKNOWN_TARGET
+
+    owner, sep, repo = stem[len(prefix):].partition("-")
+    if not sep or not owner or not repo:
+        return UNKNOWN_TARGET
+    return Target(owner=owner, repo=repo)
+
+
+# --------------------------------------------------------------------------- #
+# Windows NSSM services via `sc query` (state only).
+# --------------------------------------------------------------------------- #
+def discover_windows_services(*, runner: Runner = shellout.run) -> list[RunnerEntry]:
+    """Enumerate Windows NSSM ``forge-runner*`` services via ``sc query`` (AC1).
+
+    Reads STATE only. Absent ``sc`` / no matching services -> ``[]`` (never raises).
+    """
+    try:
+        result = runner(["sc", "query", "type=", "service", "state=", "all"])
+    except _TOLERATED:
+        return []
+    if not result.ok:
+        return []
+    return _parse_sc_query(result.stdout)
+
+
+def _parse_sc_query(text: str) -> list[RunnerEntry]:
+    entries: list[RunnerEntry] = []
+    current: str | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        upper = line.upper()
+        if upper.startswith("SERVICE_NAME:"):
+            current = line.split(":", 1)[1].strip()
+        elif upper.startswith("STATE") and current is not None:
+            if current.lower().startswith(_SERVICE_PREFIX):
+                entries.append(
+                    RunnerEntry(
+                        name=current,
+                        mechanism=NSSM,
+                        service_state=_sc_state_word(line),
+                        target=parse_target(current),
+                        online=OnlineStatus.unknown(),
+                    )
+                )
+            current = None
+    return entries
+
+
+def _sc_state_word(line: str) -> str:
+    """``STATE : 4  RUNNING`` -> ``running`` (last token after the colon)."""
+    _, _, rhs = line.partition(":")
+    tokens = rhs.split()
+    return tokens[-1].lower() if tokens else "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# Linux systemd --user units via `wsl.exe -- systemctl --user list-units`.
+# --------------------------------------------------------------------------- #
+def discover_systemd_units(
+    *,
+    wsl_runner: Runner = shellout.wsl,
+    wsl_available: Probe = shellout.wsl_available,
+) -> list[RunnerEntry]:
+    """Enumerate Linux systemd ``--user forge-runner*`` units over WSL interop (AC1).
+
+    No WSL, absent ``systemctl``, or no matching units -> ``[]`` (never raises).
+    """
+    if not wsl_available():
+        return []
+    try:
+        result = wsl_runner(
+            [
+                "systemctl",
+                "--user",
+                "list-units",
+                f"{_SERVICE_PREFIX}*",
+                "--type=service",
+                "--all",
+                "--no-legend",
+                "--no-pager",
+            ]
+        )
+    except _TOLERATED:
+        return []
+    if not result.ok:
+        return []
+    return _parse_systemd_units(result.stdout)
+
+
+def _parse_systemd_units(text: str) -> list[RunnerEntry]:
+    entries: list[RunnerEntry] = []
+    for raw in text.splitlines():
+        # `list-units` may prefix a failed unit with a bullet (● / *); drop it.
+        line = raw.strip().lstrip("*● ").strip()
+        if not line:
+            continue
+        fields = line.split(maxsplit=4)
+        if len(fields) < 4:
+            continue
+        unit, _load, _active, sub = fields[0], fields[1], fields[2], fields[3]
+        if not unit.lower().startswith(_SERVICE_PREFIX):
+            continue
+        entries.append(
+            RunnerEntry(
+                name=unit,
+                mechanism=SYSTEMD,
+                service_state=sub.lower(),
+                target=parse_target(unit),
+                online=OnlineStatus.unknown(),
+            )
+        )
+    return entries
+
+
+# --------------------------------------------------------------------------- #
+# Docker container runners via `docker ps` (over WSL when present).
+# --------------------------------------------------------------------------- #
+def discover_docker_runners(
+    *,
+    runner: Runner = shellout.run,
+    wsl_runner: Runner = shellout.wsl,
+    wsl_available: Probe = shellout.wsl_available,
+) -> list[RunnerEntry]:
+    """Enumerate Docker runner job containers via ``docker ps`` (AC1).
+
+    On this box Docker lives inside WSL, so the call is routed over ``wsl.exe --``
+    when WSL is present, else attempted natively. Absent ``docker`` / no containers
+    -> ``[]`` (never raises).
+    """
+    argv = ["docker", "ps", "--all", "--no-trunc", "--format", "{{json .}}"]
+    try:
+        result = wsl_runner(argv) if wsl_available() else runner(argv)
+    except _TOLERATED:
+        return []
+    if not result.ok:
+        return []
+    return _parse_docker_ps(result.stdout)
+
+
+def _parse_docker_ps(text: str) -> list[RunnerEntry]:
+    entries: list[RunnerEntry] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue  # tolerate a malformed line rather than crash the scan
+        name = str(obj.get("Names", ""))
+        image = str(obj.get("Image", "")).lower()
+        if "runner-run" not in name and not image.startswith("forge-local-runner"):
+            continue
+        state = str(obj.get("State", "") or _docker_state_from_status(obj.get("Status", "")))
+        entries.append(
+            RunnerEntry(
+                name=name,
+                mechanism=DOCKER,
+                service_state=state.lower() or "unknown",
+                target=parse_target(name),  # ephemeral job names carry no owner/repo
+                online=OnlineStatus.unknown(),
+            )
+        )
+    return entries
+
+
+def _docker_state_from_status(status: object) -> str:
+    text = str(status).lower()
+    if text.startswith("up"):
+        return "running"
+    if text.startswith("exited"):
+        return "exited"
+    return "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# GitHub online-runner cross-reference via `gh api` (AC3).
+# --------------------------------------------------------------------------- #
+def cross_reference_online(
+    targets: Iterable[Target], *, gh_runner: Runner = shellout.run
+) -> dict[str, OnlineStatus]:
+    """Map each distinct known target ``slug`` -> its online/offline count via gh.
+
+    gh errors (no network / not authed / repo not found / bad JSON) yield
+    :meth:`OnlineStatus.unknown` for that repo, never an exception (AC3).
+    """
+    counts: dict[str, OnlineStatus] = {}
+    for target in targets:
+        if not target.known or target.slug in counts:
+            continue
+        counts[target.slug] = _query_repo_runners(target, gh_runner)
+    return counts
+
+
+def _query_repo_runners(target: Target, gh_runner: Runner) -> OnlineStatus:
+    try:
+        result = gh_runner(
+            ["gh", "api", f"repos/{target.owner}/{target.repo}/actions/runners?per_page=100"]
+        )
+    except _TOLERATED:
+        return OnlineStatus.unknown()
+    if not result.ok:
+        return OnlineStatus.unknown()
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return OnlineStatus.unknown()
+
+    runners = data.get("runners") if isinstance(data, dict) else None
+    if not isinstance(runners, list):
+        return OnlineStatus.unknown()
+    online = sum(1 for r in runners if isinstance(r, dict) and r.get("status") == "online")
+    offline = sum(1 for r in runners if isinstance(r, dict) and r.get("status") == "offline")
+    return OnlineStatus(online=online, offline=offline, total=len(runners), known=True)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration — enumerate + resolve + cross-ref -> normalized Fleet (AC4).
+# --------------------------------------------------------------------------- #
+def discover_fleet(
+    *,
+    runner: Runner = shellout.run,
+    wsl_runner: Runner = shellout.wsl,
+    wsl_available: Probe = shellout.wsl_available,
+    gh_runner: Runner = shellout.run,
+) -> Fleet:
+    """Discover the whole fleet and return the normalized :class:`Fleet` model.
+
+    Enumerates all three mechanisms (each tolerant of absence), resolves every
+    entry's target from its NAME, cross-references GitHub once per distinct known
+    repo, and attaches the online count to each matching entry. Docker/legacy
+    entries (unknown target) keep :meth:`OnlineStatus.unknown`.
+    """
+    entries: list[RunnerEntry] = []
+    entries += discover_windows_services(runner=runner)
+    entries += discover_systemd_units(wsl_runner=wsl_runner, wsl_available=wsl_available)
+    entries += discover_docker_runners(
+        runner=runner, wsl_runner=wsl_runner, wsl_available=wsl_available
+    )
+
+    distinct = {e.target.slug: e.target for e in entries if e.target.known}
+    counts = cross_reference_online(distinct.values(), gh_runner=gh_runner)
+
+    resolved = tuple(
+        replace(entry, online=counts.get(entry.target.slug, OnlineStatus.unknown()))
+        for entry in entries
+    )
+    return Fleet(runners=resolved)

--- a/tools/runner-ui/tests/test_discovery.py
+++ b/tools/runner-ui/tests/test_discovery.py
@@ -1,0 +1,409 @@
+"""Unit tests for the fleet discovery + status core (ticket #264).
+
+Hermetic by construction: every shell-out seam (``sc query`` / ``systemctl`` /
+``docker ps`` / ``gh api``) is replaced with a fake that returns captured, real-
+shaped fixture output — no live service, WSL, docker, or network is ever touched.
+
+The fixtures below are trimmed from REAL output captured on the runner host
+(2026-07-24/25): ``sc query type= service state= all``, ``wsl.exe -- systemctl
+--user list-units 'forge-runner*' ...``, ``wsl.exe -- docker ps --format '{{json
+.}}'``, and ``gh api repos/<owner>/<repo>/actions/runners``.
+
+The suite locks in the ACs: name-based target resolution incl. the legacy bare
+name (AC2), tolerance when a mechanism is absent (AC1), the gh cross-ref incl. the
+error path (AC3), the normalized model (AC4), and — the non-negotiable — that
+NOTHING reads the runner env or a secret store.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from forge_cockpit import discovery
+from forge_cockpit.discovery import (
+    DOCKER,
+    NSSM,
+    SYSTEMD,
+    OnlineStatus,
+    Target,
+    cross_reference_online,
+    discover_docker_runners,
+    discover_fleet,
+    discover_systemd_units,
+    discover_windows_services,
+    parse_target,
+)
+from forge_cockpit.shellout import CommandResult, RunnerEnvAccessError
+
+# --------------------------------------------------------------------------- #
+# Captured, real-shaped fixtures.
+# --------------------------------------------------------------------------- #
+# `sc query type= service state= all` — two repo-scoped services, the legacy bare
+# `forge-runner` (STOPPED), and an unrelated service that must be filtered out.
+SC_QUERY_OUTPUT = """
+SERVICE_NAME: Dhcp
+DISPLAY_NAME: DHCP Client
+        TYPE               : 20  WIN32_SHARE_PROCESS
+        STATE              : 4  RUNNING
+                                (STOPPABLE, NOT_PAUSABLE, ACCEPTS_SHUTDOWN)
+        WIN32_EXIT_CODE    : 0  (0x0)
+
+SERVICE_NAME: forge-runner
+DISPLAY_NAME: forge-runner
+        TYPE               : 10  WIN32_OWN_PROCESS
+        STATE              : 1  STOPPED
+                                (NOT_STOPPABLE, NOT_PAUSABLE, IGNORES_SHUTDOWN)
+        WIN32_EXIT_CODE    : 0  (0x0)
+
+SERVICE_NAME: forge-runner-dngioidev-forge
+DISPLAY_NAME: forge-runner-dngioidev-forge
+        TYPE               : 10  WIN32_OWN_PROCESS
+        STATE              : 4  RUNNING
+                                (STOPPABLE, NOT_PAUSABLE, ACCEPTS_SHUTDOWN)
+        WIN32_EXIT_CODE    : 0  (0x0)
+
+SERVICE_NAME: forge-runner-dngioidev-iomanage
+DISPLAY_NAME: forge-runner-dngioidev-iomanage
+        TYPE               : 10  WIN32_OWN_PROCESS
+        STATE              : 4  RUNNING
+                                (STOPPABLE, NOT_PAUSABLE, ACCEPTS_SHUTDOWN)
+        WIN32_EXIT_CODE    : 0  (0x0)
+"""
+
+# `systemctl --user list-units 'forge-runner*' --type=service --all --no-legend`
+SYSTEMD_OUTPUT = (
+    "  forge-runner-dngioidev-iomanage.service loaded active running "
+    "forge local self-hosted runner supervisor (dngioidev/iomanage)\n"
+    "  forge-runner.service                    loaded active running "
+    "forge local self-hosted runner supervisor (JIT + ephemeral)\n"
+)
+
+# `docker ps --all --no-trunc --format '{{json .}}'` — two ephemeral job
+# containers plus an unrelated container that must be filtered out.
+DOCKER_OUTPUT = (
+    '{"ID":"738781cd78aa","Image":"forge-local-runner:latest",'
+    '"Names":"linux-runner-run-ddffb1f3d7f6","State":"running","Status":"Up 20 seconds"}\n'
+    '{"ID":"93f9657dfc14","Image":"forge-local-runner:latest",'
+    '"Names":"linux-runner-run-fc3b9e484668","State":"exited","Status":"Exited (0) 3 minutes ago"}\n'
+    '{"ID":"aaaa1111bbbb","Image":"postgres:16",'
+    '"Names":"some-db","State":"running","Status":"Up 2 hours"}\n'
+)
+
+# `gh api repos/dngioidev/forge/actions/runners` — 1 online, 2 offline.
+GH_RUNNERS_JSON = (
+    '{"total_count":3,"runners":['
+    '{"id":329,"name":"forge-local-1","os":"linux","status":"online","busy":true},'
+    '{"id":309,"name":"forge-local-2","os":"windows","status":"offline","busy":false},'
+    '{"id":265,"name":"forge-local-3","os":"windows","status":"offline","busy":false}]}'
+)
+
+
+def _result(argv, *, rc=0, out="", err="") -> CommandResult:
+    return CommandResult(argv=tuple(argv), returncode=rc, stdout=out, stderr=err)
+
+
+class FakeShell:
+    """Records every argv and answers by matching the leading tokens to fixtures."""
+
+    def __init__(self, *, sc=SC_QUERY_OUTPUT, systemd=SYSTEMD_OUTPUT, docker=DOCKER_OUTPUT,
+                 gh=GH_RUNNERS_JSON, wsl_up=True):
+        self.sc, self.systemd, self.docker, self.gh = sc, systemd, docker, gh
+        self.wsl_up = wsl_up
+        self.calls: list[list[str]] = []
+
+    def wsl_available(self) -> bool:
+        return self.wsl_up
+
+    def run(self, argv, **kwargs) -> CommandResult:
+        self.calls.append(list(argv))
+        if argv[:2] == ["sc", "query"]:
+            return _result(argv, out=self.sc)
+        if argv[:2] == ["gh", "api"]:
+            return _result(argv, out=self.gh)
+        if argv[0] == "docker":
+            return _result(argv, out=self.docker)
+        raise AssertionError(f"unexpected run() argv: {argv!r}")
+
+    def wsl(self, argv, **kwargs) -> CommandResult:
+        self.calls.append(["wsl.exe", "--", *argv])
+        if argv[0] == "systemctl":
+            return _result(argv, out=self.systemd)
+        if argv[0] == "docker":
+            return _result(argv, out=self.docker)
+        raise AssertionError(f"unexpected wsl() argv: {argv!r}")
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — target resolution from the NAME only (incl. the legacy bare name).
+# --------------------------------------------------------------------------- #
+def test_parse_target_repo_scoped_name():
+    t = parse_target("forge-runner-dngioidev-forge")
+    assert (t.owner, t.repo) == ("dngioidev", "forge")
+    assert t.known and t.slug == "dngioidev/forge"
+
+
+def test_parse_target_strips_dot_service_suffix():
+    t = parse_target("forge-runner-dngioidev-iomanage.service")
+    assert (t.owner, t.repo) == ("dngioidev", "iomanage")
+
+
+@pytest.mark.parametrize("name", ["forge-runner", "forge-runner.service"])
+def test_parse_target_legacy_bare_is_unknown(name):
+    t = parse_target(name)
+    assert not t.known
+    assert t.owner is None and t.repo is None
+    assert t.slug == "unknown/legacy"
+
+
+def test_parse_target_hyphenated_repo_keeps_remainder():
+    # owner = first token, repo = the rest (so hyphenated repos survive).
+    t = parse_target("forge-runner-acme-my-cool-repo")
+    assert (t.owner, t.repo) == ("acme", "my-cool-repo")
+
+
+@pytest.mark.parametrize("name", ["linux-runner-run-ddffb1f3d7f6", "some-db", "forge-runner-"])
+def test_parse_target_non_matching_is_unknown(name):
+    assert parse_target(name) == Target(None, None)
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — Windows NSSM discovery + tolerance.
+# --------------------------------------------------------------------------- #
+def test_discover_windows_parses_state_and_filters_non_forge():
+    shell = FakeShell()
+    entries = discover_windows_services(runner=shell.run)
+
+    names = {e.name for e in entries}
+    assert names == {
+        "forge-runner",
+        "forge-runner-dngioidev-forge",
+        "forge-runner-dngioidev-iomanage",
+    }  # Dhcp filtered out
+    assert all(e.mechanism == NSSM for e in entries)
+
+    by_name = {e.name: e for e in entries}
+    assert by_name["forge-runner-dngioidev-forge"].service_state == "running"
+    assert by_name["forge-runner"].service_state == "stopped"
+    # legacy bare name -> unknown target
+    assert by_name["forge-runner"].target.slug == "unknown/legacy"
+    assert by_name["forge-runner-dngioidev-iomanage"].target.slug == "dngioidev/iomanage"
+
+
+def test_discover_windows_absent_sc_yields_empty():
+    def missing(argv, **kw):
+        raise FileNotFoundError("sc not found")
+
+    assert discover_windows_services(runner=missing) == []
+
+
+def test_discover_windows_nonzero_yields_empty():
+    assert discover_windows_services(runner=lambda a, **k: _result(a, rc=1, err="boom")) == []
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — Linux systemd discovery + tolerance (no WSL).
+# --------------------------------------------------------------------------- #
+def test_discover_systemd_parses_units():
+    shell = FakeShell()
+    entries = discover_systemd_units(wsl_runner=shell.wsl, wsl_available=shell.wsl_available)
+
+    by_name = {e.name: e for e in entries}
+    assert set(by_name) == {
+        "forge-runner-dngioidev-iomanage.service",
+        "forge-runner.service",
+    }
+    assert all(e.mechanism == SYSTEMD for e in entries)
+    assert by_name["forge-runner-dngioidev-iomanage.service"].service_state == "running"
+    assert by_name["forge-runner-dngioidev-iomanage.service"].target.slug == "dngioidev/iomanage"
+    assert by_name["forge-runner.service"].target.slug == "unknown/legacy"
+
+
+def test_discover_systemd_absent_when_no_wsl_never_shells_out():
+    called = False
+
+    def wsl_runner(argv, **kw):
+        nonlocal called
+        called = True
+        raise AssertionError("must not shell out to WSL when it is unavailable")
+
+    entries = discover_systemd_units(wsl_runner=wsl_runner, wsl_available=lambda: False)
+    assert entries == []
+    assert called is False
+
+
+def test_discover_systemd_tolerates_shell_error():
+    def boom(argv, **kw):
+        raise subprocess.SubprocessError("wsl exploded")
+
+    entries = discover_systemd_units(wsl_runner=boom, wsl_available=lambda: True)
+    assert entries == []
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — Docker discovery + tolerance.
+# --------------------------------------------------------------------------- #
+def test_discover_docker_filters_to_runner_containers():
+    shell = FakeShell()
+    entries = discover_docker_runners(
+        runner=shell.run, wsl_runner=shell.wsl, wsl_available=shell.wsl_available
+    )
+
+    names = {e.name for e in entries}
+    assert names == {"linux-runner-run-ddffb1f3d7f6", "linux-runner-run-fc3b9e484668"}  # db dropped
+    assert all(e.mechanism == DOCKER for e in entries)
+    assert all(e.target.slug == "unknown/legacy" for e in entries)  # job names carry no owner/repo
+
+    by_name = {e.name: e for e in entries}
+    assert by_name["linux-runner-run-ddffb1f3d7f6"].service_state == "running"
+    assert by_name["linux-runner-run-fc3b9e484668"].service_state == "exited"
+
+
+def test_discover_docker_routes_over_wsl_when_present():
+    shell = FakeShell(wsl_up=True)
+    discover_docker_runners(
+        runner=shell.run, wsl_runner=shell.wsl, wsl_available=shell.wsl_available
+    )
+    assert shell.calls == [["wsl.exe", "--", "docker", "ps", "--all", "--no-trunc", "--format", "{{json .}}"]]
+
+
+def test_discover_docker_absent_yields_empty():
+    def missing(argv, **kw):
+        raise FileNotFoundError("docker not found")
+
+    entries = discover_docker_runners(
+        runner=missing, wsl_runner=missing, wsl_available=lambda: False
+    )
+    assert entries == []
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — GitHub online-runner cross-reference incl. the error path.
+# --------------------------------------------------------------------------- #
+def test_cross_reference_counts_online_offline():
+    shell = FakeShell()
+    counts = cross_reference_online([Target("dngioidev", "forge")], gh_runner=shell.run)
+    status = counts["dngioidev/forge"]
+    assert status.known
+    assert (status.online, status.offline, status.total) == (1, 2, 3)
+
+
+def test_cross_reference_gh_error_marks_unknown():
+    counts = cross_reference_online(
+        [Target("dngioidev", "forge")],
+        gh_runner=lambda a, **k: _result(a, rc=1, err="gh: not authenticated"),
+    )
+    status = counts["dngioidev/forge"]
+    assert status.known is False
+    assert status.online is None and status.total is None
+
+
+def test_cross_reference_bad_json_marks_unknown():
+    counts = cross_reference_online(
+        [Target("dngioidev", "forge")],
+        gh_runner=lambda a, **k: _result(a, out="<html>not json</html>"),
+    )
+    assert counts["dngioidev/forge"] == OnlineStatus.unknown()
+
+
+def test_cross_reference_skips_unknown_targets_and_dedupes():
+    seen: list[list[str]] = []
+
+    def gh(argv, **kw):
+        seen.append(list(argv))
+        return _result(argv, out=GH_RUNNERS_JSON)
+
+    counts = cross_reference_online(
+        [Target("dngioidev", "forge"), Target("dngioidev", "forge"), Target(None, None)],
+        gh_runner=gh,
+    )
+    assert set(counts) == {"dngioidev/forge"}  # unknown target skipped
+    assert len(seen) == 1  # queried once despite the duplicate
+
+
+def test_cross_reference_tolerates_raised_error():
+    def boom(argv, **kw):
+        raise OSError("gh missing")
+
+    counts = cross_reference_online([Target("dngioidev", "forge")], gh_runner=boom)
+    assert counts["dngioidev/forge"] == OnlineStatus.unknown()
+
+
+# --------------------------------------------------------------------------- #
+# AC4 — the normalized fleet model, end to end.
+# --------------------------------------------------------------------------- #
+def test_discover_fleet_normalizes_and_attaches_counts():
+    shell = FakeShell()
+    fleet = discover_fleet(
+        runner=shell.run,
+        wsl_runner=shell.wsl,
+        wsl_available=shell.wsl_available,
+        gh_runner=shell.run,
+    )
+
+    # 3 nssm + 2 systemd + 2 docker = 7 normalized entries.
+    assert len(fleet.runners) == 7
+    mechanisms = sorted(e.mechanism for e in fleet.runners)
+    assert mechanisms == [DOCKER, DOCKER, NSSM, NSSM, NSSM, SYSTEMD, SYSTEMD]
+
+    # Known repos got the gh online count attached (1 online from the fixture)…
+    forge_entries = [e for e in fleet.runners if e.repo == "dngioidev/forge"]
+    assert forge_entries and all(e.online.known and e.online_count == 1 for e in forge_entries)
+
+    # …docker + legacy (unknown target) stay unknown, never crash.
+    unknowns = [e for e in fleet.runners if e.repo == "unknown/legacy"]
+    assert unknowns and all(not e.online.known and e.online_count is None for e in unknowns)
+
+
+def test_discover_fleet_cross_refs_each_repo_once():
+    shell = FakeShell()
+    discover_fleet(
+        runner=shell.run, wsl_runner=shell.wsl,
+        wsl_available=shell.wsl_available, gh_runner=shell.run,
+    )
+    gh_calls = [c for c in shell.calls if c[:2] == ["gh", "api"]]
+    # forge appears in nssm+systemd, iomanage in nssm+systemd -> still 2 gh calls.
+    assert len(gh_calls) == 2
+    repos = sorted(c[2] for c in gh_calls)
+    assert repos == [
+        "repos/dngioidev/forge/actions/runners?per_page=100",
+        "repos/dngioidev/iomanage/actions/runners?per_page=100",
+    ]
+
+
+def test_discover_fleet_fully_tolerant_when_everything_absent():
+    def missing(argv, **kw):
+        raise FileNotFoundError("nothing installed")
+
+    fleet = discover_fleet(
+        runner=missing, wsl_runner=missing, wsl_available=lambda: False, gh_runner=missing
+    )
+    assert fleet.runners == ()  # empty, not a crash
+
+
+# --------------------------------------------------------------------------- #
+# Security invariant — never reads the PAT / runner.env, never a secret store.
+# --------------------------------------------------------------------------- #
+def test_no_command_touches_runner_env_or_service_environment():
+    shell = FakeShell()
+    discover_fleet(
+        runner=shell.run, wsl_runner=shell.wsl,
+        wsl_available=shell.wsl_available, gh_runner=shell.run,
+    )
+    assert shell.calls, "expected some commands to have run"
+
+    forbidden = ("runner.env", "environment", "appenvironmentextra", "qc", "cat", "inspect", "show")
+    for argv in shell.calls:
+        joined = " ".join(argv).lower()
+        for needle in forbidden:
+            assert needle not in joined, f"command must not reference {needle!r}: {argv!r}"
+
+
+def test_real_shellout_would_refuse_a_runner_env_argv():
+    # Backstop: the shared helper hard-refuses any runner.env path, so even a
+    # regression that built such an argv could never actually read the secret.
+    from forge_cockpit import shellout
+
+    with pytest.raises(RunnerEnvAccessError):
+        shellout.run(["cat", "/home/me/.forge/runner.env"])


### PR DESCRIPTION
Closes #264

Wave 1b of the cockpit (ADR-0006): the **data layer** the runner-fleet UI renders. Adds `forge_cockpit/discovery.py` — enumerate → resolve → cross-ref → normalized `Fleet` model — reusing the #272 argv-list shell-out helper (`shellout.run` / `.wsl` / `.wsl_available`). No new dependencies; stdlib + `sc`/`systemctl`/`docker`/`gh` shell-out only, so `uv.lock` is unchanged.

## Acceptance criteria
- [x] **AC1 — cross-platform discovery, tolerant of absence.** Windows NSSM `forge-runner*` via `sc query`; Linux systemd `--user forge-runner*` via `wsl.exe -- systemctl --user list-units`; Docker runner containers via `docker ps` (routed over WSL when present). Missing `docker` / no WSL / no matching services → empty slice, never a crash.
- [x] **AC2 — target from the NAME only (CRITICAL SAFETY).** `owner/repo` parsed from `forge-runner-<owner>-<repo>` (per #260); the service **environment is never read** (it carries the PAT). Legacy bare `forge-runner` → `unknown/legacy`.
- [x] **AC3 — GitHub online cross-ref.** `gh api repos/<owner>/<repo>/actions/runners` per distinct known repo → online/offline count; gh errors (no network / not authed / 404 / bad JSON) mark the count **unknown**, not a crash. Queried once per repo.
- [x] **AC4 — normalized, typed model, unit-tested.** `RunnerEntry{name, mechanism (nssm|systemd|docker), service_state, target, online}` in a `Fleet`. Reads service **state only** — never reads or logs the PAT / `runner.env` / service env.

## Verification (honest)
- `cd tools/runner-ui; $env:QT_QPA_PLATFORM='offscreen'; uv run pytest -q` → **43 passed** locally on the Windows host (Python 3.12 via uv).
- Tests are **fully hermetic**: every shell-out seam is faked with captured, real-shaped fixtures (`sc query` / `systemctl list-units` / `docker ps --format {{json .}}` / `gh api ...runners`), all captured from this live box on 2026-07-24/25. No live service, WSL, docker, or network is touched by the suite.
- Security: a dedicated test asserts no discovery command references `runner.env` / service `environment` / `sc qc` / `docker inspect` / `systemctl show`; a backstop test confirms the shared helper hard-refuses any `runner.env` argv.
- The `cockpit-python` job runs these new tests automatically on the self-hosted Windows runner; no CI wiring added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)