### PR TITLE
feat(cockpit): install/uninstall a runner service from the UI, secret-safe (#267)

### DIFF
--- a/tools/runner-ui/forge_cockpit/fleet_view.py
+++ b/tools/runner-ui/forge_cockpit/fleet_view.py
@@ -42,6 +42,7 @@ from forge_cockpit.control import ActionResult
 from forge_cockpit.discovery import NSSM, SYSTEMD, Fleet, RunnerEntry
 from forge_cockpit.log_view import LogViewer
 from forge_cockpit.logs import LogRead
+from forge_cockpit.provision_view import ProvisionDialog
 
 #: The discovery entry point the tab drives; injectable so tests stay hermetic.
 Discover = Callable[[], Fleet]
@@ -267,6 +268,8 @@ class FleetTab(QWidget):
     action_failed = Signal(str)
     #: Emitted on the GUI thread when a log viewer is opened (carries the viewer).
     log_viewer_opened = Signal(object)
+    #: Emitted on the GUI thread when the install/uninstall dialog is opened (#267).
+    provision_dialog_opened = Signal(object)
 
     def __init__(
         self,
@@ -279,6 +282,7 @@ class FleetTab(QWidget):
         read_logs: ReadLogs = logs.read_logs,
         notifier: Notifier | None = None,
         log_tail_lines: int = logs.DEFAULT_TAIL_LINES,
+        provisioner: Callable[..., object] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -289,8 +293,11 @@ class FleetTab(QWidget):
         self._read_logs = read_logs
         self._notifier = notifier or self._default_notifier
         self._log_tail_lines = log_tail_lines
+        self._provisioner = provisioner
         #: Live references to opened log viewers so they are not GC'd (AC2).
         self._log_viewers: list[LogViewer] = []
+        #: Live references to opened provision dialogs so they are not GC'd (#267).
+        self._provision_dialogs: list[ProvisionDialog] = []
         #: Thread ident of the last discovery call — proves it ran off the GUI
         #: thread (AC3). ``None`` until the first refresh runs.
         self.last_discovery_thread_ident: int | None = None
@@ -350,6 +357,14 @@ class FleetTab(QWidget):
         for btn in (self.start_button, self.stop_button, self.restart_button, self.logs_button):
             controls.addWidget(btn)
         controls.addStretch(1)
+        # Install / uninstall a runner service (#267) — not tied to a selection; it
+        # opens a dialog to pick the target owner/repo. PAT stays out of band.
+        self.provision_button = QPushButton("Install / uninstall…")
+        self.provision_button.setToolTip(
+            "Install or uninstall a runner service for a repo (drives the setup scripts)"
+        )
+        self.provision_button.clicked.connect(self._open_provision)
+        controls.addWidget(self.provision_button)
         layout.addLayout(controls)
 
         self.table.selectionModel().selectionChanged.connect(self._sync_controls)
@@ -516,3 +531,44 @@ class FleetTab(QWidget):
     def _forget_viewer(self, viewer: LogViewer) -> None:
         if viewer in self._log_viewers:
             self._log_viewers.remove(viewer)
+
+    # -- install / uninstall (#267) ---------------------------------------- #
+    def _open_provision(self) -> None:
+        """Open the install/uninstall dialog, prefilled from the selection."""
+        dialog = self.open_provision_dialog()
+        dialog.show()
+
+    def _current_entries(self) -> tuple[RunnerEntry, ...]:
+        """The current fleet snapshot — feeds the dialog's clobber guard (#267 AC4)."""
+        return tuple(self._model.entry_at(r) for r in range(self._model.rowCount()))
+
+    def open_provision_dialog(self) -> ProvisionDialog:
+        """Build (but do not show) the :class:`ProvisionDialog`, prefilled + wired.
+
+        Prefills owner/repo from the selected runner's target when known, hands the
+        dialog the live fleet snapshot for its clobber/mis-target guard (AC4), and
+        shares this tab's notifier + thread pool. A live reference is retained so the
+        dialog is not garbage-collected while open.
+        """
+        entry = self.selected_entry()
+        owner = entry.target.owner if entry and entry.target.known else ""
+        repo = entry.target.repo if entry and entry.target.known else ""
+        kwargs: dict[str, object] = {
+            "fleet_entries": self._current_entries,
+            "notifier": self._notifier,
+            "default_owner": owner or "",
+            "default_repo": repo or "",
+            "pool": self._pool,
+            "parent": self,
+        }
+        if self._provisioner is not None:
+            kwargs["provisioner"] = self._provisioner
+        dialog = ProvisionDialog(**kwargs)
+        self._provision_dialogs.append(dialog)
+        dialog.destroyed.connect(lambda *_: self._forget_provision_dialog(dialog))
+        self.provision_dialog_opened.emit(dialog)
+        return dialog
+
+    def _forget_provision_dialog(self, dialog: ProvisionDialog) -> None:
+        if dialog in self._provision_dialogs:
+            self._provision_dialogs.remove(dialog)

--- a/tools/runner-ui/forge_cockpit/provision.py
+++ b/tools/runner-ui/forge_cockpit/provision.py
@@ -1,0 +1,390 @@
+"""Install / uninstall a runner service FROM the cockpit (ticket #267) — secret-safe.
+
+This module reimplements **nothing**: it stands a runner service up (or tears it
+down) by shelling out to the setup scripts that are already the API —
+
+* **Windows**: ``runner/windows/setup-runner.ps1 -InstallService`` /
+  ``-UninstallService`` (the NSSM service the runner already runs under), with the
+  chosen ``-Owner``/``-Repo`` (#260 repo-scoped target).
+* **Linux**: ``runner/linux/install-service.sh`` / ``--uninstall`` (the systemd
+  ``--user`` unit), reached over ``wsl.exe --`` interop, with ``--owner``/``--repo``.
+
+The service NAME is the #260 repo-scoped ``forge-runner-<owner>-<repo>`` — the same
+slug the scripts derive — so a second repo installs a DISTINCT service instead of
+clobbering the first (:func:`service_name`).
+
+Privilege handling (ADR-0006 Decision 4): a Windows NSSM service install/uninstall
+mutates a LocalSystem service and requires administrator rights; when the cockpit
+is **not** already elevated the action is routed through the SAME explicit
+per-action UAC elevation seam as the #266 control actions
+(:func:`forge_cockpit.control.elevate_run`), never a silent no-op. systemd
+``--user`` needs no elevation.
+
+SECRET SAFETY (AC3, ADR-0005 + ADR-0006 — non-negotiable): the runner PAT is
+handled **entirely out of band**. This module NEVER accepts a token argument,
+NEVER puts a token on argv, NEVER reads or writes ``~/.forge/runner.env`` or the
+service environment, and NEVER logs one. The scripts themselves read the PAT from
+their own out-of-band store (the service environment / the gitignored, chmod-600
+``runner.env``); the cockpit only points the operator at that store
+(:data:`PAT_GUIDANCE`). ``shellout.run`` additionally refuses any argv that
+references ``runner.env`` as a hard backstop.
+
+Clobber / mis-target guard (AC4): before an install the caller cross-checks the
+already-discovered #264 fleet — if a service with the derived name already exists
+for a DIFFERENT target (a name clash) or a running service for this repo is
+mis-targeted, the guard fires and the install refuses unless ``force`` is set,
+consistent with the ``-Force`` / ``--force`` guards the CLI scripts enforce.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+
+from forge_cockpit import shellout
+from forge_cockpit.control import Elevator, elevate_run, is_elevated
+from forge_cockpit.discovery import RunnerEntry
+from forge_cockpit.shellout import CommandResult
+
+# The two provisioning verbs.
+INSTALL = "install"
+UNINSTALL = "uninstall"
+ACTIONS: tuple[str, ...] = (INSTALL, UNINSTALL)
+
+# Target platforms — which setup script to drive.
+WINDOWS = "windows"
+LINUX = "linux"
+PLATFORMS: tuple[str, ...] = (WINDOWS, LINUX)
+
+#: Repo-scoped service/unit name prefix (ADR-0005 / #260) — matches the scripts.
+_SERVICE_PREFIX = "forge-runner"
+
+# Errors that mean "the manager/shell is simply absent / could not spawn" — turned
+# into a clear failure result rather than propagated as a crash.
+_TOLERATED = (OSError, subprocess.SubprocessError)
+
+#: Repo root (…/runner/windows/…): this file is forge_cockpit/provision.py, so
+#: parents[3] is the repo root — the same anchor logs.py uses.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+WINDOWS_SCRIPT = _REPO_ROOT / "runner" / "windows" / "setup-runner.ps1"
+LINUX_SCRIPT = _REPO_ROOT / "runner" / "linux" / "install-service.sh"
+
+#: Operator guidance for the PAT — the ONE secret, kept out of band (AC3). The UI
+#: shows this instead of ever offering a token field. Never contains a token.
+PAT_GUIDANCE = (
+    "The runner PAT is handled out of band and is never entered here. Before "
+    "installing, provide it to the service's own store per the runner docs:\n"
+    "  • Windows: set it for the elevated install session only, from your store —\n"
+    "      $env:FORGE_RUNNER_PAT = '<token>'   (never setx /M, never a committed file)\n"
+    "  • Linux: write the gitignored, chmod-600 store the unit loads it from —\n"
+    "      printf 'FORGE_RUNNER_PAT=<token>\\n' > ~/.forge/runner.env && chmod 600 ~/.forge/runner.env\n"
+    "The cockpit never displays, logs, stores, or commits the token."
+)
+
+# Injectable seams (defaulted to the real helpers; overridden with fakes in tests).
+Runner = Callable[..., CommandResult]
+AdminProbe = Callable[[], bool]
+
+
+# --------------------------------------------------------------------------- #
+# Result + guard types.
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ProvisionResult:
+    """The outcome of an install/uninstall, ready to surface to the operator."""
+
+    action: str  # INSTALL | UNINSTALL
+    platform: str  # WINDOWS | LINUX
+    name: str  # the repo-scoped service/unit name
+    owner: str
+    repo: str
+    ok: bool
+    #: True when the action was routed through a UAC elevation (Windows, non-admin).
+    elevated: bool
+    #: A human-readable success/failure line for the status bar / dialog.
+    message: str
+
+
+@dataclass(frozen=True)
+class GuardVerdict:
+    """Whether an install would clobber / mis-target an existing service (AC4)."""
+
+    #: A service with the derived name already exists (a reinstall / clash risk).
+    clashes: bool
+    #: The clashing/mis-targeted fleet entry, when one was found.
+    existing: RunnerEntry | None
+    #: A human-readable warning; empty when the install is clean.
+    message: str
+
+    @property
+    def clean(self) -> bool:
+        return not self.clashes
+
+
+# --------------------------------------------------------------------------- #
+# Name derivation — the #260 repo-scoped slug the scripts also derive.
+# --------------------------------------------------------------------------- #
+def _slug(value: str) -> str:
+    """Lowercase; every run of non-alphanumerics -> a single '-'; trim edge '-'."""
+    out: list[str] = []
+    prev_dash = False
+    for ch in value.lower():
+        if ch.isalnum():
+            out.append(ch)
+            prev_dash = False
+        elif not prev_dash:
+            out.append("-")
+            prev_dash = True
+    return "".join(out).strip("-")
+
+
+def service_name(owner: str, repo: str) -> str:
+    """``forge-runner-<owner>-<repo>`` (#260) — the repo-scoped service/unit name."""
+    name = _SERVICE_PREFIX
+    o, r = _slug(owner), _slug(repo)
+    if o:
+        name = f"{name}-{o}"
+    if r:
+        name = f"{name}-{r}"
+    return name
+
+
+def default_platform() -> str:
+    """The setup script that matches this host (Windows -> NSSM, else Linux)."""
+    return WINDOWS if os.name == "nt" else LINUX
+
+
+# --------------------------------------------------------------------------- #
+# Per-platform argv (the scripts are the API — we never reimplement them).
+# --------------------------------------------------------------------------- #
+def windows_install_argv(owner: str, repo: str, *, script: str, force: bool = False) -> list[str]:
+    """``setup-runner.ps1 -InstallService -Owner <o> -Repo <r>`` (AC1)."""
+    argv = [
+        "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script,
+        "-InstallService", "-Owner", owner, "-Repo", repo,
+    ]
+    if force:
+        argv.append("-Force")
+    return argv
+
+
+def windows_uninstall_argv(owner: str, repo: str, *, script: str) -> list[str]:
+    """``setup-runner.ps1 -UninstallService -Owner <o> -Repo <r>`` (AC2)."""
+    return [
+        "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script,
+        "-UninstallService", "-Owner", owner, "-Repo", repo,
+    ]
+
+
+def linux_install_argv(owner: str, repo: str, *, script: str, force: bool = False) -> list[str]:
+    """``install-service.sh --owner <o> --repo <r>`` (AC1)."""
+    argv = ["bash", script, "--owner", owner, "--repo", repo]
+    if force:
+        argv.append("--force")
+    return argv
+
+
+def linux_uninstall_argv(owner: str, repo: str, *, script: str) -> list[str]:
+    """``install-service.sh --uninstall --owner <o> --repo <r>`` (AC2)."""
+    return ["bash", script, "--uninstall", "--owner", owner, "--repo", repo]
+
+
+def _to_wsl_path(path: Path) -> str:
+    """``C:\\mywp\\forge\\...`` -> ``/mnt/c/mywp/forge/...`` for a bash-over-WSL call."""
+    win = PureWindowsPath(str(path))
+    drive = win.drive  # e.g. "C:"
+    if len(drive) >= 2 and drive[1] == ":":
+        tail = "/".join(win.parts[1:])
+        return f"/mnt/{drive[0].lower()}/{tail}"
+    return str(path).replace("\\", "/")
+
+
+# --------------------------------------------------------------------------- #
+# Clobber / mis-target guard (AC4).
+# --------------------------------------------------------------------------- #
+def _is_mistargeted(entry: RunnerEntry) -> bool:
+    """A *running* service whose known repo has a *known* online count of 0 (#260).
+
+    Mirrors :func:`forge_cockpit.fleet_view.is_mistargeted`; inlined here to keep
+    :mod:`provision` free of a GUI-module import (avoids an import cycle).
+    """
+    return (
+        entry.service_state == "running"
+        and entry.target.known
+        and entry.online.known
+        and entry.online_count == 0
+    )
+
+
+def check_guards(owner: str, repo: str, entries: tuple[RunnerEntry, ...]) -> GuardVerdict:
+    """Would installing ``owner/repo`` clobber or mis-target an existing service?
+
+    Cross-references the already-discovered #264 fleet by the derived repo-scoped
+    NAME. A same-name entry means an install would reinstall/clobber it; if that
+    entry is *running* and its repo shows 0 online runners it is the #260
+    mis-target the fleet view flags. Returns a :class:`GuardVerdict` the caller
+    surfaces (and refuses on, unless ``force``), consistent with the CLI guards.
+    """
+    name = service_name(owner, repo).lower()
+    for entry in entries:
+        if entry.name.lower() != name:
+            continue
+        mistargeted = _is_mistargeted(entry)
+        message = (
+            f"A service '{entry.name}' for {owner}/{repo} already exists "
+            f"(state: {entry.service_state})."
+        )
+        if mistargeted:
+            message += (
+                f" It is running but its repo reports 0 online runners — likely "
+                f"mis-targeted (#260)."
+            )
+        message += " Re-installing will replace it; enable Force to proceed."
+        return GuardVerdict(clashes=True, existing=entry, message=message)
+    return GuardVerdict(clashes=False, existing=None, message="")
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration.
+# --------------------------------------------------------------------------- #
+def provision(
+    action: str,
+    owner: str,
+    repo: str,
+    *,
+    platform: str | None = None,
+    force: bool = False,
+    entries: tuple[RunnerEntry, ...] = (),
+    runner: Runner = shellout.run,
+    wsl_runner: Runner = shellout.wsl,
+    is_admin: AdminProbe = is_elevated,
+    elevate: Elevator = elevate_run,
+    windows_script: Path = WINDOWS_SCRIPT,
+    linux_script: Path = LINUX_SCRIPT,
+) -> ProvisionResult:
+    """Install / uninstall the ``owner/repo`` runner service by driving the scripts.
+
+    Routes by ``platform`` (defaulting to this host): Windows drives
+    ``setup-runner.ps1`` (elevated via UAC when not already admin), Linux drives
+    ``install-service.sh`` over WSL (no elevation). Never handles the PAT (AC3).
+    An install refuses when :func:`check_guards` flags a clobber/mis-target and
+    ``force`` is not set (AC4).
+    """
+    if action not in ACTIONS:
+        raise ValueError(f"unknown action {action!r}; expected one of {ACTIONS}")
+    if not owner or not repo:
+        raise ValueError("owner and repo are both required")
+    plat = platform or default_platform()
+    if plat not in PLATFORMS:
+        raise ValueError(f"unknown platform {plat!r}; expected one of {PLATFORMS}")
+
+    name = service_name(owner, repo)
+
+    # AC4: refuse a clobber/mis-target install unless forced — same bar as the CLI.
+    if action == INSTALL and not force:
+        verdict = check_guards(owner, repo, entries)
+        if verdict.clashes:
+            return ProvisionResult(
+                action, plat, name, owner, repo, ok=False, elevated=False,
+                message=verdict.message + " (refused — no changes made)",
+            )
+
+    if plat == WINDOWS:
+        return _provision_windows(
+            action, owner, repo, name, force, runner, is_admin, elevate, windows_script
+        )
+    return _provision_linux(action, owner, repo, name, force, wsl_runner, linux_script)
+
+
+def _provision_windows(
+    action: str,
+    owner: str,
+    repo: str,
+    name: str,
+    force: bool,
+    runner: Runner,
+    is_admin: AdminProbe,
+    elevate: Elevator,
+    script: Path,
+) -> ProvisionResult:
+    script_str = str(script)
+    if action == INSTALL:
+        argv = windows_install_argv(owner, repo, script=script_str, force=force)
+    else:
+        argv = windows_uninstall_argv(owner, repo, script=script_str)
+
+    admin = is_admin()
+    try:
+        res = runner(argv) if admin else elevate(argv)
+    except _TOLERATED as exc:
+        return ProvisionResult(
+            action, WINDOWS, name, owner, repo, ok=False, elevated=not admin,
+            message=f"Could not {action} '{name}': {exc}",
+        )
+
+    if res.ok:
+        note = " (elevated via UAC)" if not admin else ""
+        tail = _install_tail(action)
+        return ProvisionResult(
+            action, WINDOWS, name, owner, repo, ok=True, elevated=not admin,
+            message=f"{action.capitalize()} succeeded for service '{name}'{note}.{tail}",
+        )
+
+    # Failed. A non-admin failure is almost certainly a declined/failed elevation:
+    # make the "run elevated" requirement EXPLICIT rather than a silent no-op.
+    if not admin:
+        message = (
+            f"{action.capitalize()} of '{name}' needs Windows administrator rights "
+            f"and the elevation was declined or failed (exit {res.returncode}). "
+            "Re-run and accept the UAC prompt, or launch the cockpit as administrator."
+        )
+    else:
+        detail = (res.stderr or res.stdout or "").strip() or f"script exited {res.returncode}"
+        message = f"{action.capitalize()} failed for '{name}': {detail}"
+    return ProvisionResult(action, WINDOWS, name, owner, repo, ok=False, elevated=not admin, message=message)
+
+
+def _provision_linux(
+    action: str,
+    owner: str,
+    repo: str,
+    name: str,
+    force: bool,
+    wsl_runner: Runner,
+    script: Path,
+) -> ProvisionResult:
+    script_wsl = _to_wsl_path(script)
+    if action == INSTALL:
+        argv = linux_install_argv(owner, repo, script=script_wsl, force=force)
+    else:
+        argv = linux_uninstall_argv(owner, repo, script=script_wsl)
+
+    try:
+        res = wsl_runner(argv)
+    except _TOLERATED as exc:
+        return ProvisionResult(
+            action, LINUX, name, owner, repo, ok=False, elevated=False,
+            message=f"Could not {action} '{name}' over WSL: {exc}",
+        )
+
+    if res.ok:
+        tail = _install_tail(action)
+        return ProvisionResult(
+            action, LINUX, name, owner, repo, ok=True, elevated=False,
+            message=f"{action.capitalize()} succeeded for systemd --user unit '{name}'.{tail}",
+        )
+    detail = (res.stderr or res.stdout or "").strip() or f"install-service.sh exited {res.returncode}"
+    return ProvisionResult(
+        action, LINUX, name, owner, repo, ok=False, elevated=False,
+        message=f"{action.capitalize()} failed for '{name}': {detail}",
+    )
+
+
+def _install_tail(action: str) -> str:
+    """A reminder pointing at the out-of-band PAT store after an install (AC3)."""
+    if action == INSTALL:
+        return " The service loads the PAT from its own out-of-band store (see the PAT guidance)."
+    return ""

--- a/tools/runner-ui/forge_cockpit/provision_view.py
+++ b/tools/runner-ui/forge_cockpit/provision_view.py
@@ -1,0 +1,260 @@
+"""The install / uninstall dialog (ticket #267) — stand a runner up/down, secret-safe.
+
+A small modal to pick the target ``owner``/``repo`` and Install or Uninstall the
+repo-scoped runner service by driving the setup scripts via
+:mod:`forge_cockpit.provision`. The work runs OFF the GUI thread (the same
+:class:`QThreadPool` worker pattern as the #265 fleet refresh / #266 control
+actions) so a slow ``setup-runner.ps1`` / UAC prompt / ``install-service.sh`` never
+blocks the window.
+
+Secret safety (AC3): the dialog shows read-only PAT *guidance*
+(:data:`~forge_cockpit.provision.PAT_GUIDANCE`) pointing the operator at the
+out-of-band store. It has **no token field** — nothing here accepts, echoes, logs,
+persists, or commits a PAT.
+
+Clobber/mis-target guard (AC4): before an un-forced install the dialog cross-checks
+the current fleet via :func:`provision.check_guards` and, when a service for that
+repo already exists, warns via the notifier and does NOT proceed unless "Force
+(override an existing service)" is ticked.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from forge_cockpit import provision
+from forge_cockpit.discovery import RunnerEntry
+from forge_cockpit.provision import ProvisionResult
+
+#: The provisioning callable seam: (action, owner, repo, **kw) -> ProvisionResult.
+Provisioner = Callable[..., ProvisionResult]
+
+#: Supplies the current fleet snapshot for the clobber guard (injectable in tests).
+FleetEntries = Callable[[], tuple[RunnerEntry, ...]]
+
+#: User-notification seam: (level, title, text) -> None. Defaults to a QMessageBox;
+#: tests inject a recorder so no modal blocks the offscreen suite.
+Notifier = Callable[[str, str, str], None]
+
+_PLATFORM_LABELS: tuple[tuple[str, str], ...] = (
+    (provision.WINDOWS, "Windows (NSSM service)"),
+    (provision.LINUX, "Linux (systemd --user, over WSL)"),
+)
+
+
+class _JobSignals(QObject):
+    finished = Signal(object)  # ProvisionResult
+    failed = Signal(str)
+
+
+class _Job(QRunnable):
+    """Runs a callable off the GUI thread; marshals the result/error back."""
+
+    def __init__(self, fn: Callable[[], object]) -> None:
+        super().__init__()
+        self._fn = fn
+        self.signals = _JobSignals()
+
+    def run(self) -> None:  # pragma: no cover - exercised via the thread pool
+        try:
+            result = self._fn()
+        except Exception as exc:  # never let a run crash the worker thread
+            self.signals.failed.emit(f"{type(exc).__name__}: {exc}")
+            return
+        self.signals.finished.emit(result)
+
+
+class ProvisionDialog(QDialog):
+    """Pick owner/repo + Install/Uninstall the repo-scoped runner service (secret-safe)."""
+
+    #: Emitted on the GUI thread after a provision action completes (ProvisionResult).
+    provision_done = Signal(object)
+    #: Emitted on the GUI thread when the provision worker itself errored.
+    provision_failed = Signal(str)
+    #: Emitted when an install was refused pre-flight by the clobber guard (AC4).
+    guard_blocked = Signal(str)
+
+    def __init__(
+        self,
+        *,
+        provisioner: Provisioner = provision.provision,
+        fleet_entries: FleetEntries = lambda: (),
+        notifier: Notifier | None = None,
+        default_owner: str = "",
+        default_repo: str = "",
+        default_platform: str | None = None,
+        pool: QThreadPool | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._provisioner = provisioner
+        self._fleet_entries = fleet_entries
+        self._notifier = notifier or self._default_notifier
+        self._pool = pool or QThreadPool.globalInstance()
+        self._busy = False
+        self.setWindowTitle("Install / uninstall a runner service")
+        self.resize(560, 440)
+        self._build_ui(default_owner, default_repo, default_platform or provision.default_platform())
+
+    # -- UI ---------------------------------------------------------------- #
+    def _build_ui(self, owner: str, repo: str, platform: str) -> None:
+        layout = QVBoxLayout(self)
+
+        form = QFormLayout()
+        self.owner_edit = QLineEdit(owner)
+        self.owner_edit.setPlaceholderText("owner (e.g. dngioidev)")
+        self.repo_edit = QLineEdit(repo)
+        self.repo_edit.setPlaceholderText("repo (e.g. forge)")
+        self.platform_combo = QComboBox()
+        for value, label in _PLATFORM_LABELS:
+            self.platform_combo.addItem(label, value)
+        idx = self.platform_combo.findData(platform)
+        if idx >= 0:
+            self.platform_combo.setCurrentIndex(idx)
+        form.addRow("Owner", self.owner_edit)
+        form.addRow("Repository", self.repo_edit)
+        form.addRow("Platform", self.platform_combo)
+        layout.addLayout(form)
+
+        self.name_label = QLabel("")
+        self.name_label.setToolTip("The #260 repo-scoped service name the scripts derive")
+        layout.addWidget(self.name_label)
+        self.owner_edit.textChanged.connect(self._sync_name)
+        self.repo_edit.textChanged.connect(self._sync_name)
+        self._sync_name()
+
+        self.force_checkbox = QCheckBox("Force (override an existing service for this repo)")
+        self.force_checkbox.setToolTip(
+            "Maps to setup-runner.ps1 -Force / install-service.sh --force. Needed to "
+            "replace an existing (possibly mis-targeted) service for this repo."
+        )
+        layout.addWidget(self.force_checkbox)
+
+        # PAT guidance — READ-ONLY, no token field (AC3).
+        guidance = QPlainTextEdit()
+        guidance.setReadOnly(True)
+        guidance.setPlainText(provision.PAT_GUIDANCE)
+        guidance.setMaximumHeight(150)
+        layout.addWidget(QLabel("PAT (handled out of band — never entered here):"))
+        layout.addWidget(guidance)
+
+        self.status_label = QLabel("")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        buttons = QHBoxLayout()
+        self.install_button = QPushButton("Install")
+        self.install_button.setToolTip("Run the setup script's install for this repo")
+        self.install_button.clicked.connect(self._on_install)
+        self.uninstall_button = QPushButton("Uninstall")
+        self.uninstall_button.setToolTip("Run the setup script's uninstall for this repo")
+        self.uninstall_button.clicked.connect(self._on_uninstall)
+        self.close_button = QPushButton("Close")
+        self.close_button.clicked.connect(self.reject)
+        buttons.addWidget(self.install_button)
+        buttons.addWidget(self.uninstall_button)
+        buttons.addStretch(1)
+        buttons.addWidget(self.close_button)
+        layout.addLayout(buttons)
+
+    # -- accessors --------------------------------------------------------- #
+    def _target(self) -> tuple[str, str, str]:
+        return (
+            self.owner_edit.text().strip(),
+            self.repo_edit.text().strip(),
+            self.platform_combo.currentData(),
+        )
+
+    def _sync_name(self) -> None:
+        owner, repo, _ = self._target()
+        if owner and repo:
+            self.name_label.setText(f"Service name: {provision.service_name(owner, repo)}")
+        else:
+            self.name_label.setText("Service name: (enter owner + repo)")
+
+    # -- actions ----------------------------------------------------------- #
+    def _on_install(self) -> None:
+        owner, repo, platform = self._target()
+        if not owner or not repo:
+            self._notifier("warning", "Missing target", "Enter both an owner and a repo.")
+            return
+        force = self.force_checkbox.isChecked()
+
+        # AC4: pre-flight the clobber/mis-target guard against the live fleet. When it
+        # fires and Force is off, warn and do NOT proceed (no silent clobber).
+        if not force:
+            verdict = provision.check_guards(owner, repo, tuple(self._fleet_entries()))
+            if verdict.clashes:
+                self._notifier("warning", "Service already exists", verdict.message)
+                self.status_label.setText(verdict.message)
+                self.guard_blocked.emit(verdict.message)
+                return
+        self._run(provision.INSTALL, owner, repo, platform, force)
+
+    def _on_uninstall(self) -> None:
+        owner, repo, platform = self._target()
+        if not owner or not repo:
+            self._notifier("warning", "Missing target", "Enter both an owner and a repo.")
+            return
+        self._run(provision.UNINSTALL, owner, repo, platform, force=False)
+
+    def _run(self, action: str, owner: str, repo: str, platform: str, force: bool) -> None:
+        if self._busy:
+            return
+        self._busy = True
+        self._set_buttons_enabled(False)
+        self.status_label.setText(f"{action.capitalize()}ing '{provision.service_name(owner, repo)}'…")
+
+        entries = tuple(self._fleet_entries())
+
+        def work() -> ProvisionResult:
+            return self._provisioner(
+                action, owner, repo, platform=platform, force=force, entries=entries
+            )
+
+        job = _Job(work)
+        job.signals.finished.connect(self._on_done)
+        job.signals.failed.connect(self._on_error)
+        self._pool.start(job)
+
+    def _on_done(self, result: ProvisionResult) -> None:
+        self.status_label.setText(result.message)
+        if not result.ok:
+            self._notifier("warning", f"{result.action.capitalize()} failed", result.message)
+        self._end()
+        self.provision_done.emit(result)
+
+    def _on_error(self, message: str) -> None:
+        text = f"The provisioning action could not run: {message}"
+        self.status_label.setText(text)
+        self._notifier("critical", "Provisioning error", text)
+        self._end()
+        self.provision_failed.emit(message)
+
+    def _end(self) -> None:
+        self._busy = False
+        self._set_buttons_enabled(True)
+
+    def _set_buttons_enabled(self, on: bool) -> None:
+        self.install_button.setEnabled(on)
+        self.uninstall_button.setEnabled(on)
+
+    def _default_notifier(self, level: str, title: str, text: str) -> None:
+        fn = getattr(QMessageBox, level, QMessageBox.information)
+        fn(self, title, text)

--- a/tools/runner-ui/tests/test_provision.py
+++ b/tools/runner-ui/tests/test_provision.py
@@ -1,0 +1,287 @@
+"""Tests for install/uninstall provisioning (ticket #267, AC1-AC4).
+
+Hermetic: every shell-out / elevation seam is a fake, so no script, WSL, or UAC
+prompt runs. Locks:
+
+* AC1 — install drives the EXISTING scripts with the chosen owner/repo and the
+  #260 repo-scoped service name (``setup-runner.ps1 -InstallService`` /
+  ``install-service.sh --owner/--repo``), never reimplementing them.
+* AC2 — uninstall drives the ``-UninstallService`` / ``--uninstall`` counterpart.
+* AC3 — the flow NEVER passes/echoes/logs a PAT: no token argument exists, no argv
+  token carries a PAT or ``runner.env``, and the guidance points at the out-of-band
+  store.
+* AC4 — a clobber (a service for that repo already exists) refuses the install
+  unless forced, consistent with the CLI ``-Force`` / ``--force`` guard.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from forge_cockpit import provision
+from forge_cockpit.discovery import (
+    NSSM,
+    OnlineStatus,
+    RunnerEntry,
+    Target,
+)
+from forge_cockpit.provision import (
+    check_guards,
+    provision as run_provision,
+    service_name,
+)
+from forge_cockpit.shellout import CommandResult
+
+WIN_SCRIPT = "C:\\repo\\runner\\windows\\setup-runner.ps1"
+LNX_SCRIPT = "/mnt/c/repo/runner/linux/install-service.sh"
+
+
+def _result(argv, rc=0, out="", err="") -> CommandResult:
+    return CommandResult(argv=tuple(argv), returncode=rc, stdout=out, stderr=err)
+
+
+class _Recorder:
+    """A fake runner/elevator that records argv and returns a canned result."""
+
+    def __init__(self, rc: int = 0, out: str = "", err: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self._rc, self._out, self._err = rc, out, err
+
+    def __call__(self, argv, **_kw) -> CommandResult:
+        self.calls.append(list(argv))
+        return _result(argv, self._rc, self._out, self._err)
+
+
+def _entry(name: str, owner: str, repo: str, state: str = "running", online=None) -> RunnerEntry:
+    return RunnerEntry(
+        name=name,
+        mechanism=NSSM,
+        service_state=state,
+        target=Target(owner, repo),
+        online=online or OnlineStatus.unknown(),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# #260 repo-scoped naming.
+# --------------------------------------------------------------------------- #
+def test_service_name_is_repo_scoped():
+    assert service_name("acme", "widgets") == "forge-runner-acme-widgets"
+    # Sanitised: uppercase + punctuation collapse to a single dash, edges trimmed.
+    assert service_name("Acme.Co", "My_Repo") == "forge-runner-acme-co-my-repo"
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — install drives the EXISTING scripts with the chosen repo (never reimplemented).
+# --------------------------------------------------------------------------- #
+def test_windows_install_argv_drives_setup_script():
+    argv = provision.windows_install_argv("acme", "widgets", script=WIN_SCRIPT)
+    assert argv[0] == "powershell"
+    assert "-File" in argv and WIN_SCRIPT in argv
+    assert "-InstallService" in argv
+    assert argv[argv.index("-Owner") + 1] == "acme"
+    assert argv[argv.index("-Repo") + 1] == "widgets"
+    assert "-Force" not in argv
+
+
+def test_windows_install_argv_force_adds_flag():
+    argv = provision.windows_install_argv("acme", "widgets", script=WIN_SCRIPT, force=True)
+    assert "-Force" in argv
+
+
+def test_linux_install_argv_drives_install_service_script():
+    argv = provision.linux_install_argv("acme", "widgets", script=LNX_SCRIPT)
+    assert argv[0] == "bash" and argv[1] == LNX_SCRIPT
+    assert argv[argv.index("--owner") + 1] == "acme"
+    assert argv[argv.index("--repo") + 1] == "widgets"
+    assert "--force" not in argv
+
+
+def test_windows_install_admin_runs_script_directly():
+    runner, elevate = _Recorder(rc=0), _Recorder(rc=0)
+    res = run_provision(
+        provision.INSTALL, "acme", "widgets",
+        platform=provision.WINDOWS, runner=runner, elevate=elevate,
+        is_admin=lambda: True, windows_script=WIN_SCRIPT,
+    )
+    assert res.ok and res.elevated is False
+    assert res.name == "forge-runner-acme-widgets"
+    (argv,) = runner.calls
+    assert "-InstallService" in argv and "acme" in argv and "widgets" in argv
+    assert elevate.calls == []  # already admin -> no UAC
+
+
+def test_windows_install_non_admin_routes_through_uac_elevation():
+    runner, elevate = _Recorder(rc=0), _Recorder(rc=0)
+    res = run_provision(
+        provision.INSTALL, "acme", "widgets",
+        platform=provision.WINDOWS, runner=runner, elevate=elevate,
+        is_admin=lambda: False, windows_script=WIN_SCRIPT,
+    )
+    assert res.ok and res.elevated is True
+    assert runner.calls == []  # never runs the mutation un-elevated
+    (argv,) = elevate.calls
+    assert "-InstallService" in argv
+
+
+def test_linux_install_runs_over_wsl_no_elevation(tmp_path):
+    wsl = _Recorder(rc=0)
+    res = run_provision(
+        provision.INSTALL, "acme", "widgets",
+        platform=provision.LINUX, wsl_runner=wsl,
+        linux_script=tmp_path / "install-service.sh",
+    )
+    assert res.ok and res.elevated is False
+    (argv,) = wsl.calls
+    assert argv[0] == "bash"
+    assert "--owner" in argv and "acme" in argv and "widgets" in argv
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — uninstall drives the counterpart.
+# --------------------------------------------------------------------------- #
+def test_windows_uninstall_argv_uses_uninstall_flag():
+    argv = provision.windows_uninstall_argv("acme", "widgets", script=WIN_SCRIPT)
+    assert "-UninstallService" in argv
+    assert "-InstallService" not in argv
+    assert argv[argv.index("-Owner") + 1] == "acme"
+
+
+def test_linux_uninstall_argv_uses_uninstall_flag():
+    argv = provision.linux_uninstall_argv("acme", "widgets", script=LNX_SCRIPT)
+    assert "--uninstall" in argv
+    assert argv[argv.index("--owner") + 1] == "acme"
+
+
+def test_windows_uninstall_runs_counterpart():
+    runner = _Recorder(rc=0)
+    res = run_provision(
+        provision.UNINSTALL, "acme", "widgets",
+        platform=provision.WINDOWS, runner=runner,
+        is_admin=lambda: True, windows_script=WIN_SCRIPT,
+    )
+    assert res.ok
+    (argv,) = runner.calls
+    assert "-UninstallService" in argv and "-InstallService" not in argv
+
+
+def test_uninstall_is_not_blocked_by_existing_service():
+    # Uninstall of an existing service must proceed (that's the point) — no guard.
+    runner = _Recorder(rc=0)
+    fleet = (_entry("forge-runner-acme-widgets", "acme", "widgets"),)
+    res = run_provision(
+        provision.UNINSTALL, "acme", "widgets",
+        platform=provision.WINDOWS, runner=runner, is_admin=lambda: True,
+        entries=fleet, windows_script=WIN_SCRIPT,
+    )
+    assert res.ok and runner.calls  # shelled out despite the existing service
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — the PAT is never handled: no token param, no token/runner.env on argv.
+# --------------------------------------------------------------------------- #
+def test_provision_signature_has_no_pat_parameter():
+    params = set(inspect.signature(run_provision).parameters)
+    assert not any("pat" in p.lower() or "token" in p.lower() or "secret" in p.lower() for p in params)
+
+
+def test_no_argv_carries_a_pat_or_runner_env():
+    runner, wsl, elevate = _Recorder(), _Recorder(), _Recorder()
+    for platform, kw in ((provision.WINDOWS, {"runner": runner, "elevate": elevate}),
+                         (provision.LINUX, {"wsl_runner": wsl})):
+        for action in (provision.INSTALL, provision.UNINSTALL):
+            run_provision(
+                action, "acme", "widgets", platform=platform, force=True,
+                is_admin=lambda: True, windows_script=WIN_SCRIPT,
+                linux_script="/mnt/c/repo/runner/linux/install-service.sh", **kw,
+            )
+    for rec in (runner, wsl, elevate):
+        for argv in rec.calls:
+            joined = " ".join(argv).lower()
+            assert "forge_runner_pat" not in joined
+            assert "runner.env" not in joined
+            assert "-pat" not in joined
+
+
+def test_pat_guidance_points_at_out_of_band_store_without_a_token():
+    text = provision.PAT_GUIDANCE
+    assert "runner.env" in text and "out of band" in text.lower()
+    # Guidance is instructional only — it carries a <token> placeholder, never a real one.
+    assert "<token>" in text
+
+
+# --------------------------------------------------------------------------- #
+# AC4 — clobber / mis-target guard.
+# --------------------------------------------------------------------------- #
+def test_check_guards_flags_existing_service():
+    fleet = (_entry("forge-runner-acme-widgets", "acme", "widgets"),)
+    verdict = check_guards("acme", "widgets", fleet)
+    assert verdict.clashes and not verdict.clean
+    assert "already exists" in verdict.message
+
+
+def test_check_guards_flags_mistarget():
+    online_zero = OnlineStatus(online=0, offline=0, total=0, known=True)
+    fleet = (_entry("forge-runner-acme-widgets", "acme", "widgets", online=online_zero),)
+    verdict = check_guards("acme", "widgets", fleet)
+    assert verdict.clashes and "mis-target" in verdict.message.lower()
+
+
+def test_check_guards_clean_when_no_match():
+    fleet = (_entry("forge-runner-other-repo", "other", "repo"),)
+    assert check_guards("acme", "widgets", fleet).clean
+
+
+def test_install_refuses_clobber_without_force():
+    runner = _Recorder(rc=0)
+    fleet = (_entry("forge-runner-acme-widgets", "acme", "widgets"),)
+    res = run_provision(
+        provision.INSTALL, "acme", "widgets",
+        platform=provision.WINDOWS, runner=runner, is_admin=lambda: True,
+        entries=fleet, force=False, windows_script=WIN_SCRIPT,
+    )
+    assert res.ok is False
+    assert "refused" in res.message.lower()
+    assert runner.calls == []  # never shelled out — no silent clobber
+
+
+def test_install_with_force_overrides_guard_and_passes_force_flag():
+    runner = _Recorder(rc=0)
+    fleet = (_entry("forge-runner-acme-widgets", "acme", "widgets"),)
+    res = run_provision(
+        provision.INSTALL, "acme", "widgets",
+        platform=provision.WINDOWS, runner=runner, is_admin=lambda: True,
+        entries=fleet, force=True, windows_script=WIN_SCRIPT,
+    )
+    assert res.ok
+    (argv,) = runner.calls
+    assert "-Force" in argv  # forwards the override to the script's own guard
+
+
+# --------------------------------------------------------------------------- #
+# Failure surfacing + validation.
+# --------------------------------------------------------------------------- #
+def test_non_admin_install_failure_gives_clear_elevation_message():
+    runner = _Recorder(rc=0)
+    elevate = _Recorder(rc=1223)  # ERROR_CANCELLED — UAC declined
+    res = run_provision(
+        provision.INSTALL, "acme", "widgets",
+        platform=provision.WINDOWS, runner=runner, elevate=elevate,
+        is_admin=lambda: False, windows_script=WIN_SCRIPT,
+    )
+    assert res.ok is False and res.elevated is True
+    assert "administrator" in res.message.lower() and "1223" in res.message
+
+
+def test_unknown_action_raises():
+    with pytest.raises(ValueError):
+        run_provision("pause", "acme", "widgets")
+
+
+def test_missing_owner_or_repo_raises():
+    with pytest.raises(ValueError):
+        run_provision(provision.INSTALL, "", "widgets")
+    with pytest.raises(ValueError):
+        run_provision(provision.INSTALL, "acme", "")

--- a/tools/runner-ui/tests/test_provision_view.py
+++ b/tools/runner-ui/tests/test_provision_view.py
@@ -1,0 +1,230 @@
+"""Tests for the install/uninstall dialog + fleet wiring (ticket #267, AC1-AC4).
+
+Hermetic + headless (offscreen): the provisioner, fleet snapshot, and notifier are
+fakes, so no script, WSL, UAC prompt, or modal dialog runs. Locks:
+
+* AC1 — Install runs the provisioner for the chosen owner/repo OFF the GUI thread.
+* AC2 — Uninstall runs the provisioner with the UNINSTALL action.
+* AC3 — the dialog has NO PAT/token input field; it shows out-of-band guidance, and
+  the provisioner is never handed a token.
+* AC4 — an un-forced install against an existing service is blocked pre-flight
+  (guard fires, notifier warns, provisioner NOT called); Force overrides it.
+"""
+
+from __future__ import annotations
+
+from threading import get_ident
+
+import pytest
+from PySide6.QtWidgets import QLineEdit
+
+from forge_cockpit import provision
+from forge_cockpit.discovery import (
+    NSSM,
+    Fleet,
+    OnlineStatus,
+    RunnerEntry,
+    Target,
+)
+from forge_cockpit.fleet_view import FleetTab
+from forge_cockpit.provision import ProvisionResult
+from forge_cockpit.provision_view import ProvisionDialog
+
+
+@pytest.fixture
+def _app(qapp):
+    return qapp
+
+
+def _entry(name: str, owner: str, repo: str, online=None) -> RunnerEntry:
+    return RunnerEntry(
+        name=name,
+        mechanism=NSSM,
+        service_state="running",
+        target=Target(owner, repo),
+        online=online or OnlineStatus.unknown(),
+    )
+
+
+class RecordingProvisioner:
+    """Fake provisioner: records call + thread, returns a canned ProvisionResult."""
+
+    def __init__(self, ok: bool = True, message: str = "done") -> None:
+        self.calls: list[tuple] = []
+        self.kwargs: list[dict] = []
+        self.thread_idents: list[int] = []
+        self._ok, self._message = ok, message
+
+    def __call__(self, action, owner, repo, **kw) -> ProvisionResult:
+        self.calls.append((action, owner, repo))
+        self.kwargs.append(kw)
+        self.thread_idents.append(get_ident())
+        return ProvisionResult(
+            action=action, platform=kw.get("platform", provision.WINDOWS),
+            name=provision.service_name(owner, repo), owner=owner, repo=repo,
+            ok=self._ok, elevated=False, message=self._message,
+        )
+
+
+class RecordingNotifier:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def __call__(self, level, title, text) -> None:
+        self.calls.append((level, title, text))
+
+
+def _dialog(qtbot, *, provisioner=None, entries=(), notifier=None,
+            owner="acme", repo="widgets") -> ProvisionDialog:
+    dlg = ProvisionDialog(
+        provisioner=provisioner or RecordingProvisioner(),
+        fleet_entries=lambda: entries,
+        notifier=notifier or RecordingNotifier(),
+        default_owner=owner,
+        default_repo=repo,
+        default_platform=provision.WINDOWS,
+    )
+    qtbot.addWidget(dlg)
+    return dlg
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — no PAT field; out-of-band guidance shown; provisioner never gets a token.
+# --------------------------------------------------------------------------- #
+def test_dialog_has_no_pat_or_token_input_field(_app, qtbot):
+    dlg = _dialog(qtbot)
+    edits = dlg.findChildren(QLineEdit)
+    # Exactly the owner + repo fields — no PAT/token/secret entry, and none masked.
+    assert set(edits) == {dlg.owner_edit, dlg.repo_edit}
+    for e in edits:
+        assert e.echoMode() == QLineEdit.EchoMode.Normal  # nothing password-masked
+        name = (e.objectName() + e.placeholderText()).lower()
+        assert "pat" not in name and "token" not in name and "secret" not in name
+
+
+def test_dialog_shows_out_of_band_pat_guidance(_app, qtbot):
+    dlg = _dialog(qtbot)
+    from PySide6.QtWidgets import QPlainTextEdit
+
+    texts = " ".join(w.toPlainText() for w in dlg.findChildren(QPlainTextEdit))
+    assert "runner.env" in texts and "out of band" in texts.lower()
+
+
+def test_provisioner_never_receives_a_pat(_app, qtbot):
+    prov = RecordingProvisioner()
+    dlg = _dialog(qtbot, provisioner=prov)
+    with qtbot.waitSignal(dlg.provision_done, timeout=5000):
+        dlg.install_button.click()
+    for kw in prov.kwargs:
+        assert not any(k.lower() in {"pat", "token", "secret"} for k in kw)
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — Install runs the provisioner off the GUI thread for the chosen target.
+# --------------------------------------------------------------------------- #
+def test_install_runs_provisioner_off_gui_thread(_app, qtbot):
+    prov = RecordingProvisioner(ok=True, message="install ok")
+    dlg = _dialog(qtbot, provisioner=prov)
+    gui = get_ident()
+
+    with qtbot.waitSignal(dlg.provision_done, timeout=5000) as sig:
+        dlg.install_button.click()
+
+    assert prov.calls == [(provision.INSTALL, "acme", "widgets")]
+    assert prov.thread_idents[0] != gui  # ran off the GUI thread (AC1)
+    assert sig.args[0].ok is True
+    assert dlg.status_label.text() == "install ok"
+
+
+def test_install_missing_target_warns_and_does_not_run(_app, qtbot):
+    prov = RecordingProvisioner()
+    notifier = RecordingNotifier()
+    dlg = _dialog(qtbot, provisioner=prov, notifier=notifier, owner="", repo="")
+    dlg.install_button.click()
+    assert prov.calls == []
+    assert notifier.calls and notifier.calls[0][0] == "warning"
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — Uninstall runs the provisioner with the UNINSTALL action.
+# --------------------------------------------------------------------------- #
+def test_uninstall_runs_provisioner_with_uninstall_action(_app, qtbot):
+    prov = RecordingProvisioner(ok=True, message="uninstall ok")
+    dlg = _dialog(qtbot, provisioner=prov)
+    with qtbot.waitSignal(dlg.provision_done, timeout=5000):
+        dlg.uninstall_button.click()
+    assert prov.calls == [(provision.UNINSTALL, "acme", "widgets")]
+
+
+# --------------------------------------------------------------------------- #
+# AC4 — clobber guard blocks an un-forced install; Force overrides it.
+# --------------------------------------------------------------------------- #
+def test_install_blocked_by_guard_when_service_exists(_app, qtbot):
+    prov = RecordingProvisioner()
+    notifier = RecordingNotifier()
+    existing = (_entry("forge-runner-acme-widgets", "acme", "widgets"),)
+    dlg = _dialog(qtbot, provisioner=prov, entries=existing, notifier=notifier)
+
+    with qtbot.waitSignal(dlg.guard_blocked, timeout=5000):
+        dlg.install_button.click()
+
+    assert prov.calls == []  # refused pre-flight — no silent clobber (AC4)
+    assert notifier.calls and notifier.calls[0][0] == "warning"
+    assert "already exists" in notifier.calls[0][2]
+
+
+def test_force_checkbox_overrides_guard(_app, qtbot):
+    prov = RecordingProvisioner(ok=True)
+    existing = (_entry("forge-runner-acme-widgets", "acme", "widgets"),)
+    dlg = _dialog(qtbot, provisioner=prov, entries=existing)
+    dlg.force_checkbox.setChecked(True)
+
+    with qtbot.waitSignal(dlg.provision_done, timeout=5000):
+        dlg.install_button.click()
+
+    assert prov.calls == [(provision.INSTALL, "acme", "widgets")]
+    assert prov.kwargs[0]["force"] is True
+
+
+def test_failed_provision_surfaces_via_notifier(_app, qtbot):
+    prov = RecordingProvisioner(ok=False, message="needs administrator rights")
+    notifier = RecordingNotifier()
+    dlg = _dialog(qtbot, provisioner=prov, notifier=notifier)
+    with qtbot.waitSignal(dlg.provision_done, timeout=5000):
+        dlg.install_button.click()
+    assert notifier.calls and notifier.calls[0][0] == "warning"
+    assert "administrator" in notifier.calls[0][2]
+
+
+# --------------------------------------------------------------------------- #
+# Fleet wiring — the button opens a prefilled, guard-wired dialog (#267).
+# --------------------------------------------------------------------------- #
+NSSM_ENTRY = _entry("forge-runner-acme-widgets", "acme", "widgets")
+FLEET = Fleet(runners=(NSSM_ENTRY,))
+
+
+def test_fleet_button_opens_prefilled_dialog(_app, qtbot):
+    prov = RecordingProvisioner()
+    # Inject a recording notifier so the guard-blocked path never opens a real
+    # (blocking) QMessageBox in the offscreen suite.
+    tab = FleetTab(
+        lambda: FLEET, initial_refresh=False, provisioner=prov, notifier=RecordingNotifier()
+    )
+    qtbot.addWidget(tab)
+    with qtbot.waitSignal(tab.fleet_loaded, timeout=5000):
+        tab.refresh()
+    tab.table.selectRow(0)
+
+    with qtbot.waitSignal(tab.provision_dialog_opened, timeout=5000) as sig:
+        tab.provision_button.click()
+
+    dlg = sig.args[0]
+    qtbot.addWidget(dlg)
+    assert isinstance(dlg, ProvisionDialog)
+    # Prefilled from the selected runner's target (AC1 target selection).
+    assert dlg.owner_edit.text() == "acme"
+    assert dlg.repo_edit.text() == "widgets"
+    # And it carries the live fleet for its guard: an un-forced install is blocked.
+    with qtbot.waitSignal(dlg.guard_blocked, timeout=5000):
+        dlg.install_button.click()
+    assert prov.calls == []


### PR DESCRIPTION
Closes #267

Wrap the existing runner setup scripts so a runner service can be installed / uninstalled from the cockpit UI, without the UI ever touching the PAT.

## What
- `forge_cockpit/provision.py` — shells out to the **existing** scripts (reimplements nothing):
  - Windows: `setup-runner.ps1 -InstallService` / `-UninstallService` with `-Owner`/`-Repo`, run directly when already admin else through the **same** per-action UAC elevation seam as #266 control (`control.elevate_run`, ADR-0006 Decision 4).
  - Linux: `install-service.sh --owner/--repo` / `--uninstall`, over `wsl.exe --` interop.
  - The service name is the #260 repo-scoped `forge-runner-<owner>-<repo>` (`service_name()`), the same slug the scripts derive.
- `forge_cockpit/provision_view.ProvisionDialog` — pick owner/repo + platform, Install / Uninstall off the GUI thread, read-only PAT guidance, Force override. Wired into the fleet tab via an **"Install / uninstall…"** button, prefilled from the selected runner.

## Acceptance criteria
- **AC1** — install invokes the existing `setup-runner.ps1 -InstallService` / `install-service.sh` with the chosen repo + the #260 repo-scoped service name. Never reimplemented.
- **AC2** — uninstall invokes the `-UninstallService` / `--uninstall` counterpart.
- **AC3** — PAT stays out of band: **no token parameter, no token field, no token on argv**; the UI shows guidance pointing at the `~/.forge/runner.env` / service-env store and never displays/logs/persists/commits a token. `shellout`'s `runner.env` backstop still applies.
- **AC4** — refuses/warns on the #260 clobber + mis-target conditions via `check_guards` against the #264 fleet, consistent with the CLI `-Force` / `--force` guards.

## Verification (honest)
- `cd tools/runner-ui; $env:QT_QPA_PLATFORM='offscreen'; pytest` → **127 passed** (32 new, hermetic: shell-out + elevation mocked). New tests assert the correct script+args with the repo-scoped name (AC1), the uninstall counterpart (AC2), that no PAT is passed/echoed/logged and no token field exists (AC3), and that the clobber/mis-target guard fires and refuses without Force (AC4).
- New tests run on the `cockpit-python` self-hosted job automatically; `verify.yml` untouched.
- Not driven as a live GUI end-to-end (no headless desktop / real UAC / real service); the flows are exercised via the injected seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
