### PR TITLE
feat(cockpit): Claude usage/cost/token data core (#273)

### DIFF
--- a/tools/runner-ui/forge_cockpit/usage.py
+++ b/tools/runner-ui/forge_cockpit/usage.py
@@ -1,0 +1,414 @@
+"""Claude usage / cost / token data core (ticket #273) — the data layer #274 charts.
+
+Claude Code writes one JSONL *transcript* per session under
+``~/.claude/projects/**/*.jsonl`` (ADR-0006). Every assistant turn is a line
+whose ``message.usage`` records the four token classes Anthropic bills
+separately — ``input_tokens``, ``output_tokens``, ``cache_read_input_tokens``,
+``cache_creation_input_tokens`` — alongside ``message.model`` and a top-level
+ISO-8601 ``timestamp`` (and ``sessionId``). This module *discovers* those
+transcripts, *streams* them line-by-line into a normalized, typed usage model,
+*prices* each turn against a pinned per-model rate table, and *aggregates* by
+session / day / model.
+
+Privacy invariants (non-negotiable — AC4):
+
+* **Read-only.** Files are opened for reading only; nothing here writes, moves,
+  or truncates a transcript.
+* **Usage metadata only — never CONTENT.** The parser reads ``message.usage``,
+  ``message.model``, the record ``timestamp`` and ``sessionId``, and nothing
+  else. It never touches ``message.content`` / prompts / responses, and
+  :class:`UsageRecord` has no field in which message text could be stored. No
+  prompt or response text ever leaves this module.
+
+Tolerance invariant (AC1): a transcript is an append-only log that may contain
+malformed, partial, or half-written (streaming) lines. Every such line is
+*skipped*, never fatal — a single bad line never aborts a scan.
+
+Pricing invariant (AC2): :data:`PRICING` is a **pinned** table of Anthropic
+list prices (USD per million tokens; see :data:`PRICING_UNIT`). A model absent
+from the table is surfaced as **unpriced** — its tokens are still counted, its
+cost is never guessed or silently defaulted. Keep the table updated as Anthropic
+publishes new models / prices.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Pricing — a PINNED, updatable model -> rate table (AC2).
+# --------------------------------------------------------------------------- #
+
+#: Unit for every number in :data:`PRICING`: US dollars per **one million**
+#: tokens of that class. cost = tokens / 1_000_000 * rate.
+PRICING_UNIT = "USD per 1M tokens"
+
+# Cache tokens are priced relative to a model's base *input* rate (Anthropic
+# prompt-caching pricing): reads bill at ~0.1x input; 5-minute-TTL writes — the
+# default Claude Code uses — bill at ~1.25x input. Kept as named constants so
+# the table below stays a single source of truth and is trivial to re-derive.
+_CACHE_READ_MULT = 0.10
+_CACHE_WRITE_MULT = 1.25
+
+
+@dataclass(frozen=True)
+class ModelRate:
+    """Per-model prices for each billed token class (USD per 1M tokens)."""
+
+    input: float
+    output: float
+    cache_read: float
+    cache_creation: float
+
+
+def _rate(input_: float, output: float) -> ModelRate:
+    """Build a :class:`ModelRate` from the two published headline prices,
+    deriving the cache-read / cache-creation prices via the standard multipliers.
+    """
+
+    return ModelRate(
+        input=input_,
+        output=output,
+        cache_read=round(input_ * _CACHE_READ_MULT, 6),
+        cache_creation=round(input_ * _CACHE_WRITE_MULT, 6),
+    )
+
+
+#: Pinned Anthropic list prices. Update when models / prices change. Keys are the
+#: canonical model ids; date-suffixed aliases (e.g.
+#: ``claude-haiku-4-5-20251001``) resolve to their base id via
+#: :func:`resolve_rate`.
+PRICING: dict[str, ModelRate] = {
+    # Opus tier — $5 / $25
+    "claude-opus-4-8": _rate(5.0, 25.0),
+    "claude-opus-4-7": _rate(5.0, 25.0),
+    "claude-opus-4-6": _rate(5.0, 25.0),
+    "claude-opus-4-5": _rate(5.0, 25.0),
+    # Fable / Mythos tier — $10 / $50
+    "claude-fable-5": _rate(10.0, 50.0),
+    "claude-mythos-5": _rate(10.0, 50.0),
+    # Sonnet tier — $3 / $15
+    "claude-sonnet-5": _rate(3.0, 15.0),
+    "claude-sonnet-4-6": _rate(3.0, 15.0),
+    "claude-sonnet-4-5": _rate(3.0, 15.0),
+    # Haiku tier — $1 / $5
+    "claude-haiku-4-5": _rate(1.0, 5.0),
+}
+
+
+def _strip_date_suffix(model: str) -> str | None:
+    """Return ``model`` with a trailing ``-YYYYMMDD`` snapshot suffix removed,
+    or ``None`` when there is no such suffix. ``claude-haiku-4-5-20251001`` ->
+    ``claude-haiku-4-5``.
+    """
+
+    head, _, tail = model.rpartition("-")
+    if head and len(tail) == 8 and tail.isdigit():
+        return head
+    return None
+
+
+def resolve_rate(model: str | None) -> ModelRate | None:
+    """Look up the rate for ``model``: exact match first, then the base id with a
+    ``-YYYYMMDD`` snapshot suffix stripped. Returns ``None`` (→ *unpriced*) for an
+    unknown model — never a guessed default.
+    """
+
+    if not model:
+        return None
+    rate = PRICING.get(model)
+    if rate is not None:
+        return rate
+    base = _strip_date_suffix(model)
+    if base is not None:
+        return PRICING.get(base)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Normalized usage model (dataclasses) — usage metadata ONLY (AC4).
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class UsageRecord:
+    """One assistant turn's usage — the atom of the usage model.
+
+    Deliberately carries **no** message content: only the four token classes,
+    the model id, the session id, and the turn timestamp. There is nowhere here
+    to store prompt/response text (AC4).
+    """
+
+    session_id: str
+    model: str
+    timestamp: datetime | None
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+
+    @property
+    def total_tokens(self) -> int:
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_creation_tokens
+        )
+
+
+@dataclass(frozen=True)
+class Cost:
+    """Cost of a turn (or aggregate), broken out per token class (USD).
+
+    ``unpriced`` is ``True`` when the model was not in :data:`PRICING`: the
+    tokens are still counted upstream, but no cost was computed for them (AC2).
+    """
+
+    input: float = 0.0
+    output: float = 0.0
+    cache_read: float = 0.0
+    cache_creation: float = 0.0
+    unpriced: bool = False
+
+    @property
+    def total(self) -> float:
+        return self.input + self.output + self.cache_read + self.cache_creation
+
+
+def compute_cost(record: UsageRecord) -> Cost:
+    """Price one :class:`UsageRecord`. Unknown model → flagged ``unpriced`` with
+    zero cost (tokens counted elsewhere, never guessed)."""
+
+    rate = resolve_rate(record.model)
+    if rate is None:
+        return Cost(unpriced=True)
+    return Cost(
+        input=record.input_tokens / 1_000_000 * rate.input,
+        output=record.output_tokens / 1_000_000 * rate.output,
+        cache_read=record.cache_read_tokens / 1_000_000 * rate.cache_read,
+        cache_creation=record.cache_creation_tokens / 1_000_000 * rate.cache_creation,
+        unpriced=False,
+    )
+
+
+@dataclass
+class UsageAggregate:
+    """Token + cost totals for one bucket (a session, day, or model)."""
+
+    key: str
+    turns: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cost_input: float = 0.0
+    cost_output: float = 0.0
+    cost_cache_read: float = 0.0
+    cost_cache_creation: float = 0.0
+    #: Number of turns in this bucket whose model was not in :data:`PRICING`.
+    unpriced_turns: int = 0
+    #: The distinct unknown model ids that contributed unpriced turns.
+    unpriced_models: set[str] = field(default_factory=set)
+
+    def add(self, record: UsageRecord, cost: Cost) -> None:
+        self.turns += 1
+        self.input_tokens += record.input_tokens
+        self.output_tokens += record.output_tokens
+        self.cache_read_tokens += record.cache_read_tokens
+        self.cache_creation_tokens += record.cache_creation_tokens
+        self.cost_input += cost.input
+        self.cost_output += cost.output
+        self.cost_cache_read += cost.cache_read
+        self.cost_cache_creation += cost.cache_creation
+        if cost.unpriced:
+            self.unpriced_turns += 1
+            self.unpriced_models.add(record.model)
+
+    @property
+    def total_tokens(self) -> int:
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_creation_tokens
+        )
+
+    @property
+    def total_cost(self) -> float:
+        return (
+            self.cost_input
+            + self.cost_output
+            + self.cost_cache_read
+            + self.cost_cache_creation
+        )
+
+    @property
+    def has_unpriced(self) -> bool:
+        return self.unpriced_turns > 0
+
+
+# --------------------------------------------------------------------------- #
+# Discovery + tolerant streaming parser (AC1).
+# --------------------------------------------------------------------------- #
+
+
+def default_projects_root() -> Path:
+    """The standard Claude Code transcript root: ``~/.claude/projects``."""
+
+    return Path.home() / ".claude" / "projects"
+
+
+def iter_transcript_paths(root: Path | str | None = None) -> Iterator[Path]:
+    """Yield every ``*.jsonl`` transcript under ``root`` (default
+    :func:`default_projects_root`), recursively. A missing root yields nothing —
+    never raises."""
+
+    base = Path(root) if root is not None else default_projects_root()
+    if not base.exists():
+        return
+    yield from sorted(base.glob("**/*.jsonl"))
+
+
+def _parse_timestamp(raw: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp tolerantly; ``None`` on anything unusable."""
+
+    if not isinstance(raw, str) or not raw:
+        return None
+    text = raw.strip()
+    # Python's fromisoformat handles the trailing 'Z' only on 3.11+; normalize.
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _record_from_obj(obj: object) -> UsageRecord | None:
+    """Build a :class:`UsageRecord` from one decoded JSONL object, or ``None`` if
+    the line is not a priced-able assistant turn. Reads usage metadata ONLY —
+    ``message.content`` is never inspected (AC4)."""
+
+    if not isinstance(obj, dict):
+        return None
+    if obj.get("type") != "assistant":
+        return None
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    def _as_int(value: object) -> int:
+        return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+    model = message.get("model")
+    if not isinstance(model, str) or not model:
+        model = "unknown"
+
+    session_id = obj.get("sessionId")
+    if not isinstance(session_id, str) or not session_id:
+        session_id = "unknown"
+
+    return UsageRecord(
+        session_id=session_id,
+        model=model,
+        timestamp=_parse_timestamp(obj.get("timestamp")),
+        input_tokens=_as_int(usage.get("input_tokens")),
+        output_tokens=_as_int(usage.get("output_tokens")),
+        cache_read_tokens=_as_int(usage.get("cache_read_input_tokens")),
+        cache_creation_tokens=_as_int(usage.get("cache_creation_input_tokens")),
+    )
+
+
+def parse_transcript(path: Path | str) -> Iterator[UsageRecord]:
+    """Stream one transcript file, yielding a :class:`UsageRecord` per assistant
+    turn. Malformed / partial / non-assistant lines are skipped (AC1). Opened
+    read-only (AC4). An unreadable file yields nothing rather than raising."""
+
+    try:
+        handle = open(path, encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    with handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except (ValueError, TypeError):
+                # Malformed or half-written (streaming) line — skip, don't crash.
+                continue
+            record = _record_from_obj(obj)
+            if record is not None:
+                yield record
+
+
+def collect_usage(root: Path | str | None = None) -> list[UsageRecord]:
+    """Discover and parse every transcript under ``root``, returning all
+    per-turn usage records. Read-only end to end (AC4)."""
+
+    records: list[UsageRecord] = []
+    for path in iter_transcript_paths(root):
+        records.extend(parse_transcript(path))
+    return records
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation by session / day / model (AC3).
+# --------------------------------------------------------------------------- #
+
+
+def _aggregate(
+    records: Iterable[UsageRecord], key_of: Callable[[UsageRecord], str]
+) -> dict[str, UsageAggregate]:
+    buckets: dict[str, UsageAggregate] = {}
+    for record in records:
+        key = key_of(record)
+        bucket = buckets.get(key)
+        if bucket is None:
+            bucket = buckets[key] = UsageAggregate(key=key)
+        bucket.add(record, compute_cost(record))
+    return buckets
+
+
+#: Bucket key used for records whose turn has no parseable timestamp.
+UNKNOWN_DAY = "unknown"
+
+
+def _day_key(record: UsageRecord) -> str:
+    ts = record.timestamp
+    if ts is None:
+        return UNKNOWN_DAY
+    # Normalize to UTC calendar date so a day bucket is stable across offsets.
+    if ts.tzinfo is not None:
+        ts = ts.astimezone(timezone.utc)
+    day: date = ts.date()
+    return day.isoformat()
+
+
+def aggregate_by_session(records: Iterable[UsageRecord]) -> dict[str, UsageAggregate]:
+    """Totals keyed by ``session_id`` (AC3)."""
+
+    return _aggregate(records, lambda r: r.session_id)
+
+
+def aggregate_by_day(records: Iterable[UsageRecord]) -> dict[str, UsageAggregate]:
+    """Totals keyed by UTC calendar day (``YYYY-MM-DD``; :data:`UNKNOWN_DAY` for
+    turns without a timestamp) (AC3)."""
+
+    return _aggregate(records, _day_key)
+
+
+def aggregate_by_model(records: Iterable[UsageRecord]) -> dict[str, UsageAggregate]:
+    """Totals keyed by model id (AC3). Unknown models still bucket and count —
+    they carry ``unpriced_turns`` > 0."""
+
+    return _aggregate(records, lambda r: r.model)

--- a/tools/runner-ui/tests/fixtures/nested/proj/transcript_more.jsonl
+++ b/tools/runner-ui/tests/fixtures/nested/proj/transcript_more.jsonl
@@ -1,0 +1,2 @@
+{"type":"assistant","sessionId":"sess-C","timestamp":"2026-07-22T00:00:00.000Z","message":{"role":"assistant","model":"claude-fable-5","usage":{"input_tokens":2,"output_tokens":9,"cache_read_input_tokens":100,"cache_creation_input_tokens":50}}}
+{"type":"assistant","sessionId":"sess-C","message":{"role":"assistant","model":"claude-opus-4-8","usage":{"input_tokens":7,"output_tokens":7,"cache_read_input_tokens":7,"cache_creation_input_tokens":7}}}

--- a/tools/runner-ui/tests/fixtures/transcript_good.jsonl
+++ b/tools/runner-ui/tests/fixtures/transcript_good.jsonl
@@ -1,0 +1,9 @@
+{"type":"system","subtype":"init","sessionId":"sess-A","timestamp":"2026-07-20T09:00:00.000Z"}
+{"type":"user","sessionId":"sess-A","timestamp":"2026-07-20T09:00:01.000Z","message":{"role":"user","content":"SECRET-PROMPT-TEXT-should-never-surface"}}
+{"type":"assistant","sessionId":"sess-A","timestamp":"2026-07-20T09:00:02.500Z","message":{"role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"SECRET-RESPONSE-TEXT-should-never-surface"}],"usage":{"input_tokens":100,"output_tokens":40,"cache_read_input_tokens":2000,"cache_creation_input_tokens":500}}}
+{"type":"assistant","sessionId":"sess-A","timestamp":"2026-07-20T14:30:00.000Z","message":{"role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"more secret text"}],"usage":{"input_tokens":10,"output_tokens":200,"cache_read_input_tokens":21060,"cache_creation_input_tokens":9672}}}
+{"type":"assistant","sessionId":"sess-A","timestamp":"2026-07-21T08:15:00.000Z","message":{"role":"assistant","model":"claude-haiku-4-5-20251001","usage":{"input_tokens":50,"output_tokens":60}}}
+this is not json at all — a corrupt line
+{"type":"assistant","sessionId":"sess-B","timestamp":"2026-07-21T10:00:00.000Z","message":{"role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"x"}],"usage":{"input_tokens":1000,"output_tokens":500,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}
+{"type":"assistant","sessionId":"sess-B","timestamp":"2026-07-21T10:05:00.000Z","message":{"role":"assistant","model":"claude-experimental-99","usage":{"input_tokens":300,"output_tokens":80,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}}
+{"type":"assistant","sessionId":"sess-B","timestamp":"2026-07-21T10:06:00.000Z","message":{"role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"partial streaming line below is truncated on purpose"}],"usage":{"inp

--- a/tools/runner-ui/tests/test_usage.py
+++ b/tools/runner-ui/tests/test_usage.py
@@ -1,0 +1,288 @@
+"""Unit tests for the Claude usage / cost / token data core (ticket #273).
+
+Hermetic by construction: every test reads only the SYNTHETIC fixtures under
+``tests/fixtures/`` — no real ``~/.claude`` transcript is ever opened, and the
+fixtures contain no real prompt/response content. The suite locks in the ACs:
+
+* AC1 — per-turn extraction of all four token classes + model + timestamp, and
+  tolerance of malformed / partial / non-assistant lines.
+* AC2 — per-class cost math against the pinned rate table, and unknown models
+  flagged *unpriced* (tokens counted, cost never guessed).
+* AC3 — aggregation by session / day / model into the normalized dataclasses.
+* AC4 — no message content is ever surfaced or stored.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from forge_cockpit import usage
+from forge_cockpit.usage import (
+    PRICING,
+    UNKNOWN_DAY,
+    Cost,
+    ModelRate,
+    UsageAggregate,
+    UsageRecord,
+    aggregate_by_day,
+    aggregate_by_model,
+    aggregate_by_session,
+    collect_usage,
+    compute_cost,
+    iter_transcript_paths,
+    parse_transcript,
+    resolve_rate,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+GOOD = FIXTURES / "transcript_good.jsonl"
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — extraction + tolerance
+# --------------------------------------------------------------------------- #
+
+
+def test_extracts_all_four_token_classes():
+    records = list(parse_transcript(GOOD))
+    first = records[0]
+    assert first.session_id == "sess-A"
+    assert first.model == "claude-opus-4-8"
+    assert first.input_tokens == 100
+    assert first.output_tokens == 40
+    assert first.cache_read_tokens == 2000
+    assert first.cache_creation_tokens == 500
+    assert first.total_tokens == 2640
+
+
+def test_extracts_model_and_timestamp():
+    first = next(iter(parse_transcript(GOOD)))
+    assert isinstance(first.timestamp, datetime)
+    assert first.timestamp == datetime(
+        2026, 7, 20, 9, 0, 2, 500000, tzinfo=timezone.utc
+    )
+
+
+def test_skips_malformed_partial_and_nonassistant_lines():
+    records = list(parse_transcript(GOOD))
+    # The fixture has a corrupt line, a truncated streaming line, plus system /
+    # user lines — none of which may become records. Only the 5 well-formed
+    # assistant turns survive.
+    assert len(records) == 5
+    assert all(isinstance(r, UsageRecord) for r in records)
+
+
+def test_missing_token_fields_default_to_zero():
+    # The haiku turn records only input/output; cache fields are absent.
+    haiku = next(
+        r for r in parse_transcript(GOOD) if r.model.startswith("claude-haiku")
+    )
+    assert haiku.input_tokens == 50
+    assert haiku.output_tokens == 60
+    assert haiku.cache_read_tokens == 0
+    assert haiku.cache_creation_tokens == 0
+
+
+def test_unreadable_file_yields_nothing():
+    assert list(parse_transcript(FIXTURES / "does-not-exist.jsonl")) == []
+
+
+def test_bad_token_types_are_tolerated(tmp_path: Path):
+    # A line whose token values are strings/bools/nulls must not crash — those
+    # coerce to 0 rather than raising.
+    bad = tmp_path / "t.jsonl"
+    bad.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "sessionId": "s",
+                "timestamp": "not-a-timestamp",
+                "message": {
+                    "model": "claude-opus-4-8",
+                    "usage": {
+                        "input_tokens": "oops",
+                        "output_tokens": None,
+                        "cache_read_input_tokens": True,
+                        "cache_creation_input_tokens": 5,
+                    },
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (record,) = list(parse_transcript(bad))
+    assert record.input_tokens == 0
+    assert record.output_tokens == 0
+    assert record.cache_read_tokens == 0  # bool is not counted as int
+    assert record.cache_creation_tokens == 5
+    assert record.timestamp is None  # unparseable timestamp -> None, not fatal
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — pricing (per class) + unpriced flagging
+# --------------------------------------------------------------------------- #
+
+
+def test_cost_priced_per_class():
+    rec = UsageRecord(
+        session_id="s",
+        model="claude-opus-4-8",
+        timestamp=None,
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=1_000_000,
+        cache_creation_tokens=1_000_000,
+    )
+    cost = compute_cost(rec)
+    assert not cost.unpriced
+    # Opus: input $5, output $25, cache-read 0.1x = $0.50, cache-write 1.25x = $6.25
+    assert cost.input == pytest.approx(5.0)
+    assert cost.output == pytest.approx(25.0)
+    assert cost.cache_read == pytest.approx(0.5)
+    assert cost.cache_creation == pytest.approx(6.25)
+    assert cost.total == pytest.approx(36.75)
+
+
+def test_each_class_uses_its_own_rate():
+    # Only output tokens -> only the output rate contributes.
+    rec = UsageRecord("s", "claude-sonnet-5", None, 0, 2_000_000, 0, 0)
+    cost = compute_cost(rec)
+    assert cost.input == 0.0
+    assert cost.output == pytest.approx(30.0)  # 2M * $15/M
+    assert cost.cache_read == 0.0
+    assert cost.cache_creation == 0.0
+
+
+def test_unknown_model_flagged_not_guessed():
+    rec = UsageRecord("s", "claude-experimental-99", None, 300, 80, 10, 5)
+    cost = compute_cost(rec)
+    assert cost.unpriced is True
+    # Cost is never guessed for an unknown model.
+    assert cost.total == 0.0
+    # ...but the tokens are still real and counted on the record itself.
+    assert rec.total_tokens == 395
+
+
+def test_date_suffixed_model_resolves_to_base_rate():
+    assert resolve_rate("claude-haiku-4-5-20251001") is PRICING["claude-haiku-4-5"]
+
+
+def test_resolve_rate_unknown_and_empty():
+    assert resolve_rate("totally-made-up") is None
+    assert resolve_rate("") is None
+    assert resolve_rate(None) is None
+
+
+def test_pricing_table_covers_current_models():
+    for model in (
+        "claude-opus-4-8",
+        "claude-fable-5",
+        "claude-sonnet-5",
+        "claude-haiku-4-5",
+    ):
+        rate = resolve_rate(model)
+        assert isinstance(rate, ModelRate)
+        assert rate.input > 0 and rate.output > 0
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — aggregation by session / day / model
+# --------------------------------------------------------------------------- #
+
+
+def test_aggregate_by_session():
+    records = collect_usage(FIXTURES)
+    by_session = aggregate_by_session(records)
+    assert set(by_session) == {"sess-A", "sess-B", "sess-C"}
+    a = by_session["sess-A"]
+    assert isinstance(a, UsageAggregate)
+    assert a.turns == 3  # two opus turns + one haiku turn
+    assert a.input_tokens == 100 + 10 + 50
+    assert a.output_tokens == 40 + 200 + 60
+    assert not a.has_unpriced
+
+
+def test_aggregate_by_day_buckets_by_utc_date():
+    records = collect_usage(FIXTURES)
+    by_day = aggregate_by_day(records)
+    # sess-A has turns on the 20th (x2) and 21st; sess-B both on the 21st;
+    # sess-C one on the 22nd and one with no timestamp -> UNKNOWN_DAY.
+    assert "2026-07-20" in by_day
+    assert "2026-07-21" in by_day
+    assert "2026-07-22" in by_day
+    assert UNKNOWN_DAY in by_day
+    assert by_day["2026-07-20"].turns == 2
+
+
+def test_aggregate_by_model_flags_unpriced_bucket():
+    records = collect_usage(FIXTURES)
+    by_model = aggregate_by_model(records)
+    assert "claude-experimental-99" in by_model
+    unknown = by_model["claude-experimental-99"]
+    assert unknown.has_unpriced
+    assert unknown.unpriced_turns == 1
+    assert unknown.unpriced_models == {"claude-experimental-99"}
+    assert unknown.total_tokens == 395  # tokens counted despite being unpriced
+    assert unknown.total_cost == 0.0
+    # A priced model bucket carries real cost and no unpriced flag.
+    opus = by_model["claude-opus-4-8"]
+    assert not opus.has_unpriced
+    assert opus.total_cost > 0.0
+
+
+def test_aggregate_cost_sums_match_per_record():
+    records = collect_usage(FIXTURES)
+    by_model = aggregate_by_model(records)
+    expected = 0.0
+    for rec in records:
+        expected += compute_cost(rec).total
+    got = sum(agg.total_cost for agg in by_model.values())
+    assert got == pytest.approx(expected)
+
+
+def test_recursive_discovery_finds_nested_transcripts():
+    paths = list(iter_transcript_paths(FIXTURES))
+    names = {p.name for p in paths}
+    assert "transcript_good.jsonl" in names
+    assert "transcript_more.jsonl" in names  # lives in fixtures/nested/proj/
+
+
+def test_missing_root_yields_no_paths(tmp_path: Path):
+    assert list(iter_transcript_paths(tmp_path / "nope")) == []
+
+
+# --------------------------------------------------------------------------- #
+# AC4 — no message content ever surfaced or stored
+# --------------------------------------------------------------------------- #
+
+
+def test_record_has_no_content_field():
+    fields = set(UsageRecord.__dataclass_fields__)
+    assert "content" not in fields
+    # The full field set is exactly the usage-metadata columns — nothing else.
+    assert fields == {
+        "session_id",
+        "model",
+        "timestamp",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+    }
+
+
+def test_no_prompt_or_response_text_surfaces_anywhere():
+    # The good fixture embeds sentinel SECRET-*-TEXT strings in message content.
+    # None of them may appear in any parsed record's repr.
+    records = list(parse_transcript(GOOD))
+    blob = " ".join(repr(r) for r in records)
+    assert "SECRET" not in blob
+    # And nothing in the record objects equals the content sentinels.
+    for rec in records:
+        for value in vars(rec).values():
+            assert "SECRET" not in str(value)


### PR DESCRIPTION
Closes #273

Wave-2 opener for the PySide6 cockpit (epic #262, ADR-0006): the Claude usage/cost/token **data layer**. No UI — #274 adds the QtCharts panel over this.

## What
`forge_cockpit/usage.py` — transcript discovery + a tolerant streaming parser, a pinned model→rate table, a per-class cost computer, and session/day/model aggregations into typed dataclasses.

## Acceptance criteria
- **AC1 — parse + all token classes + tolerance.** Globs `~/.claude/projects/**/*.jsonl`, streams line-by-line, extracts per-assistant-turn `input` / `output` / `cache_read` / `cache_creation` tokens + `message.model` + record `timestamp`. Malformed / partial / streaming-truncated / non-assistant lines are skipped, never fatal. Grounded against a real transcript's shape (`message.usage.{input_tokens,output_tokens,cache_read_input_tokens,cache_creation_input_tokens}`, `message.model`, top-level `timestamp`/`sessionId`).
- **AC2 — pinned pricing, per class, unknown flagged.** `PRICING` is a pinned table in **USD per 1M tokens** (Opus $5/$25, Fable/Mythos $10/$50, Sonnet $3/$15, Haiku $1/$5). Each token class priced separately (cache-read = 0.1× input, cache-write = 1.25× input, the Anthropic prompt-caching multipliers). Date-suffixed ids (`claude-haiku-4-5-20251001`) resolve to their base rate. **Unknown models are flagged `unpriced` — tokens still counted, cost never guessed/defaulted.**
- **AC3 — aggregation.** `aggregate_by_session` / `aggregate_by_day` (UTC calendar day) / `aggregate_by_model` return normalized `UsageAggregate` dataclasses with per-class token + cost sums and an unpriced roll-up.
- **AC4 — read-only, no content.** Files opened read-only. `UsageRecord` has **no content field**; the parser reads only `usage` / `model` / `timestamp` / `sessionId` and never touches `message.content`. A test asserts sentinel prompt/response strings from the fixture never surface.

## Verification (honest)
- New `tests/test_usage.py` (20 tests) over **synthetic** fixtures under `tests/fixtures/` — no real transcript is read in tests, no real content copied into the repo.
- Full suite green locally: **150 passed** (`QT_QPA_PLATFORM=offscreen pytest`).
- Read-only smoke over the real `~/.claude` transcripts (metadata only, no content printed): parsed 40,401 turns across 23 sessions / 10 days; known models priced, a `<synthetic>` model correctly surfaced as `[UNPRICED]` with tokens counted and $0 cost.

## Notes
- **Pricing is a pinned table** — keep it updated as Anthropic publishes new models/prices. Cache rates are derived from each model's input rate via named multipliers so the table stays a single source of truth.
- **Stdlib only** (`json`/`glob`/`pathlib`) — no new deps, no `uv.lock` change. `verify.yml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SATRHKa6mDHDuirhP6QuwL