### PR TITLE
fix(ci): make test-windows PATH-self-sufficient on the stripped self-hosted runner env (#278)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,8 +55,23 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm verify
+      # The self-hosted runner service does not inherit the full Machine PATH
+      # (its AppEnvironmentExtra replaces rather than extends it), so each step
+      # (a fresh shell) prepends the Machine PATH itself. Without System32 et al.
+      # on PATH, vitest's worker-teardown spawn fails with "The system cannot
+      # find the path specified." and exits 1 even though all tests pass (#278).
+      # Machine PATH goes in FRONT of the step $env:PATH, which already resolves
+      # node/pnpm from setup-node — keep that on the end.
+      - name: Install deps (pnpm)
+        shell: powershell
+        run: |
+          $env:PATH = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + $env:PATH
+          pnpm install --frozen-lockfile
+      - name: Run pnpm verify
+        shell: powershell
+        run: |
+          $env:PATH = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + $env:PATH
+          pnpm verify
 
   # actionlint runs as a pinned, checksum-verified BINARY — not a docker://
   # container action. On the containerized forge-local runner a container action


### PR DESCRIPTION
Closes #278

## Problem
The self-hosted Windows `test-windows` leg (`pnpm verify` = `vitest run`) reds on `main`: all 478 tests pass, then it emits `The system cannot find the path specified.` and exits 1 — a spawn at vitest worker teardown. Root cause: the NSSM runner service runs with a **stripped PATH** (its `AppEnvironmentExtra PATH=...` replaced rather than extended the system PATH), so System32 et al. are absent from the fresh step shell and the teardown spawn can't resolve.

## Fix (code-only, no host action)
In the `test-windows` job, the `Install deps` and `Run pnpm verify` steps now run under `shell: powershell` and prepend the Machine PATH to the step's `$env:PATH` before invoking pnpm — mirroring the `cockpit-python` PATH-self-sufficiency fix from #272. The existing `$env:PATH` (which resolves node/pnpm from setup-node) is kept on the end; the Machine PATH (System32, WinGet Links, Python, etc. — the dir the teardown spawn needs) goes in front.

No runner service, `AppEnvironmentExtra`, or PAT was read or modified.

## Acceptance criteria
- [ ] **AC1** — `test-windows` goes GREEN on this PR (478 passed AND exit 0).
- [x] **AC2** — No runner service / `AppEnvironmentExtra` / PAT was touched; the fix is entirely in `verify.yml`.
- [ ] **AC3** — Follow-up filed for the durable service-env repair (extend, not replace, the system PATH) so these per-step prepends can later be removed. See linked follow-up.

## Verification note (honest)
Locally with a full PATH, `pnpm verify` already exits 0 (478 passed, no trailing error) — the failure is purely the runner's stripped env, not test code. This change makes the runner shell match the local full-PATH environment; AC1 is proven by the `test-windows` leg going green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)