### PR TITLE
feat(cockpit): fleet overview screen with mis-target flags (#265)

### DIFF
--- a/tools/runner-ui/forge_cockpit/app.py
+++ b/tools/runner-ui/forge_cockpit/app.py
@@ -1,10 +1,12 @@
 """The cockpit main window — a QMainWindow shell with a tabbed layout.
 
-Wave-1 wires three empty placeholder tabs (ADR-0006 Decision 2 charter):
-"Runner fleet", "Usage / cost", "Terminal". Each holds a TODO label only; the
-real panels arrive in Waves 1b/2/3. Keeping the shell separate from the panels
-lets the smoke test construct the window headless (QT_QPA_PLATFORM=offscreen)
-and assert the tab wiring without a desktop session.
+The shell wires three tabs (ADR-0006 Decision 2 charter): "Runner fleet",
+"Usage / cost", "Terminal". "Runner fleet" is now the live fleet overview
+(:class:`~forge_cockpit.fleet_view.FleetTab`, ticket #265) over the #264
+discovery core; the remaining two are still TODO placeholders whose real panels
+arrive in Waves 2/3. Keeping the shell separate from the panels lets the smoke
+test construct the window headless (QT_QPA_PLATFORM=offscreen) and assert the tab
+wiring without a desktop session.
 """
 
 from __future__ import annotations
@@ -18,7 +20,14 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-#: Tab title -> the TODO note shown on its placeholder, in display order.
+from forge_cockpit import discovery
+from forge_cockpit.fleet_view import Discover, FleetTab
+
+#: Fleet auto-refresh interval in the running app (AC3). Off in tests.
+FLEET_REFRESH_MS = 15_000
+
+#: Placeholder tab title -> the TODO note shown on its body, in display order.
+#: The "Runner fleet" tab is the live :class:`FleetTab`, wired separately.
 COCKPIT_TABS: tuple[tuple[str, str], ...] = (
     ("Runner fleet", "TODO: runner fleet control (service/container state, start/stop)."),
     ("Usage / cost", "TODO: Claude usage / cost / token monitor (from local transcripts)."),
@@ -39,15 +48,35 @@ def _placeholder(todo: str) -> QWidget:
     return page
 
 
-class CockpitWindow(QMainWindow):
-    """The cockpit shell: a main window whose central widget is a tab bar."""
+#: Title of the live fleet-overview tab (the rest stay placeholders).
+FLEET_TAB_TITLE = "Runner fleet"
 
-    def __init__(self) -> None:
+
+class CockpitWindow(QMainWindow):
+    """The cockpit shell: a main window whose central widget is a tab bar.
+
+    The "Runner fleet" tab is the live :class:`FleetTab` (#265); the others remain
+    TODO placeholders until their waves land.
+    """
+
+    def __init__(
+        self,
+        *,
+        fleet_discover: Discover = discovery.discover_fleet,
+        fleet_auto_refresh_ms: int = FLEET_REFRESH_MS,
+        fleet_initial_refresh: bool = True,
+    ) -> None:
         super().__init__()
         self.setWindowTitle(WINDOW_TITLE)
         self.resize(1024, 720)
 
         self.tabs = QTabWidget()
+        self.fleet_tab = FleetTab(
+            fleet_discover,
+            auto_refresh_ms=fleet_auto_refresh_ms,
+            initial_refresh=fleet_initial_refresh,
+        )
         for title, todo in COCKPIT_TABS:
-            self.tabs.addTab(_placeholder(todo), title)
+            body = self.fleet_tab if title == FLEET_TAB_TITLE else _placeholder(todo)
+            self.tabs.addTab(body, title)
         self.setCentralWidget(self.tabs)

--- a/tools/runner-ui/forge_cockpit/fleet_view.py
+++ b/tools/runner-ui/forge_cockpit/fleet_view.py
@@ -1,0 +1,336 @@
+"""The "Runner fleet" tab — the main view over the #264 discovery core (ticket #265).
+
+This is the read-only overview screen: a table over the normalized
+:class:`~forge_cockpit.discovery.Fleet` model that lists every runner with its
+target repo, OS/mechanism, service state, and online-runner count (AC1); flags a
+mis-targeted service — one that is *running* yet whose configured repo shows **0**
+online runners — with a warning icon, a highlighted row, and an explanatory
+tooltip (AC2, the #260 diagnosability made visual); and refreshes on demand (a
+Refresh button) and on an optional interval **without blocking the UI** (AC3).
+
+Threading (AC3): discovery shells out (``sc query`` / ``systemctl`` / ``docker
+ps`` / ``gh api``) and can be slow, so it runs in a :class:`QRunnable` on the
+global :class:`QThreadPool`; the result is marshalled back to the GUI thread via a
+queued signal. The GUI thread never calls :func:`discovery.discover_fleet`
+directly, so the window stays responsive during a scan.
+
+This module renders ONLY the already-normalized, PAT-free #264 model. It never
+reads a service environment, ``~/.forge/runner.env``, or any secret store.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import get_ident
+
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, QObject, QRunnable, Qt, QThreadPool, QTimer, Signal
+from PySide6.QtGui import QBrush, QColor, QIcon
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QStyle,
+    QTableView,
+    QVBoxLayout,
+    QWidget,
+)
+
+from forge_cockpit import discovery
+from forge_cockpit.discovery import Fleet, RunnerEntry
+
+#: The discovery entry point the tab drives; injectable so tests stay hermetic.
+Discover = Callable[[], Fleet]
+
+#: Column order for the fleet table (AC1: every field the overview must show).
+_COLUMNS: tuple[str, ...] = (
+    "Runner",
+    "Target repo",
+    "OS / mechanism",
+    "Service state",
+    "Online runners",
+)
+
+#: Row-highlight tint for a mis-targeted entry (AC2). A semi-transparent amber so
+#: it reads as a warning under both light and dark palettes.
+_WARN_BRUSH = QBrush(QColor(220, 120, 0, 70))
+
+
+def is_mistargeted(entry: RunnerEntry) -> bool:
+    """True when a *running* service's known repo has a *known* online count of 0.
+
+    This is the #260 mis-target signal (AC2): the service is up, GitHub answered,
+    and yet **no** runner for its configured ``owner/repo`` is online — the runner
+    is almost certainly registered against the wrong repo (or not registered at
+    all). An *unknown* online count (gh error / no network) is never flagged: we
+    only warn when we positively know the repo has zero online runners.
+    """
+    return (
+        entry.service_state == "running"
+        and entry.target.known
+        and entry.online.known
+        and entry.online_count == 0
+    )
+
+
+def _mistarget_tooltip(entry: RunnerEntry) -> str:
+    return (
+        f"Mis-target: the '{entry.name}' service is running, but its configured "
+        f"repo {entry.repo} reports 0 online runners. The runner is likely "
+        f"registered against the wrong repository (see #260)."
+    )
+
+
+class FleetTableModel(QAbstractTableModel):
+    """A :class:`QAbstractTableModel` bound to the normalized #264 fleet model.
+
+    Holds an immutable snapshot of :class:`RunnerEntry` rows and renders each
+    field for :data:`_COLUMNS`. A mis-targeted row (:func:`is_mistargeted`) carries
+    a warning icon on its first cell, an amber background across the row, and an
+    explanatory tooltip — the AC2 visual.
+    """
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._rows: tuple[RunnerEntry, ...] = ()
+        self._warn_icon: QIcon | None = None
+
+    # -- population -------------------------------------------------------- #
+    def set_fleet(self, fleet: Fleet) -> None:
+        """Replace the whole snapshot with ``fleet``'s runners (a full reset)."""
+        self.beginResetModel()
+        self._rows = fleet.runners
+        self.endResetModel()
+
+    def entry_at(self, row: int) -> RunnerEntry:
+        """The :class:`RunnerEntry` backing ``row`` (for tests / row-level logic)."""
+        return self._rows[row]
+
+    # -- Qt model contract ------------------------------------------------- #
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: B008
+        return 0 if parent.isValid() else len(self._rows)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: B008
+        return 0 if parent.isValid() else len(_COLUMNS)
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> object:
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation == Qt.Orientation.Horizontal and 0 <= section < len(_COLUMNS):
+            return _COLUMNS[section]
+        return None
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> object:
+        if not index.isValid() or not (0 <= index.row() < len(self._rows)):
+            return None
+        entry = self._rows[index.row()]
+        col = index.column()
+        flagged = is_mistargeted(entry)
+
+        if role == Qt.ItemDataRole.DisplayRole:
+            return _cell_text(entry, col)
+        if role == Qt.ItemDataRole.DecorationRole and col == 0 and flagged:
+            return self._warning_icon()
+        if role == Qt.ItemDataRole.BackgroundRole and flagged:
+            return _WARN_BRUSH
+        if role == Qt.ItemDataRole.ToolTipRole and flagged:
+            return _mistarget_tooltip(entry)
+        return None
+
+    def _warning_icon(self) -> QIcon:
+        if self._warn_icon is None:
+            from PySide6.QtWidgets import QApplication
+
+            app = QApplication.instance()
+            style = app.style() if app is not None else None
+            self._warn_icon = (
+                style.standardIcon(QStyle.StandardPixmap.SP_MessageBoxWarning)
+                if style is not None
+                else QIcon()
+            )
+        return self._warn_icon
+
+
+def _cell_text(entry: RunnerEntry, col: int) -> str:
+    if col == 0:
+        return entry.name
+    if col == 1:
+        return entry.repo
+    if col == 2:
+        return entry.mechanism
+    if col == 3:
+        return entry.service_state
+    if col == 4:
+        return str(entry.online_count) if entry.online.known else "?"
+    return ""
+
+
+class _WorkerSignals(QObject):
+    """Signals emitted from the discovery worker back onto the GUI thread."""
+
+    finished = Signal(object)  # Fleet
+    failed = Signal(str)
+
+
+class _DiscoveryWorker(QRunnable):
+    """Runs :func:`discovery.discover_fleet` off the GUI thread (AC3).
+
+    ``discover`` is called on a thread-pool thread; its result — or the string of
+    any exception — is emitted via :class:`_WorkerSignals`, which Qt delivers to
+    the connected slots on the receiver's (GUI) thread via a queued connection.
+    """
+
+    def __init__(self, discover: Discover) -> None:
+        super().__init__()
+        self._discover = discover
+        self.signals = _WorkerSignals()
+
+    def run(self) -> None:  # pragma: no cover - exercised via the thread pool
+        try:
+            fleet = self._discover()
+        except Exception as exc:  # never let a scan crash the worker thread
+            self.signals.failed.emit(f"{type(exc).__name__}: {exc}")
+            return
+        self.signals.finished.emit(fleet)
+
+
+class FleetTab(QWidget):
+    """The "Runner fleet" tab: a table over the fleet model + async refresh.
+
+    :param discover: the discovery callable (default :func:`discovery.discover_fleet`;
+        overridden with a fixture in tests).
+    :param auto_refresh_ms: if > 0, poll the fleet on this interval (AC3). Default
+        0 (off) so tests are deterministic; the app enables it.
+    :param pool: the :class:`QThreadPool` to run discovery on (default the global
+        pool); injectable for tests.
+    :param initial_refresh: kick a first refresh on construction (default True so
+        the tab self-populates in the app; tests may pass False).
+    """
+
+    #: Emitted on the GUI thread after a successful refresh has updated the model.
+    fleet_loaded = Signal()
+    #: Emitted on the GUI thread when a refresh failed (carries the error string).
+    refresh_failed = Signal(str)
+
+    def __init__(
+        self,
+        discover: Discover = discovery.discover_fleet,
+        *,
+        auto_refresh_ms: int = 0,
+        pool: QThreadPool | None = None,
+        initial_refresh: bool = True,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._discover = discover
+        self._pool = pool or QThreadPool.globalInstance()
+        self._busy = False
+        #: Thread ident of the last discovery call — proves it ran off the GUI
+        #: thread (AC3). ``None`` until the first refresh runs.
+        self.last_discovery_thread_ident: int | None = None
+        self._gui_thread_ident = get_ident()
+
+        self._model = FleetTableModel(self)
+        self._build_ui()
+
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self.refresh)
+        if auto_refresh_ms > 0:
+            self._timer.start(auto_refresh_ms)
+
+        if initial_refresh:
+            self.refresh()
+
+    # -- UI ---------------------------------------------------------------- #
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        bar = QHBoxLayout()
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.setToolTip("Re-scan the runner fleet now")
+        self.refresh_button.clicked.connect(self.refresh)
+        self.status_label = QLabel("")
+        bar.addWidget(self.refresh_button)
+        bar.addWidget(self.status_label)
+        bar.addStretch(1)
+        layout.addLayout(bar)
+
+        self.table = QTableView()
+        self.table.setModel(self._model)
+        self.table.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(QTableView.EditTrigger.NoEditTriggers)
+        self.table.setAlternatingRowColors(True)
+        self.table.verticalHeader().setVisible(False)
+        header = self.table.horizontalHeader()
+        header.setStretchLastSection(True)
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        layout.addWidget(self.table)
+
+    # -- accessors (for tests / callers) ---------------------------------- #
+    @property
+    def model(self) -> FleetTableModel:
+        return self._model
+
+    def mistarget_rows(self) -> list[int]:
+        """Row indices currently flagged as mis-targeted (AC2)."""
+        return [
+            r for r in range(self._model.rowCount()) if is_mistargeted(self._model.entry_at(r))
+        ]
+
+    @property
+    def discovery_ran_off_gui_thread(self) -> bool:
+        """True once a scan has run and it ran off the GUI thread (AC3)."""
+        return (
+            self.last_discovery_thread_ident is not None
+            and self.last_discovery_thread_ident != self._gui_thread_ident
+        )
+
+    # -- refresh (AC3) ----------------------------------------------------- #
+    def refresh(self) -> None:
+        """Kick an off-thread fleet scan; results land back on the GUI thread.
+
+        A refresh already in flight is a no-op (the interval timer and the button
+        can't stack scans). Never blocks: the actual :func:`discover_fleet` call
+        happens on a thread-pool thread.
+        """
+        if self._busy:
+            return
+        self._busy = True
+        self.refresh_button.setEnabled(False)
+        self.status_label.setText("Scanning fleet…")
+
+        worker = _DiscoveryWorker(self._instrumented_discover)
+        worker.signals.finished.connect(self._on_finished)
+        worker.signals.failed.connect(self._on_failed)
+        self._pool.start(worker)
+
+    def _instrumented_discover(self) -> Fleet:
+        # Runs on the worker thread — record which thread, so AC3 (off-GUI-thread)
+        # is assertable, then delegate to the real discovery.
+        self.last_discovery_thread_ident = get_ident()
+        return self._discover()
+
+    def _on_finished(self, fleet: Fleet) -> None:
+        self._model.set_fleet(fleet)
+        flagged = len(self.mistarget_rows())
+        n = self._model.rowCount()
+        note = f"{n} runner(s)"
+        if flagged:
+            note += f" — {flagged} mis-targeted"
+        self.status_label.setText(note)
+        self._end_refresh()
+        self.fleet_loaded.emit()
+
+    def _on_failed(self, message: str) -> None:
+        self.status_label.setText(f"Scan failed: {message}")
+        self._end_refresh()
+        self.refresh_failed.emit(message)
+
+    def _end_refresh(self) -> None:
+        self._busy = False
+        self.refresh_button.setEnabled(True)

--- a/tools/runner-ui/tests/test_app_smoke.py
+++ b/tools/runner-ui/tests/test_app_smoke.py
@@ -1,15 +1,18 @@
 """Headless smoke test for the cockpit shell (AC2 + AC4).
 
 Constructs the real QMainWindow under the offscreen Qt platform, asserts the
-three placeholder tabs are wired, then tears down — proving the app launches
-without a desktop session on the CI runner.
+three tabs are wired — the live "Runner fleet" fleet overview (#265) plus the two
+remaining TODO placeholders — then tears down, proving the app launches without a
+desktop session on the CI runner.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from forge_cockpit.app import COCKPIT_TABS, WINDOW_TITLE, CockpitWindow
+from forge_cockpit.app import COCKPIT_TABS, FLEET_TAB_TITLE, WINDOW_TITLE, CockpitWindow
+from forge_cockpit.discovery import Fleet
+from forge_cockpit.fleet_view import FleetTab
 
 
 @pytest.fixture
@@ -18,8 +21,12 @@ def app(qapp):
     return qapp
 
 
-def test_window_has_three_placeholder_tabs(app, qtbot):
-    window = CockpitWindow()
+def test_window_has_three_tabs(app, qtbot):
+    window = CockpitWindow(
+        fleet_discover=lambda: Fleet(runners=()),
+        fleet_auto_refresh_ms=0,
+        fleet_initial_refresh=False,
+    )
     qtbot.addWidget(window)
 
     assert window.windowTitle() == WINDOW_TITLE
@@ -31,22 +38,45 @@ def test_window_has_three_placeholder_tabs(app, qtbot):
     ]
 
 
-def test_each_tab_has_a_todo_placeholder(app, qtbot):
-    from PySide6.QtWidgets import QLabel
-
-    window = CockpitWindow()
+def test_runner_fleet_tab_is_the_live_fleet_view(app, qtbot):
+    window = CockpitWindow(
+        fleet_discover=lambda: Fleet(runners=()),
+        fleet_auto_refresh_ms=0,
+        fleet_initial_refresh=False,
+    )
     qtbot.addWidget(window)
 
-    for i, (_title, todo) in enumerate(COCKPIT_TABS):
+    idx = next(i for i in range(window.tabs.count()) if window.tabs.tabText(i) == FLEET_TAB_TITLE)
+    assert isinstance(window.tabs.widget(idx), FleetTab)
+    assert window.fleet_tab is window.tabs.widget(idx)
+
+
+def test_placeholder_tabs_keep_their_todo(app, qtbot):
+    from PySide6.QtWidgets import QLabel
+
+    window = CockpitWindow(
+        fleet_discover=lambda: Fleet(runners=()),
+        fleet_auto_refresh_ms=0,
+        fleet_initial_refresh=False,
+    )
+    qtbot.addWidget(window)
+
+    for i, (title, todo) in enumerate(COCKPIT_TABS):
+        if title == FLEET_TAB_TITLE:
+            continue  # the live fleet tab has no TODO placeholder
         page = window.tabs.widget(i)
         assert page is not None
         texts = [lbl.text() for lbl in page.findChildren(QLabel)]
-        assert todo in texts  # each tab carries its TODO note
+        assert todo in texts  # each remaining tab carries its TODO note
 
 
 def test_window_show_and_close_headless(app, qtbot):
     """Full launch/teardown cycle: show the window, then close it."""
-    window = CockpitWindow()
+    window = CockpitWindow(
+        fleet_discover=lambda: Fleet(runners=()),
+        fleet_auto_refresh_ms=0,
+        fleet_initial_refresh=False,
+    )
     qtbot.addWidget(window)
     window.show()
     assert window.isVisible()

--- a/tools/runner-ui/tests/test_fleet_view.py
+++ b/tools/runner-ui/tests/test_fleet_view.py
@@ -1,0 +1,250 @@
+"""Tests for the "Runner fleet" overview tab (ticket #265).
+
+Hermetic + headless: discovery is replaced with an in-memory fixture fleet (no
+service, WSL, docker, or network is touched), and every widget is built under the
+offscreen Qt platform (conftest). The suite locks the ACs:
+
+* AC1 — every runner renders across the five columns (name / target / mechanism /
+  service state / online count).
+* AC2 — a *running* service whose known repo shows **0** online runners is flagged
+  (warning icon + row highlight + tooltip), while the near-miss cases (stopped, or
+  online unknown, or online > 0) are NOT.
+* AC3 — refresh re-queries discovery **off the GUI thread** and updates the model
+  without blocking the UI.
+"""
+
+from __future__ import annotations
+
+from threading import get_ident
+
+import pytest
+
+from forge_cockpit.discovery import (
+    DOCKER,
+    NSSM,
+    SYSTEMD,
+    Fleet,
+    OnlineStatus,
+    RunnerEntry,
+    Target,
+    UNKNOWN_TARGET,
+)
+from forge_cockpit.fleet_view import FleetTab, FleetTableModel, is_mistargeted
+from PySide6.QtCore import Qt
+
+
+# --------------------------------------------------------------------------- #
+# Fixture fleet — one entry per interesting case.
+# --------------------------------------------------------------------------- #
+def _online(n: int) -> OnlineStatus:
+    return OnlineStatus(online=n, offline=0, total=n, known=True)
+
+
+# A running NSSM service whose repo has 0 online runners -> MIS-TARGETED (AC2).
+MISTARGETED = RunnerEntry(
+    name="forge-runner-acme-widgets",
+    mechanism=NSSM,
+    service_state="running",
+    target=Target(owner="acme", repo="widgets"),
+    online=OnlineStatus(online=0, offline=1, total=1, known=True),
+)
+# A healthy running service: 2 online -> not flagged.
+HEALTHY = RunnerEntry(
+    name="forge-runner-acme-forge",
+    mechanism=NSSM,
+    service_state="running",
+    target=Target(owner="acme", repo="forge"),
+    online=_online(2),
+)
+# Running but online count is UNKNOWN (gh error) -> not flagged (we don't guess).
+UNKNOWN_ONLINE = RunnerEntry(
+    name="forge-runner-acme-tools",
+    mechanism=SYSTEMD,
+    service_state="running",
+    target=Target(owner="acme", repo="tools"),
+    online=OnlineStatus.unknown(),
+)
+# Stopped service with 0 online -> not flagged (not running, so no mis-target).
+STOPPED = RunnerEntry(
+    name="forge-runner-acme-legacy",
+    mechanism=SYSTEMD,
+    service_state="stopped",
+    target=Target(owner="acme", repo="legacy"),
+    online=OnlineStatus(online=0, offline=0, total=0, known=True),
+)
+# A docker job container (unknown target) -> never flagged.
+DOCKER_JOB = RunnerEntry(
+    name="runner-run-abc123",
+    mechanism=DOCKER,
+    service_state="running",
+    target=UNKNOWN_TARGET,
+    online=OnlineStatus.unknown(),
+)
+
+FIXTURE_ROWS = (MISTARGETED, HEALTHY, UNKNOWN_ONLINE, STOPPED, DOCKER_JOB)
+FIXTURE_FLEET = Fleet(runners=FIXTURE_ROWS)
+
+
+class RecordingDiscover:
+    """A discovery stand-in: records call count + the thread it ran on."""
+
+    def __init__(self, fleet: Fleet) -> None:
+        self.fleet = fleet
+        self.calls = 0
+        self.thread_idents: list[int] = []
+
+    def __call__(self) -> Fleet:
+        self.calls += 1
+        self.thread_idents.append(get_ident())
+        return self.fleet
+
+
+@pytest.fixture
+def _app(qapp):
+    return qapp
+
+
+def _make_tab(qtbot, discover) -> FleetTab:
+    tab = FleetTab(discover, initial_refresh=False)
+    qtbot.addWidget(tab)
+    return tab
+
+
+def _load(qtbot, tab) -> None:
+    with qtbot.waitSignal(tab.fleet_loaded, timeout=5000):
+        tab.refresh()
+
+
+# --------------------------------------------------------------------------- #
+# is_mistargeted — the pure AC2 rule.
+# --------------------------------------------------------------------------- #
+def test_is_mistargeted_flags_running_zero_online():
+    assert is_mistargeted(MISTARGETED) is True
+
+
+@pytest.mark.parametrize("entry", [HEALTHY, UNKNOWN_ONLINE, STOPPED, DOCKER_JOB])
+def test_is_mistargeted_does_not_flag_near_misses(entry):
+    assert is_mistargeted(entry) is False
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — every runner renders across the five columns.
+# --------------------------------------------------------------------------- #
+def test_all_rows_render_with_columns(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingDiscover(FIXTURE_FLEET))
+    _load(qtbot, tab)
+    model = tab.model
+
+    assert model.rowCount() == len(FIXTURE_ROWS)
+    assert model.columnCount() == 5
+    headers = [
+        model.headerData(c, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
+        for c in range(model.columnCount())
+    ]
+    assert headers == ["Runner", "Target repo", "OS / mechanism", "Service state", "Online runners"]
+
+    # Row 0 is the mis-targeted NSSM entry — spot-check every column's text.
+    def cell(r, c):
+        return model.data(model.index(r, c), Qt.ItemDataRole.DisplayRole)
+
+    assert cell(0, 0) == "forge-runner-acme-widgets"
+    assert cell(0, 1) == "acme/widgets"
+    assert cell(0, 2) == NSSM
+    assert cell(0, 3) == "running"
+    assert cell(0, 4) == "0"
+    # Unknown online count renders as "?" (row 2).
+    assert cell(2, 4) == "?"
+    # Docker job's unknown target renders the legacy sentinel slug (row 4).
+    assert cell(4, 1) == "unknown/legacy"
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — the mis-targeted row is visibly flagged; the others are not.
+# --------------------------------------------------------------------------- #
+def test_mistargeted_row_is_flagged(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingDiscover(FIXTURE_FLEET))
+    _load(qtbot, tab)
+    model = tab.model
+
+    assert tab.mistarget_rows() == [0]
+
+    warn_idx = model.index(0, 0)
+    icon = model.data(warn_idx, Qt.ItemDataRole.DecorationRole)
+    assert icon is not None and not icon.isNull()  # warning icon present
+    assert model.data(warn_idx, Qt.ItemDataRole.BackgroundRole) is not None  # row highlight
+    tip = model.data(warn_idx, Qt.ItemDataRole.ToolTipRole)
+    assert tip is not None and "acme/widgets" in tip and "0 online" in tip
+
+
+def test_healthy_rows_are_not_flagged(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingDiscover(FIXTURE_FLEET))
+    _load(qtbot, tab)
+    model = tab.model
+
+    for row in range(1, model.rowCount()):
+        idx = model.index(row, 0)
+        assert model.data(idx, Qt.ItemDataRole.DecorationRole) is None
+        assert model.data(idx, Qt.ItemDataRole.BackgroundRole) is None
+        assert model.data(idx, Qt.ItemDataRole.ToolTipRole) is None
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — refresh re-queries off the GUI thread, non-blocking, and updates.
+# --------------------------------------------------------------------------- #
+def test_refresh_runs_discovery_off_the_gui_thread(_app, qtbot):
+    discover = RecordingDiscover(FIXTURE_FLEET)
+    tab = _make_tab(qtbot, discover)
+    gui_thread = get_ident()
+
+    _load(qtbot, tab)
+
+    assert discover.calls == 1
+    # The discovery call recorded a thread ident that is NOT the GUI thread's.
+    assert discover.thread_idents[0] != gui_thread
+    assert tab.discovery_ran_off_gui_thread is True
+
+
+def test_refresh_requeries_and_updates_model(_app, qtbot):
+    discover = RecordingDiscover(Fleet(runners=(HEALTHY,)))
+    tab = _make_tab(qtbot, discover)
+
+    _load(qtbot, tab)
+    assert tab.model.rowCount() == 1
+    assert tab.mistarget_rows() == []
+
+    # Fleet changes under us: a mis-target appears. Refresh must re-query + update.
+    discover.fleet = FIXTURE_FLEET
+    _load(qtbot, tab)
+
+    assert discover.calls == 2
+    assert tab.model.rowCount() == len(FIXTURE_ROWS)
+    assert tab.mistarget_rows() == [0]
+
+
+def test_refresh_failure_is_surfaced_not_raised(_app, qtbot):
+    def boom() -> Fleet:
+        raise RuntimeError("gh exploded")
+
+    tab = FleetTab(boom, initial_refresh=False)
+    qtbot.addWidget(tab)
+
+    with qtbot.waitSignal(tab.refresh_failed, timeout=5000) as sig:
+        tab.refresh()
+
+    assert "gh exploded" in sig.args[0]
+    assert "failed" in tab.status_label.text().lower()
+    assert tab.model.rowCount() == 0  # nothing rendered, no crash
+
+
+def test_auto_refresh_interval_wires_a_running_timer(_app, qtbot):
+    tab = FleetTab(RecordingDiscover(FIXTURE_FLEET), auto_refresh_ms=10_000, initial_refresh=False)
+    qtbot.addWidget(tab)
+    assert tab._timer.isActive()
+    assert tab._timer.interval() == 10_000
+
+
+def test_model_set_fleet_directly(_app, qtbot):
+    model = FleetTableModel()
+    model.set_fleet(FIXTURE_FLEET)
+    assert model.rowCount() == len(FIXTURE_ROWS)
+    assert model.entry_at(0) is MISTARGETED


### PR DESCRIPTION
Closes #265

The **Runner fleet** tab is now the live fleet-overview screen over the #264 discovery core (builds on #272 shell + #264 discovery, both merged). It renders ONLY the already-normalized, PAT-free #264 model — it never re-queries services itself and never reads a service environment or `runner.env`.

## Acceptance criteria
- [x] **AC1** — lists every runner with target repo, OS/mechanism, service state, and online-runner count. A `QAbstractTableModel` (`FleetTableModel`) bound to a `QTableView` renders the five columns over `Fleet.runners`.
- [x] **AC2** — flags mis-targeting: a **running** service whose **known** repo reports **0** online runners is warned with a warning icon (col 0), an amber row highlight, and an explanatory tooltip (the #260 diagnosability made visual). `is_mistargeted()` is the pure rule; near-misses (stopped / online-unknown / online > 0 / unknown target) are deliberately NOT flagged — we only warn when we positively know the repo has zero online runners.
- [x] **AC3** — refreshes on demand (Refresh button) and on an optional interval (`QTimer`, enabled in-app at 15s), always running discovery **off the GUI thread** via a `QRunnable` on the global `QThreadPool`, with the result marshalled back over a queued signal. The GUI thread never calls `discover_fleet` directly, so the window stays responsive.

## Design notes
- `CockpitWindow` gains injectable fleet params (`fleet_discover` / `fleet_auto_refresh_ms` / `fleet_initial_refresh`) so the headless smoke test constructs the shell with a fixture fleet and does **no** real shell-outs.
- No new dependencies (PySide6 + pytest-qt only) — `uv.lock` untouched. No CI changes: the new tests under `tools/runner-ui/tests/` run automatically on the existing `cockpit-python` leg.

## Verification (honest)
Ran locally on the runner host, headless: `cd tools/runner-ui; $env:QT_QPA_PLATFORM='offscreen'; uv run pytest` → **57 passed**, stable across 3 consecutive runs (threading/off-GUI-thread assertions non-flaky). New `test_fleet_view.py` covers AC1 (all rows/columns), AC2 (flagged row + every near-miss negative), and AC3 (off-thread re-query + model update + surfaced failure). The `cockpit-python` and `test-windows` legs will confirm on the self-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)