### PR TITLE
feat(cockpit): runner control actions + log viewing (#266)

### DIFF
--- a/tools/runner-ui/forge_cockpit/control.py
+++ b/tools/runner-ui/forge_cockpit/control.py
@@ -1,0 +1,233 @@
+"""Runner control actions (ticket #266) — start / stop / restart per mechanism.
+
+Reimplements nothing: it drives the service managers that are already the API —
+``nssm start|stop|restart <service>`` for a Windows NSSM service (the manager
+``setup-runner.ps1`` installs the runner under) and ``systemctl --user
+start|stop|restart <unit>`` (reached over ``wsl.exe --`` interop) for a Linux
+``--user`` unit — all through the argv-list shell-out helper in
+:mod:`forge_cockpit.shellout`.
+
+Privilege handling (AC3, ADR-0006 Decision 4): mutating a Windows NSSM service
+(it runs as LocalSystem) needs administrator rights. When the cockpit is **not**
+already elevated the action is run through an **explicit** per-action UAC
+"runas" elevation (PowerShell ``Start-Process -Verb RunAs -Wait -PassThru``, whose
+exit code mirrors the elevated child's). It **never silently no-ops**: it either
+runs directly (already admin), prompts for elevation, or returns a failure result
+carrying a clear "run elevated" message. systemd ``--user`` needs no elevation.
+
+Security invariants (ADR-0005 + ADR-0006): the service/unit NAME comes from the
+#264 fleet model (name-derived, never the env). Nothing here reads the service
+ENVIRONMENT, ``~/.forge/runner.env``, or a PAT; :mod:`shellout` refuses any argv
+referencing ``runner.env`` as a hard backstop.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from forge_cockpit import shellout
+from forge_cockpit.discovery import NSSM, SYSTEMD, RunnerEntry
+from forge_cockpit.shellout import CommandResult
+
+# The three control verbs (AC1).
+START = "start"
+STOP = "stop"
+RESTART = "restart"
+ACTIONS: tuple[str, ...] = (START, STOP, RESTART)
+
+# Errors that mean "the manager is simply absent / the call could not spawn" —
+# turned into a clear failure result rather than propagated as a crash.
+_TOLERATED = (OSError, subprocess.SubprocessError)
+
+# Windows exit code the elevation launcher reports when the UAC prompt is declined
+# (ERROR_CANCELLED). Surfaced as an explicit "run elevated" failure, never a no-op.
+_ERROR_CANCELLED = 1223
+
+# Injectable seams (defaulted to the real helpers; overridden with fakes in tests).
+Runner = Callable[..., CommandResult]
+Elevator = Callable[[list[str]], CommandResult]
+AdminProbe = Callable[[], bool]
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    """The outcome of a control action, ready to surface to the user (AC1)."""
+
+    action: str
+    name: str
+    mechanism: str
+    ok: bool
+    #: True when the action was routed through a UAC elevation (Windows, non-admin).
+    elevated: bool
+    #: A human-readable success/failure line for the status bar / dialog.
+    message: str
+
+
+# --------------------------------------------------------------------------- #
+# Privilege probe + per-action elevation ("runas") — AC3.
+# --------------------------------------------------------------------------- #
+def is_elevated() -> bool:
+    """Best-effort: is this process running with Windows administrator rights?
+
+    Non-Windows returns ``True`` (the systemd ``--user`` path needs no elevation).
+    On any probe error we conservatively return ``False`` so a Windows mutation
+    elevates rather than failing silently.
+    """
+    if os.name != "nt":
+        return True
+    try:
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - platform/loader specific
+        return False
+
+
+def _ps_single_quote(value: str) -> str:
+    """Quote ``value`` as a PowerShell single-quoted literal (doubling ``'``)."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def elevate_run(
+    argv: list[str], *, runner: Runner = shellout.run, timeout: float | None = 120.0
+) -> CommandResult:
+    """Run ``argv`` with an explicit per-action UAC elevation and return its result.
+
+    Launches (non-elevated) a PowerShell that spawns ``argv`` elevated via
+    ``Start-Process -Verb RunAs -Wait -PassThru`` and exits with the elevated
+    child's exit code — so the returned :class:`CommandResult`'s ``returncode``
+    reflects whether the elevated action itself succeeded. If the UAC prompt is
+    declined ``Start-Process`` raises and the launcher exits ``1223``
+    (ERROR_CANCELLED); there is never a silent no-op (AC3, ADR-0006 Decision 4).
+    """
+    if not argv:
+        raise ValueError("argv must be a non-empty list")
+    exe, *args = argv
+    start = f"Start-Process -FilePath {_ps_single_quote(exe)}"
+    if args:
+        start += " -ArgumentList " + ", ".join(_ps_single_quote(a) for a in args)
+    start += " -Verb RunAs -Wait -PassThru"
+    script = (
+        "$ErrorActionPreference='Stop'; "
+        f"try {{ $p = {start}; exit $p.ExitCode }} "
+        f"catch {{ [Console]::Error.WriteLine($_.Exception.Message); exit {_ERROR_CANCELLED} }}"
+    )
+    return runner(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        timeout=timeout,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Per-mechanism argv (the managers are the API — we never reimplement them).
+# --------------------------------------------------------------------------- #
+def windows_service_argv(name: str, action: str) -> list[str]:
+    """``nssm start|stop|restart <name>`` — the manager that installed the service."""
+    return ["nssm", action, name]
+
+
+def systemd_argv(name: str, action: str) -> list[str]:
+    """``systemctl --user start|stop|restart <unit>`` (run over ``wsl.exe --``)."""
+    return ["systemctl", "--user", action, name]
+
+
+# --------------------------------------------------------------------------- #
+# Control orchestration.
+# --------------------------------------------------------------------------- #
+def control(
+    entry: RunnerEntry,
+    action: str,
+    *,
+    runner: Runner = shellout.run,
+    wsl_runner: Runner = shellout.wsl,
+    is_admin: AdminProbe = is_elevated,
+    elevate: Elevator = elevate_run,
+) -> ActionResult:
+    """Start / stop / restart ``entry``'s service, surfacing success/failure (AC1).
+
+    Routes by mechanism: a systemd ``--user`` unit over WSL (no elevation), a
+    Windows NSSM service directly when already admin else through a per-action UAC
+    elevation (AC3). Docker job containers are ephemeral one-job runners and are
+    not controllable as a service — a clear unsupported result is returned.
+    """
+    if action not in ACTIONS:
+        raise ValueError(f"unknown action {action!r}; expected one of {ACTIONS}")
+
+    if entry.mechanism == SYSTEMD:
+        return _control_systemd(entry, action, wsl_runner)
+    if entry.mechanism == NSSM:
+        return _control_nssm(entry, action, runner, is_admin, elevate)
+    return ActionResult(
+        action=action,
+        name=entry.name,
+        mechanism=entry.mechanism,
+        ok=False,
+        elevated=False,
+        message=(
+            f"Cannot {action} '{entry.name}': it is an ephemeral docker job "
+            "container, not a managed service. Control applies to NSSM services "
+            "and systemd --user units."
+        ),
+    )
+
+
+def _control_systemd(entry: RunnerEntry, action: str, wsl_runner: Runner) -> ActionResult:
+    argv = systemd_argv(entry.name, action)
+    try:
+        res = wsl_runner(argv)
+    except _TOLERATED as exc:
+        return ActionResult(
+            action, entry.name, SYSTEMD, False, False,
+            f"Could not {action} '{entry.name}' over WSL: {exc}",
+        )
+    if res.ok:
+        return ActionResult(
+            action, entry.name, SYSTEMD, True, False,
+            f"{action.capitalize()} succeeded for systemd --user unit '{entry.name}'.",
+        )
+    detail = (res.stderr or res.stdout or "").strip() or f"systemctl exited {res.returncode}"
+    return ActionResult(
+        action, entry.name, SYSTEMD, False, False,
+        f"{action.capitalize()} failed for '{entry.name}': {detail}",
+    )
+
+
+def _control_nssm(
+    entry: RunnerEntry,
+    action: str,
+    runner: Runner,
+    is_admin: AdminProbe,
+    elevate: Elevator,
+) -> ActionResult:
+    argv = windows_service_argv(entry.name, action)
+    admin = is_admin()
+    try:
+        res = runner(argv) if admin else elevate(argv)
+    except _TOLERATED as exc:
+        return ActionResult(
+            action, entry.name, NSSM, False, not admin,
+            f"Could not {action} '{entry.name}': {exc}",
+        )
+
+    if res.ok:
+        note = " (elevated via UAC)" if not admin else ""
+        return ActionResult(
+            action, entry.name, NSSM, res.ok, not admin,
+            f"{action.capitalize()} succeeded for service '{entry.name}'{note}.",
+        )
+
+    # Failed. A non-admin failure is almost certainly a declined/failed elevation:
+    # make the "run elevated" requirement EXPLICIT rather than a silent no-op (AC3).
+    if not admin:
+        message = (
+            f"{action.capitalize()} of '{entry.name}' needs Windows administrator "
+            f"rights and the elevation was declined or failed (exit {res.returncode}). "
+            "Re-run the action and accept the UAC prompt, or launch the cockpit as "
+            "administrator."
+        )
+    else:
+        detail = (res.stderr or res.stdout or "").strip() or f"nssm exited {res.returncode}"
+        message = f"{action.capitalize()} failed for '{entry.name}': {detail}"
+    return ActionResult(action, entry.name, NSSM, False, not admin, message)

--- a/tools/runner-ui/forge_cockpit/fleet_view.py
+++ b/tools/runner-ui/forge_cockpit/fleet_view.py
@@ -29,6 +29,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QHeaderView,
     QLabel,
+    QMessageBox,
     QPushButton,
     QStyle,
     QTableView,
@@ -36,11 +37,31 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from forge_cockpit import discovery
-from forge_cockpit.discovery import Fleet, RunnerEntry
+from forge_cockpit import control, discovery, logs
+from forge_cockpit.control import ActionResult
+from forge_cockpit.discovery import NSSM, SYSTEMD, Fleet, RunnerEntry
+from forge_cockpit.log_view import LogViewer
+from forge_cockpit.logs import LogRead
 
 #: The discovery entry point the tab drives; injectable so tests stay hermetic.
 Discover = Callable[[], Fleet]
+
+#: Control seam: (entry, action) -> ActionResult. Injectable for hermetic tests.
+Controller = Callable[[RunnerEntry, str], ActionResult]
+
+#: Log-read seam: (entry) -> LogRead. Injectable for hermetic tests.
+ReadLogs = Callable[[RunnerEntry], LogRead]
+
+#: User-notification seam: (level, title, text) -> None. Defaults to a QMessageBox;
+#: tests inject a recorder so no modal dialog blocks the offscreen suite.
+Notifier = Callable[[str, str, str], None]
+
+#: Mechanisms whose service can be started/stopped/restarted (AC1). Docker job
+#: containers are ephemeral one-job runners — not controllable as a service.
+_CONTROLLABLE = frozenset({NSSM, SYSTEMD})
+
+#: Mechanisms that have a viewable service log source (AC2).
+_LOGGABLE = frozenset({NSSM, SYSTEMD})
 
 #: Column order for the fleet table (AC1: every field the overview must show).
 _COLUMNS: tuple[str, ...] = (
@@ -199,6 +220,29 @@ class _DiscoveryWorker(QRunnable):
         self.signals.finished.emit(fleet)
 
 
+class _Job(QRunnable):
+    """Runs an arbitrary callable off the GUI thread (control actions, AC1/AC3).
+
+    Reuses the #265 worker pattern: the callable runs on a thread-pool thread and
+    its result — or the string of any exception — is emitted via
+    :class:`_WorkerSignals`, delivered to the GUI thread by a queued connection so
+    a slow ``nssm``/``systemctl`` mutation never blocks the window.
+    """
+
+    def __init__(self, fn: Callable[[], object]) -> None:
+        super().__init__()
+        self._fn = fn
+        self.signals = _WorkerSignals()
+
+    def run(self) -> None:  # pragma: no cover - exercised via the thread pool
+        try:
+            result = self._fn()
+        except Exception as exc:  # never let an action crash the worker thread
+            self.signals.failed.emit(f"{type(exc).__name__}: {exc}")
+            return
+        self.signals.finished.emit(result)
+
+
 class FleetTab(QWidget):
     """The "Runner fleet" tab: a table over the fleet model + async refresh.
 
@@ -216,6 +260,13 @@ class FleetTab(QWidget):
     fleet_loaded = Signal()
     #: Emitted on the GUI thread when a refresh failed (carries the error string).
     refresh_failed = Signal(str)
+    #: Emitted on the GUI thread after a control action completes (carries the
+    #: :class:`ActionResult`) — the test seam for AC1/AC3 success+failure surfacing.
+    action_completed = Signal(object)
+    #: Emitted on the GUI thread when a control action's worker itself errored.
+    action_failed = Signal(str)
+    #: Emitted on the GUI thread when a log viewer is opened (carries the viewer).
+    log_viewer_opened = Signal(object)
 
     def __init__(
         self,
@@ -224,12 +275,22 @@ class FleetTab(QWidget):
         auto_refresh_ms: int = 0,
         pool: QThreadPool | None = None,
         initial_refresh: bool = True,
+        controller: Controller = control.control,
+        read_logs: ReadLogs = logs.read_logs,
+        notifier: Notifier | None = None,
+        log_tail_lines: int = logs.DEFAULT_TAIL_LINES,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._discover = discover
         self._pool = pool or QThreadPool.globalInstance()
         self._busy = False
+        self._controller = controller
+        self._read_logs = read_logs
+        self._notifier = notifier or self._default_notifier
+        self._log_tail_lines = log_tail_lines
+        #: Live references to opened log viewers so they are not GC'd (AC2).
+        self._log_viewers: list[LogViewer] = []
         #: Thread ident of the last discovery call — proves it ran off the GUI
         #: thread (AC3). ``None`` until the first refresh runs.
         self.last_discovery_thread_ident: int | None = None
@@ -263,6 +324,7 @@ class FleetTab(QWidget):
         self.table = QTableView()
         self.table.setModel(self._model)
         self.table.setSelectionBehavior(QTableView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QTableView.SelectionMode.SingleSelection)
         self.table.setEditTriggers(QTableView.EditTrigger.NoEditTriggers)
         self.table.setAlternatingRowColors(True)
         self.table.verticalHeader().setVisible(False)
@@ -270,6 +332,28 @@ class FleetTab(QWidget):
         header.setStretchLastSection(True)
         header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
         layout.addWidget(self.table)
+
+        # -- control bar (AC1/AC2/AC3): act on the selected runner ---------- #
+        controls = QHBoxLayout()
+        self.start_button = QPushButton("Start")
+        self.start_button.setToolTip("Start the selected runner service")
+        self.start_button.clicked.connect(lambda: self._do_control(control.START))
+        self.stop_button = QPushButton("Stop")
+        self.stop_button.setToolTip("Stop the selected runner service")
+        self.stop_button.clicked.connect(lambda: self._do_control(control.STOP))
+        self.restart_button = QPushButton("Restart")
+        self.restart_button.setToolTip("Restart the selected runner service")
+        self.restart_button.clicked.connect(lambda: self._do_control(control.RESTART))
+        self.logs_button = QPushButton("View logs")
+        self.logs_button.setToolTip("View + tail the selected runner's logs")
+        self.logs_button.clicked.connect(self._view_logs)
+        for btn in (self.start_button, self.stop_button, self.restart_button, self.logs_button):
+            controls.addWidget(btn)
+        controls.addStretch(1)
+        layout.addLayout(controls)
+
+        self.table.selectionModel().selectionChanged.connect(self._sync_controls)
+        self._sync_controls()
 
     # -- accessors (for tests / callers) ---------------------------------- #
     @property
@@ -334,3 +418,101 @@ class FleetTab(QWidget):
     def _end_refresh(self) -> None:
         self._busy = False
         self.refresh_button.setEnabled(True)
+        self._sync_controls()
+
+    # -- selection + control state (AC1/AC2) ------------------------------- #
+    def selected_entry(self) -> RunnerEntry | None:
+        """The :class:`RunnerEntry` for the selected row, or ``None`` if none."""
+        rows = self.table.selectionModel().selectedRows()
+        if not rows:
+            return None
+        row = rows[0].row()
+        if 0 <= row < self._model.rowCount():
+            return self._model.entry_at(row)
+        return None
+
+    def _sync_controls(self, *_args: object) -> None:
+        """Enable start/stop/restart/logs for the selected row, per mechanism.
+
+        No selection -> all disabled. A docker job container is not a controllable
+        service and has no service log source, so its controls stay disabled.
+        """
+        entry = self.selected_entry()
+        controllable = entry is not None and entry.mechanism in _CONTROLLABLE
+        loggable = entry is not None and entry.mechanism in _LOGGABLE
+        for btn in (self.start_button, self.stop_button, self.restart_button):
+            btn.setEnabled(controllable)
+        self.logs_button.setEnabled(loggable)
+
+    # -- control actions (AC1/AC3) ----------------------------------------- #
+    def _do_control(self, action: str) -> None:
+        """Run ``action`` on the selected runner off the GUI thread (AC1/AC3).
+
+        Disables the control bar while the action is in flight, then surfaces the
+        :class:`ActionResult` — a status line on success, and additionally a
+        warning dialog on failure. The action itself (``nssm`` / ``systemctl`` /
+        UAC elevation) runs on a thread-pool thread so the window never blocks.
+        """
+        entry = self.selected_entry()
+        if entry is None or entry.mechanism not in _CONTROLLABLE:
+            return
+        self._set_control_buttons_enabled(False)
+        self.status_label.setText(f"{action.capitalize()}ing '{entry.name}'…")
+
+        job = _Job(lambda: self._controller(entry, action))
+        job.signals.finished.connect(self._on_control_done)
+        job.signals.failed.connect(self._on_control_error)
+        self._pool.start(job)
+
+    def _on_control_done(self, result: ActionResult) -> None:
+        self.status_label.setText(result.message)
+        if not result.ok:
+            self._notifier("warning", f"{result.action.capitalize()} failed", result.message)
+        self._sync_controls()
+        self.action_completed.emit(result)
+
+    def _on_control_error(self, message: str) -> None:
+        text = f"The control action could not run: {message}"
+        self.status_label.setText(text)
+        self._notifier("critical", "Control action error", text)
+        self._sync_controls()
+        self.action_failed.emit(message)
+
+    def _set_control_buttons_enabled(self, on: bool) -> None:
+        for btn in (self.start_button, self.stop_button, self.restart_button, self.logs_button):
+            btn.setEnabled(on)
+
+    def _default_notifier(self, level: str, title: str, text: str) -> None:
+        """Surface a message via a modal dialog (the real, non-test notifier)."""
+        fn = getattr(QMessageBox, level, QMessageBox.information)
+        fn(self, title, text)
+
+    # -- log viewing (AC2) ------------------------------------------------- #
+    def _view_logs(self) -> None:
+        """Open a log viewer for the selected runner (reads off the GUI thread)."""
+        entry = self.selected_entry()
+        if entry is None or entry.mechanism not in _LOGGABLE:
+            return
+        viewer = self.open_log_viewer(entry)
+        viewer.show()
+
+    def open_log_viewer(self, entry: RunnerEntry) -> LogViewer:
+        """Build (but do not show) a :class:`LogViewer` for ``entry``.
+
+        The viewer is handed a reader bound to this entry + the configured tail
+        depth; it reads on the shared thread pool. A live reference is retained so
+        the dialog is not garbage-collected while open.
+        """
+        def read() -> LogRead:
+            return self._read_logs(entry, lines=self._log_tail_lines)
+
+        title = f"Logs — {entry.name} ({entry.mechanism})"
+        viewer = LogViewer(title, read, pool=self._pool, parent=self)
+        self._log_viewers.append(viewer)
+        viewer.destroyed.connect(lambda *_: self._forget_viewer(viewer))
+        self.log_viewer_opened.emit(viewer)
+        return viewer
+
+    def _forget_viewer(self, viewer: LogViewer) -> None:
+        if viewer in self._log_viewers:
+            self._log_viewers.remove(viewer)

--- a/tools/runner-ui/forge_cockpit/log_view.py
+++ b/tools/runner-ui/forge_cockpit/log_view.py
@@ -1,0 +1,180 @@
+"""The log viewer dialog (ticket #266, AC2) — read + tail a runner's logs.
+
+Reads happen OFF the GUI thread (the same :class:`QThreadPool` worker pattern as
+the #265 fleet refresh) so the window never blocks; a Refresh button reads once
+and a "Tail" toggle re-reads the last N lines on an interval for a live tail.
+
+It renders read-only text only — it never fetches the service ENVIRONMENT or a
+PAT; it shows exactly what the runner already wrote to its own logs/journal, via
+the PAT-free :func:`forge_cockpit.logs.read_logs` seam.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from PySide6.QtCore import QObject, QRunnable, Qt, QThreadPool, QTimer, Signal
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from forge_cockpit.logs import LogRead
+
+#: A bound reader: returns the current tail for one runner. Injectable for tests.
+ReadLogs = Callable[[], LogRead]
+
+#: Default tail poll interval when the "Tail" toggle is on (ms).
+TAIL_INTERVAL_MS = 3000
+
+
+class _ReadSignals(QObject):
+    finished = Signal(object)  # LogRead
+    failed = Signal(str)
+
+
+class _ReadJob(QRunnable):
+    """Runs a :data:`ReadLogs` off the GUI thread and marshals the result back."""
+
+    def __init__(self, read: ReadLogs) -> None:
+        super().__init__()
+        self._read = read
+        self.signals = _ReadSignals()
+
+    def run(self) -> None:  # pragma: no cover - exercised via the thread pool
+        try:
+            result = self._read()
+        except Exception as exc:  # never let a read crash the worker thread
+            self.signals.failed.emit(f"{type(exc).__name__}: {exc}")
+            return
+        self.signals.finished.emit(result)
+
+
+class LogViewer(QDialog):
+    """A dialog that shows + tails one runner's logs, reading off the GUI thread.
+
+    :param title: window title (usually the runner name + source).
+    :param read: the bound reader callable (default binds :func:`logs.read_logs`).
+    :param pool: thread pool to read on (default the global pool); injectable.
+    :param tail_ms: interval for the "Tail" toggle (default :data:`TAIL_INTERVAL_MS`).
+    :param initial_read: kick a first read on construction (default True; tests may
+        pass False for determinism).
+    """
+
+    #: Emitted on the GUI thread after a read has updated the pane.
+    logs_loaded = Signal()
+    #: Emitted on the GUI thread when a read failed (carries the error string).
+    load_failed = Signal(str)
+
+    def __init__(
+        self,
+        title: str,
+        read: ReadLogs,
+        *,
+        pool: QThreadPool | None = None,
+        tail_ms: int = TAIL_INTERVAL_MS,
+        initial_read: bool = True,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._read = read
+        self._pool = pool or QThreadPool.globalInstance()
+        self._busy = False
+        self.setWindowTitle(title)
+        self.resize(820, 560)
+
+        self._build_ui()
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(tail_ms)
+        self._timer.timeout.connect(self.refresh)
+
+        if initial_read:
+            self.refresh()
+
+    # -- UI ---------------------------------------------------------------- #
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        bar = QHBoxLayout()
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.setToolTip("Re-read the last lines of the log now")
+        self.refresh_button.clicked.connect(self.refresh)
+        self.tail_checkbox = QCheckBox("Tail")
+        self.tail_checkbox.setToolTip("Automatically re-read the log on an interval")
+        self.tail_checkbox.toggled.connect(self._on_tail_toggled)
+        self.status_label = QLabel("")
+        bar.addWidget(self.refresh_button)
+        bar.addWidget(self.tail_checkbox)
+        bar.addWidget(self.status_label)
+        bar.addStretch(1)
+        layout.addLayout(bar)
+
+        self.text = QPlainTextEdit()
+        self.text.setReadOnly(True)
+        self.text.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        # A monospaced-ish, log-friendly view; keep a bounded scrollback.
+        self.text.setMaximumBlockCount(20_000)
+        layout.addWidget(self.text)
+
+    # -- tail toggle ------------------------------------------------------- #
+    def _on_tail_toggled(self, on: bool) -> None:
+        if on:
+            self._timer.start()
+            self.refresh()
+        else:
+            self._timer.stop()
+
+    @property
+    def tailing(self) -> bool:
+        """True when the tail timer is active."""
+        return self._timer.isActive()
+
+    # -- read (off the GUI thread) ----------------------------------------- #
+    def refresh(self) -> None:
+        """Kick an off-thread log read; the result lands back on the GUI thread."""
+        if self._busy:
+            return
+        self._busy = True
+        self.refresh_button.setEnabled(False)
+        self.status_label.setText("Reading…")
+
+        job = _ReadJob(self._read)
+        job.signals.finished.connect(self._on_finished)
+        job.signals.failed.connect(self._on_failed)
+        self._pool.start(job)
+
+    def _on_finished(self, result: LogRead) -> None:
+        self.text.setPlainText(result.text)
+        self._scroll_to_end()
+        if result.ok:
+            self.status_label.setText(result.source)
+        else:
+            self.status_label.setText(f"No logs: {result.source}")
+        self._end()
+        self.logs_loaded.emit()
+
+    def _on_failed(self, message: str) -> None:
+        self.status_label.setText(f"Read failed: {message}")
+        self._end()
+        self.load_failed.emit(message)
+
+    def _scroll_to_end(self) -> None:
+        self.text.moveCursor(self.text.textCursor().MoveOperation.End)
+        bar = self.text.verticalScrollBar()
+        bar.setValue(bar.maximum())
+
+    def _end(self) -> None:
+        self._busy = False
+        self.refresh_button.setEnabled(True)
+
+    # -- lifecycle --------------------------------------------------------- #
+    def closeEvent(self, event) -> None:  # noqa: N802 - Qt override
+        self._timer.stop()
+        super().closeEvent(event)

--- a/tools/runner-ui/forge_cockpit/logs.py
+++ b/tools/runner-ui/forge_cockpit/logs.py
@@ -1,0 +1,124 @@
+"""Runner log reading + tailing (ticket #266, AC2).
+
+Reads the *selected* service's own logs and returns the tail (last N lines):
+
+* **Windows NSSM service** — the runner's own stdout/stderr, which
+  ``setup-runner.ps1`` points NSSM at: ``runner/windows/logs/service.out.log`` and
+  ``service.err.log`` (NSSM ``AppStdout`` / ``AppStderr``).
+* **Linux systemd ``--user`` unit** — ``journalctl --user -u <unit>`` run over
+  ``wsl.exe --`` interop.
+
+Returning the last N lines (rather than a blocking ``tail -f`` / ``journalctl
+-f``) lets a viewer poll on an interval for a live tail while staying off the GUI
+thread (same worker pattern as the #265 fleet refresh).
+
+Security (ADR-0005 + ADR-0006): reads only the runner's OWN output logs and
+journal — never the service ENVIRONMENT, ``~/.forge/runner.env``, or a PAT. The
+service/unit NAME comes from the #264 fleet model (name-derived); nothing here
+dumps a service's environment.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from forge_cockpit import shellout
+from forge_cockpit.discovery import NSSM, SYSTEMD, RunnerEntry
+from forge_cockpit.shellout import CommandResult
+
+Runner = Callable[..., CommandResult]
+
+#: NSSM service log dir — ``setup-runner.ps1`` writes to ``$PSScriptRoot/logs`` under
+#: ``runner/windows/``. Resolved from this file's repo location; injectable in tests.
+DEFAULT_WINDOWS_LOG_DIR = Path(__file__).resolve().parents[3] / "runner" / "windows" / "logs"
+
+#: The two files NSSM writes (AppStdout / AppStderr), in display order.
+WINDOWS_LOG_FILES: tuple[str, ...] = ("service.out.log", "service.err.log")
+
+#: Default tail depth (lines) for both mechanisms.
+DEFAULT_TAIL_LINES = 200
+
+_TOLERATED = (OSError, subprocess.SubprocessError)
+
+
+@dataclass(frozen=True)
+class LogRead:
+    """The result of a log read — text to render plus where it came from (AC2)."""
+
+    ok: bool
+    text: str
+    source: str
+
+
+def read_logs(
+    entry: RunnerEntry,
+    *,
+    lines: int = DEFAULT_TAIL_LINES,
+    wsl_runner: Runner = shellout.wsl,
+    windows_log_dir: Path | None = None,
+) -> LogRead:
+    """Read the last ``lines`` of ``entry``'s service logs (AC2).
+
+    Windows NSSM -> the ``service.out.log`` / ``service.err.log`` files; Linux
+    systemd -> ``journalctl --user -u <unit>`` over WSL. Docker job containers have
+    no persistent service log source and return a clear unsupported result.
+    """
+    if entry.mechanism == SYSTEMD:
+        return _read_journal(entry, lines, wsl_runner)
+    if entry.mechanism == NSSM:
+        return _read_windows_logs(entry, lines, windows_log_dir or DEFAULT_WINDOWS_LOG_DIR)
+    return LogRead(
+        ok=False,
+        text=(
+            f"No log source for '{entry.name}': it is an ephemeral docker job "
+            "container. Use `docker logs` for a specific job container."
+        ),
+        source=entry.mechanism,
+    )
+
+
+def _tail(text: str, lines: int) -> str:
+    return "\n".join(text.splitlines()[-lines:]) if lines > 0 else text
+
+
+def _read_windows_logs(entry: RunnerEntry, lines: int, log_dir: Path) -> LogRead:
+    source = str(log_dir)
+    chunks: list[str] = []
+    found = False
+    for fname in WINDOWS_LOG_FILES:
+        path = log_dir / fname
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace")
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            chunks.append(f"--- {fname}: cannot read ({exc}) ---")
+            continue
+        found = True
+        chunks.append(f"--- {fname} ---\n{_tail(content, lines)}")
+
+    if not found:
+        note = (
+            f"No service log files found in {log_dir} "
+            f"({' / '.join(WINDOWS_LOG_FILES)}). The service may not have run yet."
+        )
+        # Include any partial read-error notes we accumulated.
+        text = ("\n".join(chunks) + "\n\n" + note) if chunks else note
+        return LogRead(ok=False, text=text, source=source)
+    return LogRead(ok=True, text="\n\n".join(chunks), source=source)
+
+
+def _read_journal(entry: RunnerEntry, lines: int, wsl_runner: Runner) -> LogRead:
+    argv = ["journalctl", "--user", "-u", entry.name, "-n", str(lines), "--no-pager"]
+    source = f"journalctl --user -u {entry.name}"
+    try:
+        res = wsl_runner(argv)
+    except _TOLERATED as exc:
+        return LogRead(ok=False, text=f"Could not read journal over WSL: {exc}", source=source)
+    if not res.ok:
+        detail = (res.stderr or res.stdout or "").strip() or f"journalctl exited {res.returncode}"
+        return LogRead(ok=False, text=detail, source=source)
+    return LogRead(ok=True, text=res.stdout, source=source)

--- a/tools/runner-ui/tests/test_control.py
+++ b/tools/runner-ui/tests/test_control.py
@@ -1,0 +1,205 @@
+"""Tests for runner control actions (ticket #266, AC1 + AC3).
+
+Hermetic: every shell-out / elevation seam is a fake, so no service, WSL, or UAC
+prompt is touched. The suite locks:
+
+* AC1 — start/stop/restart issue the correct argv per mechanism (``nssm ...`` for a
+  Windows NSSM service, ``systemctl --user ...`` over WSL for a Linux unit) and
+  surface BOTH success and failure.
+* AC3 — an NSSM mutation while NOT elevated routes through the explicit UAC
+  elevation seam (never the direct runner); a declined/failed elevation yields a
+  clear "run elevated" message, never a silent no-op. systemd needs no elevation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from forge_cockpit import control
+from forge_cockpit.control import ActionResult, control as run_control, elevate_run, is_elevated
+from forge_cockpit.discovery import (
+    DOCKER,
+    NSSM,
+    SYSTEMD,
+    OnlineStatus,
+    RunnerEntry,
+    Target,
+    UNKNOWN_TARGET,
+)
+from forge_cockpit.shellout import CommandResult
+
+
+def _entry(mechanism: str, name: str = "forge-runner-acme-widgets") -> RunnerEntry:
+    return RunnerEntry(
+        name=name,
+        mechanism=mechanism,
+        service_state="running",
+        target=Target("acme", "widgets") if mechanism != DOCKER else UNKNOWN_TARGET,
+        online=OnlineStatus.unknown(),
+    )
+
+
+def _result(argv, rc=0, out="", err="") -> CommandResult:
+    return CommandResult(argv=tuple(argv), returncode=rc, stdout=out, stderr=err)
+
+
+class _Recorder:
+    """A fake runner/elevator that records argv and returns a canned result."""
+
+    def __init__(self, rc: int = 0, out: str = "", err: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self._rc, self._out, self._err = rc, out, err
+
+    def __call__(self, argv, **_kw) -> CommandResult:
+        self.calls.append(list(argv))
+        return _result(argv, self._rc, self._out, self._err)
+
+
+# --------------------------------------------------------------------------- #
+# systemd --user (AC1 Linux, no elevation).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("action", [control.START, control.STOP, control.RESTART])
+def test_systemd_issues_systemctl_user_argv_over_wsl(action):
+    wsl = _Recorder(rc=0)
+    admin = _Recorder()  # should never run for systemd
+    res = run_control(
+        _entry(SYSTEMD, "forge-runner-acme-tools"),
+        action,
+        runner=admin,
+        wsl_runner=wsl,
+        is_admin=lambda: False,
+        elevate=admin,
+    )
+    assert wsl.calls == [["systemctl", "--user", action, "forge-runner-acme-tools"]]
+    assert admin.calls == []  # no elevation, no direct windows runner
+    assert res.ok is True and res.elevated is False
+    assert res.mechanism == SYSTEMD
+
+
+def test_systemd_failure_is_surfaced_not_raised():
+    wsl = _Recorder(rc=1, err="Failed to start unit: not loaded")
+    res = run_control(
+        _entry(SYSTEMD),
+        control.START,
+        wsl_runner=wsl,
+        is_admin=lambda: True,
+    )
+    assert res.ok is False
+    assert "not loaded" in res.message
+    assert res.action == control.START
+
+
+# --------------------------------------------------------------------------- #
+# NSSM while ALREADY admin (AC1 Windows, direct — no elevation).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("action", [control.START, control.STOP, control.RESTART])
+def test_nssm_admin_runs_directly_without_elevation(action):
+    runner = _Recorder(rc=0)
+    elevate = _Recorder(rc=0)
+    res = run_control(
+        _entry(NSSM),
+        action,
+        runner=runner,
+        is_admin=lambda: True,
+        elevate=elevate,
+    )
+    assert runner.calls == [["nssm", action, "forge-runner-acme-widgets"]]
+    assert elevate.calls == []  # already admin -> never elevates
+    assert res.ok is True and res.elevated is False
+
+
+def test_nssm_admin_failure_surfaces_detail():
+    runner = _Recorder(rc=2, err="Can't open service!")
+    res = run_control(_entry(NSSM), control.STOP, runner=runner, is_admin=lambda: True)
+    assert res.ok is False
+    assert "Can't open service!" in res.message
+
+
+# --------------------------------------------------------------------------- #
+# NSSM while NOT admin (AC3 — explicit elevation, never a silent no-op).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("action", [control.START, control.STOP, control.RESTART])
+def test_nssm_non_admin_routes_through_elevation(action):
+    runner = _Recorder(rc=0)  # must NOT be used
+    elevate = _Recorder(rc=0)
+    res = run_control(
+        _entry(NSSM),
+        action,
+        runner=runner,
+        is_admin=lambda: False,
+        elevate=elevate,
+    )
+    assert runner.calls == []  # never runs the mutation un-elevated
+    assert elevate.calls == [["nssm", action, "forge-runner-acme-widgets"]]
+    assert res.ok is True and res.elevated is True
+    assert "elevated" in res.message.lower()
+
+
+def test_nssm_declined_elevation_gives_clear_message_not_silent_noop():
+    runner = _Recorder(rc=0)
+    # 1223 == ERROR_CANCELLED: the UAC prompt was declined.
+    elevate = _Recorder(rc=1223)
+    res = run_control(
+        _entry(NSSM),
+        control.RESTART,
+        runner=runner,
+        is_admin=lambda: False,
+        elevate=elevate,
+    )
+    assert runner.calls == []
+    assert elevate.calls == [["nssm", "restart", "forge-runner-acme-widgets"]]
+    # Failure surfaced with an explicit "run elevated" message — never a no-op.
+    assert res.ok is False and res.elevated is True
+    assert res.message  # non-empty
+    assert "administrator" in res.message.lower()
+    assert "1223" in res.message
+
+
+# --------------------------------------------------------------------------- #
+# Docker + bad action.
+# --------------------------------------------------------------------------- #
+def test_docker_job_container_is_unsupported_with_clear_message():
+    runner = _Recorder()
+    res = run_control(_entry(DOCKER, "runner-run-abc123"), control.START, runner=runner)
+    assert res.ok is False
+    assert "docker" in res.message.lower()
+    assert runner.calls == []  # nothing shelled out
+
+
+def test_unknown_action_raises():
+    with pytest.raises(ValueError):
+        run_control(_entry(NSSM), "pause")
+
+
+# --------------------------------------------------------------------------- #
+# elevate_run helper — builds a UAC 'runas' PowerShell launcher (AC3).
+# --------------------------------------------------------------------------- #
+def test_elevate_run_builds_runas_powershell():
+    captured: list[list[str]] = []
+
+    def fake_runner(argv, **_kw) -> CommandResult:
+        captured.append(list(argv))
+        return _result(argv, 0)
+
+    elevate_run(["nssm", "start", "forge-runner-acme-widgets"], runner=fake_runner)
+
+    (argv,) = captured
+    assert argv[0] == "powershell"
+    script = argv[-1]
+    assert "Start-Process" in script
+    assert "-Verb RunAs" in script
+    assert "-Wait" in script and "-PassThru" in script
+    # The service name is passed as an argument, single-quoted.
+    assert "'forge-runner-acme-widgets'" in script
+    # A declined prompt maps to the cancelled exit code.
+    assert "1223" in script
+
+
+def test_elevate_run_rejects_empty_argv():
+    with pytest.raises(ValueError):
+        elevate_run([])
+
+
+def test_is_elevated_true_off_windows(monkeypatch):
+    monkeypatch.setattr(control.os, "name", "posix")
+    assert is_elevated() is True

--- a/tools/runner-ui/tests/test_fleet_control.py
+++ b/tools/runner-ui/tests/test_fleet_control.py
@@ -1,0 +1,230 @@
+"""Tests for the fleet tab's control + log wiring (ticket #266, AC1/AC2/AC3).
+
+Hermetic + headless (offscreen): discovery, the controller, the log reader, and
+the user-notifier are all fakes, so no service, WSL, UAC prompt, or modal dialog
+is touched. Locks:
+
+* AC1 — a control button runs the controller for the SELECTED runner OFF the GUI
+  thread and surfaces success (status line) and failure (status + notifier).
+* AC2 — "View logs" opens a :class:`LogViewer` bound to the selected runner.
+* AC3 — a failed (e.g. non-elevated) NSSM action surfaces a clear message via the
+  notifier; it is never a silent no-op. Docker rows disable control + logs.
+"""
+
+from __future__ import annotations
+
+from threading import get_ident
+
+import pytest
+
+from forge_cockpit import control
+from forge_cockpit.control import ActionResult
+from forge_cockpit.discovery import (
+    DOCKER,
+    NSSM,
+    SYSTEMD,
+    Fleet,
+    OnlineStatus,
+    RunnerEntry,
+    Target,
+    UNKNOWN_TARGET,
+)
+from forge_cockpit.fleet_view import FleetTab
+from forge_cockpit.log_view import LogViewer
+from forge_cockpit.logs import LogRead
+
+NSSM_ENTRY = RunnerEntry(
+    name="forge-runner-acme-widgets",
+    mechanism=NSSM,
+    service_state="running",
+    target=Target("acme", "widgets"),
+    online=OnlineStatus.unknown(),
+)
+SYSTEMD_ENTRY = RunnerEntry(
+    name="forge-runner-acme-tools",
+    mechanism=SYSTEMD,
+    service_state="running",
+    target=Target("acme", "tools"),
+    online=OnlineStatus.unknown(),
+)
+DOCKER_ENTRY = RunnerEntry(
+    name="runner-run-abc123",
+    mechanism=DOCKER,
+    service_state="running",
+    target=UNKNOWN_TARGET,
+    online=OnlineStatus.unknown(),
+)
+FLEET = Fleet(runners=(NSSM_ENTRY, SYSTEMD_ENTRY, DOCKER_ENTRY))
+
+
+@pytest.fixture
+def _app(qapp):
+    return qapp
+
+
+class RecordingController:
+    """Fake controller: records (entry, action) + thread, returns a canned result."""
+
+    def __init__(self, ok: bool = True, message: str = "done", elevated: bool = False) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.thread_idents: list[int] = []
+        self._ok, self._message, self._elevated = ok, message, elevated
+
+    def __call__(self, entry: RunnerEntry, action: str) -> ActionResult:
+        self.calls.append((entry.name, action))
+        self.thread_idents.append(get_ident())
+        return ActionResult(
+            action=action,
+            name=entry.name,
+            mechanism=entry.mechanism,
+            ok=self._ok,
+            elevated=self._elevated,
+            message=self._message,
+        )
+
+
+class RecordingNotifier:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def __call__(self, level: str, title: str, text: str) -> None:
+        self.calls.append((level, title, text))
+
+
+def _fake_read(entry: RunnerEntry, **_kw) -> LogRead:
+    return LogRead(ok=True, text=f"logs for {entry.name}", source="fake")
+
+
+def _make_tab(qtbot, controller=None, notifier=None) -> FleetTab:
+    tab = FleetTab(
+        lambda: FLEET,
+        initial_refresh=False,
+        controller=controller or RecordingController(),
+        read_logs=_fake_read,
+        notifier=notifier or RecordingNotifier(),
+    )
+    qtbot.addWidget(tab)
+    with qtbot.waitSignal(tab.fleet_loaded, timeout=5000):
+        tab.refresh()
+    return tab
+
+
+# --------------------------------------------------------------------------- #
+# Selection gates the controls (AC1/AC2/AC3).
+# --------------------------------------------------------------------------- #
+def test_controls_disabled_without_selection(_app, qtbot):
+    tab = _make_tab(qtbot)
+    assert not tab.start_button.isEnabled()
+    assert not tab.stop_button.isEnabled()
+    assert not tab.restart_button.isEnabled()
+    assert not tab.logs_button.isEnabled()
+
+
+def test_nssm_selection_enables_controls_and_logs(_app, qtbot):
+    tab = _make_tab(qtbot)
+    tab.table.selectRow(0)  # NSSM
+    assert tab.selected_entry() is NSSM_ENTRY
+    assert tab.start_button.isEnabled()
+    assert tab.logs_button.isEnabled()
+
+
+def test_docker_selection_disables_control_and_logs(_app, qtbot):
+    tab = _make_tab(qtbot)
+    tab.table.selectRow(2)  # docker
+    assert tab.selected_entry() is DOCKER_ENTRY
+    assert not tab.start_button.isEnabled()
+    assert not tab.stop_button.isEnabled()
+    assert not tab.restart_button.isEnabled()
+    assert not tab.logs_button.isEnabled()
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — a control action runs off the GUI thread + surfaces success.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "button_attr,action",
+    [("start_button", control.START), ("stop_button", control.STOP), ("restart_button", control.RESTART)],
+)
+def test_control_button_runs_controller_off_gui_thread(_app, qtbot, button_attr, action):
+    ctrl = RecordingController(ok=True, message=f"{action} ok")
+    tab = _make_tab(qtbot, controller=ctrl)
+    tab.table.selectRow(0)  # NSSM
+    gui_thread = get_ident()
+
+    with qtbot.waitSignal(tab.action_completed, timeout=5000) as sig:
+        getattr(tab, button_attr).click()
+
+    assert ctrl.calls == [("forge-runner-acme-widgets", action)]
+    assert ctrl.thread_idents[0] != gui_thread  # ran off the GUI thread (AC1)
+    result = sig.args[0]
+    assert result.ok is True
+    assert tab.status_label.text() == f"{action} ok"
+
+
+def test_systemd_control_issues_action(_app, qtbot):
+    ctrl = RecordingController(ok=True, message="started")
+    tab = _make_tab(qtbot, controller=ctrl)
+    tab.table.selectRow(1)  # systemd
+
+    with qtbot.waitSignal(tab.action_completed, timeout=5000):
+        tab.start_button.click()
+
+    assert ctrl.calls == [("forge-runner-acme-tools", control.START)]
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — a failed action surfaces a clear message via the notifier (never silent).
+# --------------------------------------------------------------------------- #
+def test_failed_action_surfaces_via_notifier(_app, qtbot):
+    ctrl = RecordingController(
+        ok=False,
+        message="Start of 'forge-runner-acme-widgets' needs Windows administrator rights.",
+        elevated=True,
+    )
+    notifier = RecordingNotifier()
+    tab = _make_tab(qtbot, controller=ctrl, notifier=notifier)
+    tab.table.selectRow(0)
+
+    with qtbot.waitSignal(tab.action_completed, timeout=5000):
+        tab.start_button.click()
+
+    # Status line updated AND a warning dialog fired — not a silent no-op.
+    assert "administrator" in tab.status_label.text()
+    assert len(notifier.calls) == 1
+    level, _title, text = notifier.calls[0]
+    assert level == "warning"
+    assert "administrator" in text
+
+
+def test_controller_exception_is_surfaced(_app, qtbot):
+    def boom(entry, action):
+        raise RuntimeError("nssm missing")
+
+    notifier = RecordingNotifier()
+    tab = _make_tab(qtbot, controller=boom, notifier=notifier)
+    tab.table.selectRow(0)
+
+    with qtbot.waitSignal(tab.action_failed, timeout=5000) as sig:
+        tab.start_button.click()
+
+    assert "nssm missing" in sig.args[0]
+    assert notifier.calls and notifier.calls[0][0] == "critical"
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — "View logs" opens a LogViewer bound to the selected runner.
+# --------------------------------------------------------------------------- #
+def test_view_logs_opens_viewer_for_selected_runner(_app, qtbot):
+    tab = _make_tab(qtbot)
+    tab.table.selectRow(0)  # NSSM
+
+    with qtbot.waitSignal(tab.log_viewer_opened, timeout=5000) as sig:
+        tab.logs_button.click()
+
+    viewer = sig.args[0]
+    assert isinstance(viewer, LogViewer)
+    qtbot.addWidget(viewer)
+    # The viewer reads via the injected reader for THIS entry.
+    with qtbot.waitSignal(viewer.logs_loaded, timeout=5000):
+        viewer.refresh()
+    assert "forge-runner-acme-widgets" in viewer.text.toPlainText()

--- a/tools/runner-ui/tests/test_log_view.py
+++ b/tools/runner-ui/tests/test_log_view.py
@@ -1,0 +1,93 @@
+"""Tests for the log viewer dialog (ticket #266, AC2).
+
+Hermetic + headless (offscreen): the reader is a fake, so no file/journal is
+touched. Locks: the viewer reads OFF the GUI thread, renders the text, surfaces a
+source line, handles a failed read without crashing, and the "Tail" toggle arms
+the poll timer.
+"""
+
+from __future__ import annotations
+
+from threading import get_ident
+
+import pytest
+
+from forge_cockpit.log_view import LogViewer
+from forge_cockpit.logs import LogRead
+
+
+@pytest.fixture
+def _app(qapp):
+    return qapp
+
+
+class RecordingRead:
+    """A fake bound reader: records the thread it ran on, returns a canned read."""
+
+    def __init__(self, result: LogRead) -> None:
+        self.result = result
+        self.calls = 0
+        self.thread_idents: list[int] = []
+
+    def __call__(self) -> LogRead:
+        self.calls += 1
+        self.thread_idents.append(get_ident())
+        return self.result
+
+
+def _make(qtbot, read) -> LogViewer:
+    viewer = LogViewer("Logs — test", read, initial_read=False)
+    qtbot.addWidget(viewer)
+    return viewer
+
+
+def test_reads_off_the_gui_thread_and_renders(_app, qtbot):
+    read = RecordingRead(LogRead(ok=True, text="line a\nline b", source="C:/logs"))
+    viewer = _make(qtbot, read)
+    gui_thread = get_ident()
+
+    with qtbot.waitSignal(viewer.logs_loaded, timeout=5000):
+        viewer.refresh()
+
+    assert read.calls == 1
+    assert read.thread_idents[0] != gui_thread  # ran off the GUI thread (AC2)
+    assert "line a" in viewer.text.toPlainText()
+    assert viewer.status_label.text() == "C:/logs"
+
+
+def test_failed_read_result_is_surfaced(_app, qtbot):
+    read = RecordingRead(LogRead(ok=False, text="No service log files", source="C:/logs"))
+    viewer = _make(qtbot, read)
+
+    with qtbot.waitSignal(viewer.logs_loaded, timeout=5000):
+        viewer.refresh()
+
+    assert "No service log files" in viewer.text.toPlainText()
+    assert "No logs" in viewer.status_label.text()
+
+
+def test_reader_exception_is_caught_not_raised(_app, qtbot):
+    def boom() -> LogRead:
+        raise RuntimeError("journal exploded")
+
+    viewer = _make(qtbot, boom)
+
+    with qtbot.waitSignal(viewer.load_failed, timeout=5000) as sig:
+        viewer.refresh()
+
+    assert "journal exploded" in sig.args[0]
+    assert "failed" in viewer.status_label.text().lower()
+
+
+def test_tail_toggle_arms_the_timer(_app, qtbot):
+    read = RecordingRead(LogRead(ok=True, text="x", source="s"))
+    viewer = _make(qtbot, read)
+
+    assert viewer.tailing is False
+    # Toggling on both reads immediately and starts the poll timer.
+    with qtbot.waitSignal(viewer.logs_loaded, timeout=5000):
+        viewer.tail_checkbox.setChecked(True)
+    assert viewer.tailing is True
+
+    viewer.tail_checkbox.setChecked(False)
+    assert viewer.tailing is False

--- a/tools/runner-ui/tests/test_logs.py
+++ b/tools/runner-ui/tests/test_logs.py
@@ -1,0 +1,122 @@
+"""Tests for runner log reading + tailing (ticket #266, AC2).
+
+Hermetic: the Windows path reads files from a tmp dir (never the real
+``runner/windows/logs``); the Linux path uses a fake WSL runner. Locks:
+
+* Windows NSSM -> reads ``service.out.log`` / ``service.err.log`` from the log dir
+  and returns the tail (last N lines).
+* Linux systemd -> issues ``journalctl --user -u <unit> -n N`` over ``wsl.exe --``
+  and returns its output.
+* Missing logs / journalctl errors are surfaced (``ok=False``), never raised.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from forge_cockpit.discovery import (
+    DOCKER,
+    NSSM,
+    SYSTEMD,
+    OnlineStatus,
+    RunnerEntry,
+    Target,
+    UNKNOWN_TARGET,
+)
+from forge_cockpit.logs import DEFAULT_WINDOWS_LOG_DIR, WINDOWS_LOG_FILES, read_logs
+from forge_cockpit.shellout import CommandResult
+
+
+def _entry(mechanism: str, name: str = "forge-runner-acme-widgets") -> RunnerEntry:
+    return RunnerEntry(
+        name=name,
+        mechanism=mechanism,
+        service_state="running",
+        target=Target("acme", "widgets") if mechanism != DOCKER else UNKNOWN_TARGET,
+        online=OnlineStatus.unknown(),
+    )
+
+
+def _cmd(argv, rc=0, out="", err="") -> CommandResult:
+    return CommandResult(argv=tuple(argv), returncode=rc, stdout=out, stderr=err)
+
+
+# --------------------------------------------------------------------------- #
+# Windows NSSM logs (files).
+# --------------------------------------------------------------------------- #
+def test_windows_reads_both_log_files_and_tails(tmp_path: Path):
+    (tmp_path / "service.out.log").write_text(
+        "\n".join(f"out {i}" for i in range(100)), encoding="utf-8"
+    )
+    (tmp_path / "service.err.log").write_text("err line 1\nerr line 2\n", encoding="utf-8")
+
+    res = read_logs(_entry(NSSM), lines=5, windows_log_dir=tmp_path)
+
+    assert res.ok is True
+    assert res.source == str(tmp_path)
+    # Both files appear, labelled.
+    assert "service.out.log" in res.text and "service.err.log" in res.text
+    # Only the last 5 stdout lines are kept (tail), so line 94 is out, 95 is in.
+    assert "out 99" in res.text and "out 95" in res.text
+    assert "out 94" not in res.text
+    assert "err line 2" in res.text
+
+
+def test_windows_missing_logs_is_surfaced_not_raised(tmp_path: Path):
+    res = read_logs(_entry(NSSM), windows_log_dir=tmp_path)
+    assert res.ok is False
+    assert "No service log files" in res.text
+    for fname in WINDOWS_LOG_FILES:
+        assert fname in res.text
+
+
+def test_windows_reads_when_only_one_file_present(tmp_path: Path):
+    (tmp_path / "service.out.log").write_text("only stdout\n", encoding="utf-8")
+    res = read_logs(_entry(NSSM), windows_log_dir=tmp_path)
+    assert res.ok is True
+    assert "only stdout" in res.text
+
+
+def test_default_windows_log_dir_points_at_repo_runner_logs():
+    # Sanity: the default resolves to runner/windows/logs (never runner.env).
+    assert DEFAULT_WINDOWS_LOG_DIR.parts[-3:] == ("runner", "windows", "logs")
+
+
+# --------------------------------------------------------------------------- #
+# Linux systemd logs (journalctl over WSL).
+# --------------------------------------------------------------------------- #
+def test_linux_issues_journalctl_user_over_wsl():
+    calls: list[list[str]] = []
+
+    def fake_wsl(argv, **_kw) -> CommandResult:
+        calls.append(list(argv))
+        return _cmd(argv, 0, out="Jul 25 runner started\nJul 25 job done\n")
+
+    res = read_logs(
+        _entry(SYSTEMD, "forge-runner-acme-tools"), lines=50, wsl_runner=fake_wsl
+    )
+
+    assert calls == [
+        ["journalctl", "--user", "-u", "forge-runner-acme-tools", "-n", "50", "--no-pager"]
+    ]
+    assert res.ok is True
+    assert "runner started" in res.text
+    assert "journalctl" in res.source
+
+
+def test_linux_journalctl_error_is_surfaced():
+    def fake_wsl(argv, **_kw) -> CommandResult:
+        return _cmd(argv, rc=1, err="Failed to get journal: unit not found")
+
+    res = read_logs(_entry(SYSTEMD), wsl_runner=fake_wsl)
+    assert res.ok is False
+    assert "unit not found" in res.text
+
+
+# --------------------------------------------------------------------------- #
+# Docker — no persistent service log source.
+# --------------------------------------------------------------------------- #
+def test_docker_has_no_service_log_source():
+    res = read_logs(_entry(DOCKER, "runner-run-abc123"))
+    assert res.ok is False
+    assert "docker" in res.text.lower()


### PR DESCRIPTION
Closes #266

Adds per-runner control + log viewing to the cockpit (Wave 1), building on the #265 fleet view.

## Acceptance criteria
- **AC1** start/stop/restart a selected runner service — `nssm` (Windows NSSM) / `wsl.exe -- systemctl --user` (Linux), surfacing success and failure.
- **AC2** view + tail logs — Windows `runner/windows/logs/` (service.out/err.log), Linux `journalctl --user -u <unit>` over WSL; off-GUI-thread LogViewer with Refresh + Tail.
- **AC3** explicit privilege handling — NSSM mutations trigger per-action UAC `runas` elevation (ADR-0006), never a silent no-op; systemd --user needs none.

## Verification
Local: `uv run pytest` offscreen = 95 passed (38 new pytest-qt tests). No new deps, uv.lock + verify.yml untouched. Safety: name-derived service/unit only; never reads the service env / runner.env / PAT.
