### PR TITLE
feat(cockpit): usage/cost/token QtCharts panel (#274)

### DIFF
--- a/tools/runner-ui/forge_cockpit/app.py
+++ b/tools/runner-ui/forge_cockpit/app.py
@@ -1,12 +1,14 @@
 """The cockpit main window — a QMainWindow shell with a tabbed layout.
 
 The shell wires three tabs (ADR-0006 Decision 2 charter): "Runner fleet",
-"Usage / cost", "Terminal". "Runner fleet" is now the live fleet overview
-(:class:`~forge_cockpit.fleet_view.FleetTab`, ticket #265) over the #264
-discovery core; the remaining two are still TODO placeholders whose real panels
-arrive in Waves 2/3. Keeping the shell separate from the panels lets the smoke
-test construct the window headless (QT_QPA_PLATFORM=offscreen) and assert the tab
-wiring without a desktop session.
+"Usage / cost", "Terminal". "Runner fleet" is the live fleet overview
+(:class:`~forge_cockpit.fleet_view.FleetTab`, ticket #265) over the #264 discovery
+core; "Usage / cost" is the live usage/cost dashboard
+(:class:`~forge_cockpit.usage_view.UsageTab`, ticket #274) over the #273 usage
+core; "Terminal" is still a TODO placeholder whose real panel arrives in Wave 3.
+Keeping the shell separate from the panels lets the smoke test construct the
+window headless (QT_QPA_PLATFORM=offscreen) and assert the tab wiring without a
+desktop session.
 """
 
 from __future__ import annotations
@@ -22,12 +24,13 @@ from PySide6.QtWidgets import (
 
 from forge_cockpit import discovery
 from forge_cockpit.fleet_view import Discover, FleetTab
+from forge_cockpit.usage_view import USAGE_REFRESH_MS, LoadUsage, UsageTab, default_load_usage
 
 #: Fleet auto-refresh interval in the running app (AC3). Off in tests.
 FLEET_REFRESH_MS = 15_000
 
-#: Placeholder tab title -> the TODO note shown on its body, in display order.
-#: The "Runner fleet" tab is the live :class:`FleetTab`, wired separately.
+#: Placeholder tab title -> the TODO note shown on its body, in display order. The
+#: "Runner fleet" and "Usage / cost" tabs are live panels, wired separately.
 COCKPIT_TABS: tuple[tuple[str, str], ...] = (
     ("Runner fleet", "TODO: runner fleet control (service/container state, start/stop)."),
     ("Usage / cost", "TODO: Claude usage / cost / token monitor (from local transcripts)."),
@@ -48,15 +51,18 @@ def _placeholder(todo: str) -> QWidget:
     return page
 
 
-#: Title of the live fleet-overview tab (the rest stay placeholders).
+#: Title of the live fleet-overview tab.
 FLEET_TAB_TITLE = "Runner fleet"
+#: Title of the live usage/cost dashboard tab (#274).
+USAGE_TAB_TITLE = "Usage / cost"
 
 
 class CockpitWindow(QMainWindow):
     """The cockpit shell: a main window whose central widget is a tab bar.
 
-    The "Runner fleet" tab is the live :class:`FleetTab` (#265); the others remain
-    TODO placeholders until their waves land.
+    The "Runner fleet" tab is the live :class:`FleetTab` (#265) and "Usage / cost"
+    is the live :class:`UsageTab` (#274); "Terminal" remains a TODO placeholder
+    until its wave lands.
     """
 
     def __init__(
@@ -65,6 +71,9 @@ class CockpitWindow(QMainWindow):
         fleet_discover: Discover = discovery.discover_fleet,
         fleet_auto_refresh_ms: int = FLEET_REFRESH_MS,
         fleet_initial_refresh: bool = True,
+        usage_load: LoadUsage = default_load_usage,
+        usage_auto_refresh_ms: int = USAGE_REFRESH_MS,
+        usage_initial_refresh: bool = True,
     ) -> None:
         super().__init__()
         self.setWindowTitle(WINDOW_TITLE)
@@ -76,7 +85,13 @@ class CockpitWindow(QMainWindow):
             auto_refresh_ms=fleet_auto_refresh_ms,
             initial_refresh=fleet_initial_refresh,
         )
+        self.usage_tab = UsageTab(
+            usage_load,
+            auto_refresh_ms=usage_auto_refresh_ms,
+            initial_refresh=usage_initial_refresh,
+        )
+        live = {FLEET_TAB_TITLE: self.fleet_tab, USAGE_TAB_TITLE: self.usage_tab}
         for title, todo in COCKPIT_TABS:
-            body = self.fleet_tab if title == FLEET_TAB_TITLE else _placeholder(todo)
+            body = live.get(title) or _placeholder(todo)
             self.tabs.addTab(body, title)
         self.setCentralWidget(self.tabs)

--- a/tools/runner-ui/forge_cockpit/usage_view.py
+++ b/tools/runner-ui/forge_cockpit/usage_view.py
@@ -1,0 +1,505 @@
+"""The "Usage / cost" tab — a QtCharts dashboard over the #273 usage core (ticket #274).
+
+This is the read-only usage view. It renders the already-normalized, content-free
+aggregates from :mod:`forge_cockpit.usage` (ticket #273) — it never re-parses a
+transcript, never re-implements pricing, and never touches message CONTENT. The
+panel shows:
+
+* a **time series** of tokens + estimated cost per day (QtCharts line chart) — AC1;
+* a **per-model breakdown** of tokens (QtCharts bar chart), including any
+  unknown/unpriced model so nothing is hidden — AC1;
+* a **today / session summary** with token + estimated-cost totals — AC1/AC3.
+
+Every cost figure is CLEARLY LABELLED as an estimate derived from local transcripts
+× published rates, and a visible indicator counts any ``unpriced`` (unknown-model)
+turns so the totals stay honest (AC3).
+
+Threading (AC2): discovering + parsing ``~/.claude/projects/**/*.jsonl`` and
+aggregating it is slow (the ~40k-turn scan), so it runs in a :class:`QRunnable` on
+the global :class:`QThreadPool` and marshals the result back to the GUI thread via
+a queued signal — reusing the #265 worker pattern. The GUI thread never calls the
+loader directly, so the window stays responsive during a scan. A Refresh button
+re-queries on demand; an optional interval :class:`QTimer` re-queries as new
+transcript turns are written.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from threading import get_ident
+
+from PySide6.QtCharts import (
+    QBarCategoryAxis,
+    QBarSeries,
+    QBarSet,
+    QChart,
+    QChartView,
+    QLineSeries,
+    QValueAxis,
+)
+from PySide6.QtCore import QObject, QRunnable, Qt, QThreadPool, QTimer, Signal
+from PySide6.QtGui import QPainter
+from PySide6.QtWidgets import (
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from forge_cockpit import usage
+from forge_cockpit.usage import UNKNOWN_DAY, UsageAggregate
+
+#: Auto-refresh interval in the running app (AC2). Off (0) in tests for determinism.
+USAGE_REFRESH_MS = 30_000
+
+#: The AC3 estimate disclaimer — cost is never authoritative; it is derived locally.
+ESTIMATE_NOTE = (
+    "Estimated — costs are derived from local transcripts × published list rates, "
+    "not billed figures."
+)
+
+
+@dataclass(frozen=True)
+class UsageSnapshot:
+    """One immutable set of usage aggregates, partitioned three ways (#273).
+
+    Each dict is a full partition of the same per-turn records, so any of them
+    sums to the same grand total. Carries usage metadata ONLY — no message content.
+    """
+
+    by_day: dict[str, UsageAggregate] = field(default_factory=dict)
+    by_model: dict[str, UsageAggregate] = field(default_factory=dict)
+    by_session: dict[str, UsageAggregate] = field(default_factory=dict)
+
+
+#: The loader seam the tab drives: () -> UsageSnapshot. Injectable so tests can
+#: supply fixture aggregates without parsing any transcript (AC2 hermetic).
+LoadUsage = Callable[[], UsageSnapshot]
+
+
+def default_load_usage(root: object | None = None) -> UsageSnapshot:
+    """Discover + parse every transcript and aggregate it three ways (the real
+    loader). Read-only end to end; delegates entirely to :mod:`forge_cockpit.usage`
+    — no re-parsing or re-pricing here."""
+
+    records = usage.collect_usage(root)
+    return UsageSnapshot(
+        by_day=usage.aggregate_by_day(records),
+        by_model=usage.aggregate_by_model(records),
+        by_session=usage.aggregate_by_session(records),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Summary math — pure functions over a snapshot (usage metadata only).
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class UsageTotals:
+    """Rolled-up token + estimated-cost totals for a set of buckets."""
+
+    turns: int = 0
+    total_tokens: int = 0
+    total_cost: float = 0.0
+    unpriced_turns: int = 0
+    unpriced_models: frozenset[str] = frozenset()
+
+    @property
+    def has_unpriced(self) -> bool:
+        return self.unpriced_turns > 0
+
+
+def _sum_totals(buckets: object) -> UsageTotals:
+    """Roll an iterable of :class:`UsageAggregate` up into one :class:`UsageTotals`."""
+    turns = tokens = unpriced = 0
+    cost = 0.0
+    models: set[str] = set()
+    for agg in buckets:
+        turns += agg.turns
+        tokens += agg.total_tokens
+        cost += agg.total_cost
+        unpriced += agg.unpriced_turns
+        models |= agg.unpriced_models
+    return UsageTotals(
+        turns=turns,
+        total_tokens=tokens,
+        total_cost=cost,
+        unpriced_turns=unpriced,
+        unpriced_models=frozenset(models),
+    )
+
+
+def grand_totals(snapshot: UsageSnapshot) -> UsageTotals:
+    """All-time totals across every model bucket (a full partition of the turns)."""
+    return _sum_totals(snapshot.by_model.values())
+
+
+def today_totals(snapshot: UsageSnapshot, today: str) -> UsageTotals:
+    """Totals for the single ``today`` day bucket (empty if that day has no turns)."""
+    agg = snapshot.by_day.get(today)
+    return _sum_totals([agg] if agg is not None else [])
+
+
+def sorted_day_keys(snapshot: UsageSnapshot) -> list[str]:
+    """Real calendar-day keys, ascending. The :data:`UNKNOWN_DAY` bucket (turns
+    without a parseable timestamp) is excluded from the time axis but still counts
+    toward the grand totals."""
+    return sorted(k for k in snapshot.by_day if k != UNKNOWN_DAY)
+
+
+def _fmt_tokens(n: int) -> str:
+    return f"{n:,}"
+
+
+def _fmt_cost(usd: float) -> str:
+    return f"${usd:,.2f}"
+
+
+# --------------------------------------------------------------------------- #
+# Off-GUI-thread worker (AC2) — reuses the #265 pattern.
+# --------------------------------------------------------------------------- #
+
+
+class _WorkerSignals(QObject):
+    finished = Signal(object)  # UsageSnapshot
+    failed = Signal(str)
+
+
+class _UsageWorker(QRunnable):
+    """Runs the usage loader off the GUI thread (AC2).
+
+    ``load`` — the slow discover→parse→aggregate — is called on a thread-pool
+    thread; its result (a :class:`UsageSnapshot`) or the string of any exception is
+    emitted via :class:`_WorkerSignals`, which Qt delivers to the connected slots on
+    the GUI thread via a queued connection. The GUI thread never blocks on the scan.
+    """
+
+    def __init__(self, load: LoadUsage) -> None:
+        super().__init__()
+        self._load = load
+        self.signals = _WorkerSignals()
+
+    def run(self) -> None:  # pragma: no cover - exercised via the thread pool
+        try:
+            snapshot = self._load()
+        except Exception as exc:  # never let a scan crash the worker thread
+            self.signals.failed.emit(f"{type(exc).__name__}: {exc}")
+            return
+        self.signals.finished.emit(snapshot)
+
+
+# --------------------------------------------------------------------------- #
+# The tab.
+# --------------------------------------------------------------------------- #
+
+
+def _today_iso() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+class UsageTab(QWidget):
+    """The "Usage / cost" tab: QtCharts dashboard over the #273 usage aggregates.
+
+    :param load: the usage loader (default :func:`default_load_usage`; overridden
+        with a fixture in tests). Runs off the GUI thread on refresh.
+    :param auto_refresh_ms: if > 0, re-query on this interval (AC2). Default 0 (off)
+        so tests are deterministic; the app enables it.
+    :param pool: the :class:`QThreadPool` to run the loader on (default the global
+        pool); injectable for tests.
+    :param initial_refresh: kick a first refresh on construction (default True so the
+        tab self-populates in the app; tests pass False to drive it explicitly).
+    :param today: the day key treated as "today" for the summary (default the current
+        UTC date); injectable so the summary is deterministic in tests.
+    """
+
+    #: Emitted on the GUI thread after a successful refresh has updated the charts.
+    usage_loaded = Signal()
+    #: Emitted on the GUI thread when a refresh failed (carries the error string).
+    refresh_failed = Signal(str)
+
+    def __init__(
+        self,
+        load: LoadUsage = default_load_usage,
+        *,
+        auto_refresh_ms: int = 0,
+        pool: QThreadPool | None = None,
+        initial_refresh: bool = True,
+        today: str | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._load = load
+        self._pool = pool or QThreadPool.globalInstance()
+        self._today = today or _today_iso()
+        self._busy = False
+        #: The most recent snapshot rendered (None until the first refresh lands).
+        self._snapshot: UsageSnapshot | None = None
+        #: Thread ident of the last loader call — proves it ran off the GUI thread
+        #: (AC2). ``None`` until the first refresh runs.
+        self.last_load_thread_ident: int | None = None
+        self._gui_thread_ident = get_ident()
+
+        self._build_ui()
+
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self.refresh)
+        if auto_refresh_ms > 0:
+            self._timer.start(auto_refresh_ms)
+
+        if initial_refresh:
+            self.refresh()
+
+    # -- UI ---------------------------------------------------------------- #
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        # Top bar: Refresh + status + the standing estimate disclaimer (AC3).
+        bar = QHBoxLayout()
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.setToolTip("Re-scan local transcripts and re-aggregate now")
+        self.refresh_button.clicked.connect(self.refresh)
+        self.status_label = QLabel("")
+        bar.addWidget(self.refresh_button)
+        bar.addWidget(self.status_label)
+        bar.addStretch(1)
+        self.estimate_label = QLabel(ESTIMATE_NOTE)
+        self.estimate_label.setWordWrap(True)
+        self.estimate_label.setToolTip(
+            "Token counts come from your local Claude Code transcripts; costs multiply "
+            "them by pinned published list rates. Figures are estimates, not invoices."
+        )
+        bar.addWidget(self.estimate_label)
+        layout.addLayout(bar)
+
+        # Summary row: today / all-time totals + the unpriced honesty indicator (AC3).
+        layout.addWidget(self._build_summary())
+
+        # Charts: time series (tokens + cost over time) and per-model breakdown (AC1).
+        charts = QHBoxLayout()
+        charts.addWidget(self._build_time_chart(), 2)
+        charts.addWidget(self._build_model_chart(), 1)
+        layout.addLayout(charts, 1)
+
+    def _build_summary(self) -> QGroupBox:
+        box = QGroupBox("Summary")
+        grid = QGridLayout(box)
+        grid.addWidget(QLabel("Today"), 0, 0)
+        self.today_tokens_label = QLabel("—")
+        self.today_cost_label = QLabel("—")
+        grid.addWidget(self.today_tokens_label, 0, 1)
+        grid.addWidget(self.today_cost_label, 0, 2)
+
+        grid.addWidget(QLabel("All-time"), 1, 0)
+        self.total_tokens_label = QLabel("—")
+        self.total_cost_label = QLabel("—")
+        grid.addWidget(self.total_tokens_label, 1, 1)
+        grid.addWidget(self.total_cost_label, 1, 2)
+
+        grid.addWidget(QLabel("Sessions"), 2, 0)
+        self.sessions_label = QLabel("—")
+        grid.addWidget(self.sessions_label, 2, 1)
+
+        # The unpriced indicator: hidden when everything is priced, visible + explicit
+        # when some turns used an unknown model (AC3 — never hide unpriced turns).
+        self.unpriced_label = QLabel("")
+        self.unpriced_label.setWordWrap(True)
+        self.unpriced_label.setToolTip(
+            "Turns whose model is not in the pinned pricing table. Their tokens ARE "
+            "counted; their cost is not estimated, so totals understate spend."
+        )
+        self.unpriced_label.setVisible(False)
+        grid.addWidget(self.unpriced_label, 3, 0, 1, 3)
+        return box
+
+    def _build_time_chart(self) -> QChartView:
+        self.time_chart = QChart()
+        self.time_chart.setTitle("Tokens & estimated cost over time")
+
+        self.cost_series = QLineSeries()
+        self.cost_series.setName("Est. cost (USD)")
+        self.tokens_series = QLineSeries()
+        self.tokens_series.setName("Tokens")
+        self.time_chart.addSeries(self.cost_series)
+        self.time_chart.addSeries(self.tokens_series)
+
+        self.time_axis_x = QBarCategoryAxis()
+        self.time_axis_cost = QValueAxis()
+        self.time_axis_cost.setTitleText("Est. cost (USD)")
+        self.time_axis_tokens = QValueAxis()
+        self.time_axis_tokens.setTitleText("Tokens")
+
+        self.time_chart.addAxis(self.time_axis_x, Qt.AlignmentFlag.AlignBottom)
+        self.time_chart.addAxis(self.time_axis_cost, Qt.AlignmentFlag.AlignLeft)
+        self.time_chart.addAxis(self.time_axis_tokens, Qt.AlignmentFlag.AlignRight)
+        self.cost_series.attachAxis(self.time_axis_x)
+        self.cost_series.attachAxis(self.time_axis_cost)
+        self.tokens_series.attachAxis(self.time_axis_x)
+        self.tokens_series.attachAxis(self.time_axis_tokens)
+
+        view = QChartView(self.time_chart)
+        view.setRenderHint(QPainter.RenderHint.Antialiasing)
+        return view
+
+    def _build_model_chart(self) -> QChartView:
+        self.model_chart = QChart()
+        self.model_chart.setTitle("Tokens by model")
+
+        self.model_barset = QBarSet("Tokens")
+        self.model_series = QBarSeries()
+        self.model_series.append(self.model_barset)
+        self.model_chart.addSeries(self.model_series)
+
+        self.model_axis_x = QBarCategoryAxis()
+        self.model_axis_y = QValueAxis()
+        self.model_axis_y.setTitleText("Tokens")
+        self.model_chart.addAxis(self.model_axis_x, Qt.AlignmentFlag.AlignBottom)
+        self.model_chart.addAxis(self.model_axis_y, Qt.AlignmentFlag.AlignLeft)
+        self.model_series.attachAxis(self.model_axis_x)
+        self.model_series.attachAxis(self.model_axis_y)
+
+        view = QChartView(self.model_chart)
+        view.setRenderHint(QPainter.RenderHint.Antialiasing)
+        return view
+
+    # -- accessors (for tests / callers) ---------------------------------- #
+    @property
+    def snapshot(self) -> UsageSnapshot | None:
+        """The most recent rendered snapshot (None before the first refresh)."""
+        return self._snapshot
+
+    @property
+    def load_ran_off_gui_thread(self) -> bool:
+        """True once a load has run and it ran off the GUI thread (AC2)."""
+        return (
+            self.last_load_thread_ident is not None
+            and self.last_load_thread_ident != self._gui_thread_ident
+        )
+
+    def time_series_days(self) -> list[str]:
+        """The day categories currently plotted on the time-series X axis."""
+        return list(self.time_axis_x.categories())
+
+    def model_names(self) -> list[str]:
+        """The model categories currently plotted on the per-model X axis."""
+        return list(self.model_axis_x.categories())
+
+    # -- refresh (AC2) ----------------------------------------------------- #
+    def refresh(self) -> None:
+        """Kick an off-thread usage scan; results land back on the GUI thread.
+
+        A refresh already in flight is a no-op (the interval timer and the button
+        can't stack scans). Never blocks: the discover→parse→aggregate happens on a
+        thread-pool thread.
+        """
+        if self._busy:
+            return
+        self._busy = True
+        self.refresh_button.setEnabled(False)
+        self.status_label.setText("Scanning transcripts…")
+
+        worker = _UsageWorker(self._instrumented_load)
+        worker.signals.finished.connect(self._on_finished)
+        worker.signals.failed.connect(self._on_failed)
+        self._pool.start(worker)
+
+    def _instrumented_load(self) -> UsageSnapshot:
+        # Runs on the worker thread — record which thread so AC2 (off-GUI-thread) is
+        # assertable, then delegate to the real (or injected) loader.
+        self.last_load_thread_ident = get_ident()
+        return self._load()
+
+    def _on_finished(self, snapshot: UsageSnapshot) -> None:
+        self._snapshot = snapshot
+        self._render(snapshot)
+        self._end_refresh()
+        self.usage_loaded.emit()
+
+    def _on_failed(self, message: str) -> None:
+        self.status_label.setText(f"Scan failed: {message}")
+        self._end_refresh()
+        self.refresh_failed.emit(message)
+
+    def _end_refresh(self) -> None:
+        self._busy = False
+        self.refresh_button.setEnabled(True)
+
+    # -- rendering --------------------------------------------------------- #
+    def _render(self, snapshot: UsageSnapshot) -> None:
+        self._render_summary(snapshot)
+        self._render_time_chart(snapshot)
+        self._render_model_chart(snapshot)
+
+    def _render_summary(self, snapshot: UsageSnapshot) -> None:
+        grand = grand_totals(snapshot)
+        today = today_totals(snapshot, self._today)
+
+        self.today_tokens_label.setText(f"{_fmt_tokens(today.total_tokens)} tokens")
+        self.today_cost_label.setText(f"{_fmt_cost(today.total_cost)} est.")
+        self.total_tokens_label.setText(f"{_fmt_tokens(grand.total_tokens)} tokens")
+        self.total_cost_label.setText(f"{_fmt_cost(grand.total_cost)} est.")
+        self.sessions_label.setText(str(len(snapshot.by_session)))
+
+        if grand.has_unpriced:
+            models = ", ".join(sorted(grand.unpriced_models)) or "unknown"
+            self.unpriced_label.setText(
+                f"⚠ {grand.unpriced_turns} turn(s) unpriced (unknown model: {models}) — "
+                "their tokens are counted but excluded from the cost estimate, so the "
+                "total understates actual spend."
+            )
+            self.unpriced_label.setVisible(True)
+        else:
+            self.unpriced_label.setText("")
+            self.unpriced_label.setVisible(False)
+
+        note = (
+            f"{grand.turns} turn(s) across {len(snapshot.by_session)} session(s)"
+            if grand.turns
+            else "No usage found in local transcripts."
+        )
+        self.status_label.setText(note)
+
+    def _render_time_chart(self, snapshot: UsageSnapshot) -> None:
+        days = sorted_day_keys(snapshot)
+        self.cost_series.clear()
+        self.tokens_series.clear()
+
+        max_cost = 0.0
+        max_tokens = 0
+        for i, day in enumerate(days):
+            agg = snapshot.by_day[day]
+            cost = agg.total_cost
+            tokens = agg.total_tokens
+            self.cost_series.append(i, cost)
+            self.tokens_series.append(i, tokens)
+            max_cost = max(max_cost, cost)
+            max_tokens = max(max_tokens, tokens)
+
+        self.time_axis_x.clear()
+        self.time_axis_x.append(days)
+        self.time_axis_cost.setRange(0, max_cost * 1.1 if max_cost > 0 else 1.0)
+        self.time_axis_tokens.setRange(0, max_tokens * 1.1 if max_tokens > 0 else 1.0)
+
+    def _render_model_chart(self, snapshot: UsageSnapshot) -> None:
+        # Every model that produced turns — sorted by tokens desc so the heaviest
+        # models lead; unknown/unpriced models appear here too (never hidden, AC3).
+        aggs = sorted(
+            snapshot.by_model.values(), key=lambda a: a.total_tokens, reverse=True
+        )
+        self.model_barset.remove(0, self.model_barset.count())
+        categories: list[str] = []
+        max_tokens = 0
+        for agg in aggs:
+            label = agg.key + (" (unpriced)" if agg.has_unpriced else "")
+            categories.append(label)
+            self.model_barset.append(agg.total_tokens)
+            max_tokens = max(max_tokens, agg.total_tokens)
+
+        self.model_axis_x.clear()
+        self.model_axis_x.append(categories)
+        self.model_axis_y.setRange(0, max_tokens * 1.1 if max_tokens > 0 else 1.0)

--- a/tools/runner-ui/tests/test_app_smoke.py
+++ b/tools/runner-ui/tests/test_app_smoke.py
@@ -1,18 +1,42 @@
 """Headless smoke test for the cockpit shell (AC2 + AC4).
 
 Constructs the real QMainWindow under the offscreen Qt platform, asserts the
-three tabs are wired — the live "Runner fleet" fleet overview (#265) plus the two
-remaining TODO placeholders — then tears down, proving the app launches without a
-desktop session on the CI runner.
+three tabs are wired — the live "Runner fleet" fleet overview (#265), the live
+"Usage / cost" dashboard (#274), and the remaining "Terminal" TODO placeholder —
+then tears down, proving the app launches without a desktop session on the CI
+runner.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from forge_cockpit.app import COCKPIT_TABS, FLEET_TAB_TITLE, WINDOW_TITLE, CockpitWindow
+from forge_cockpit.app import (
+    COCKPIT_TABS,
+    FLEET_TAB_TITLE,
+    USAGE_TAB_TITLE,
+    WINDOW_TITLE,
+    CockpitWindow,
+)
 from forge_cockpit.discovery import Fleet
 from forge_cockpit.fleet_view import FleetTab
+from forge_cockpit.usage_view import UsageSnapshot, UsageTab
+
+#: Tab titles that are live panels (not TODO placeholders) — skipped by the
+#: placeholder assertion below.
+_LIVE_TITLES = {FLEET_TAB_TITLE, USAGE_TAB_TITLE}
+
+
+def _make_window() -> CockpitWindow:
+    """A fully hermetic cockpit window: no discovery, no transcript parse, no timers."""
+    return CockpitWindow(
+        fleet_discover=lambda: Fleet(runners=()),
+        fleet_auto_refresh_ms=0,
+        fleet_initial_refresh=False,
+        usage_load=lambda: UsageSnapshot(),
+        usage_auto_refresh_ms=0,
+        usage_initial_refresh=False,
+    )
 
 
 @pytest.fixture
@@ -22,11 +46,7 @@ def app(qapp):
 
 
 def test_window_has_three_tabs(app, qtbot):
-    window = CockpitWindow(
-        fleet_discover=lambda: Fleet(runners=()),
-        fleet_auto_refresh_ms=0,
-        fleet_initial_refresh=False,
-    )
+    window = _make_window()
     qtbot.addWidget(window)
 
     assert window.windowTitle() == WINDOW_TITLE
@@ -39,11 +59,7 @@ def test_window_has_three_tabs(app, qtbot):
 
 
 def test_runner_fleet_tab_is_the_live_fleet_view(app, qtbot):
-    window = CockpitWindow(
-        fleet_discover=lambda: Fleet(runners=()),
-        fleet_auto_refresh_ms=0,
-        fleet_initial_refresh=False,
-    )
+    window = _make_window()
     qtbot.addWidget(window)
 
     idx = next(i for i in range(window.tabs.count()) if window.tabs.tabText(i) == FLEET_TAB_TITLE)
@@ -51,19 +67,24 @@ def test_runner_fleet_tab_is_the_live_fleet_view(app, qtbot):
     assert window.fleet_tab is window.tabs.widget(idx)
 
 
+def test_usage_cost_tab_is_the_live_usage_view(app, qtbot):
+    window = _make_window()
+    qtbot.addWidget(window)
+
+    idx = next(i for i in range(window.tabs.count()) if window.tabs.tabText(i) == USAGE_TAB_TITLE)
+    assert isinstance(window.tabs.widget(idx), UsageTab)
+    assert window.usage_tab is window.tabs.widget(idx)
+
+
 def test_placeholder_tabs_keep_their_todo(app, qtbot):
     from PySide6.QtWidgets import QLabel
 
-    window = CockpitWindow(
-        fleet_discover=lambda: Fleet(runners=()),
-        fleet_auto_refresh_ms=0,
-        fleet_initial_refresh=False,
-    )
+    window = _make_window()
     qtbot.addWidget(window)
 
     for i, (title, todo) in enumerate(COCKPIT_TABS):
-        if title == FLEET_TAB_TITLE:
-            continue  # the live fleet tab has no TODO placeholder
+        if title in _LIVE_TITLES:
+            continue  # live panels have no TODO placeholder
         page = window.tabs.widget(i)
         assert page is not None
         texts = [lbl.text() for lbl in page.findChildren(QLabel)]
@@ -72,11 +93,7 @@ def test_placeholder_tabs_keep_their_todo(app, qtbot):
 
 def test_window_show_and_close_headless(app, qtbot):
     """Full launch/teardown cycle: show the window, then close it."""
-    window = CockpitWindow(
-        fleet_discover=lambda: Fleet(runners=()),
-        fleet_auto_refresh_ms=0,
-        fleet_initial_refresh=False,
-    )
+    window = _make_window()
     qtbot.addWidget(window)
     window.show()
     assert window.isVisible()

--- a/tools/runner-ui/tests/test_usage_panel.py
+++ b/tools/runner-ui/tests/test_usage_panel.py
@@ -1,0 +1,335 @@
+"""Tests for the "Usage / cost" QtCharts dashboard tab (ticket #274).
+
+Hermetic + headless: the usage loader is replaced with an in-memory fixture
+snapshot (no transcript under ``~/.claude/projects`` is ever read, no pricing is
+recomputed — the panel renders the #273 aggregates as-is), and every widget is
+built under the offscreen Qt platform (conftest). The suite locks the ACs:
+
+* AC1 — the charts populate from the aggregates: a tokens+cost time series, a
+  per-model breakdown, and a today/all-time summary all render.
+* AC2 — Refresh re-queries the loader **off the GUI thread** and updates the
+  charts without blocking (we assert the worker/signal path + the recorded
+  thread, never a direct GUI-thread parse).
+* AC3 — the estimate labelling renders, and turns on an unknown/unpriced model
+  are surfaced honestly (a visible indicator with the count + model), never
+  hidden.
+"""
+
+from __future__ import annotations
+
+from threading import get_ident
+
+import pytest
+
+from forge_cockpit.usage import UsageAggregate
+from forge_cockpit.usage_view import (
+    ESTIMATE_NOTE,
+    UsageSnapshot,
+    UsageTab,
+    default_load_usage,
+    grand_totals,
+    today_totals,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture snapshot — two priced models across two days + one UNPRICED model.
+# --------------------------------------------------------------------------- #
+TODAY = "2026-07-25"
+YESTERDAY = "2026-07-24"
+
+
+def _agg(
+    key: str,
+    *,
+    turns: int,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cost_input: float = 0.0,
+    cost_output: float = 0.0,
+    unpriced_turns: int = 0,
+    unpriced_models: set[str] | None = None,
+) -> UsageAggregate:
+    return UsageAggregate(
+        key=key,
+        turns=turns,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_input=cost_input,
+        cost_output=cost_output,
+        unpriced_turns=unpriced_turns,
+        unpriced_models=set(unpriced_models or ()),
+    )
+
+
+# by_day: yesterday (priced) + today (priced + one unpriced turn).
+DAY_YESTERDAY = _agg(
+    YESTERDAY, turns=2, input_tokens=1_000_000, output_tokens=200_000,
+    cost_input=5.0, cost_output=5.0,
+)
+DAY_TODAY = _agg(
+    TODAY, turns=3, input_tokens=2_000_000, output_tokens=100_000,
+    cost_input=6.0, cost_output=2.5,
+    unpriced_turns=1, unpriced_models={"claude-mystery-9"},
+)
+
+# by_model: two priced models + one unknown/unpriced model (tokens counted, no cost).
+MODEL_OPUS = _agg(
+    "claude-opus-4-8", turns=3, input_tokens=2_000_000, output_tokens=250_000,
+    cost_input=10.0, cost_output=6.25,
+)
+MODEL_HAIKU = _agg(
+    "claude-haiku-4-5", turns=1, input_tokens=1_000_000, output_tokens=50_000,
+    cost_input=1.0, cost_output=1.25,
+)
+MODEL_UNKNOWN = _agg(
+    "claude-mystery-9", turns=1, input_tokens=500_000, output_tokens=0,
+    unpriced_turns=1, unpriced_models={"claude-mystery-9"},
+)
+
+# by_session: two sessions.
+SESSION_A = _agg("sess-a", turns=4, input_tokens=3_000_000)
+SESSION_B = _agg("sess-b", turns=1, input_tokens=500_000)
+
+FIXTURE_SNAPSHOT = UsageSnapshot(
+    by_day={YESTERDAY: DAY_YESTERDAY, TODAY: DAY_TODAY},
+    by_model={
+        "claude-opus-4-8": MODEL_OPUS,
+        "claude-haiku-4-5": MODEL_HAIKU,
+        "claude-mystery-9": MODEL_UNKNOWN,
+    },
+    by_session={"sess-a": SESSION_A, "sess-b": SESSION_B},
+)
+
+
+class RecordingLoad:
+    """A usage-loader stand-in: records call count + the thread it ran on."""
+
+    def __init__(self, snapshot: UsageSnapshot) -> None:
+        self.snapshot = snapshot
+        self.calls = 0
+        self.thread_idents: list[int] = []
+
+    def __call__(self) -> UsageSnapshot:
+        self.calls += 1
+        self.thread_idents.append(get_ident())
+        return self.snapshot
+
+
+@pytest.fixture
+def _app(qapp):
+    return qapp
+
+
+def _make_tab(qtbot, load, **kwargs) -> UsageTab:
+    tab = UsageTab(load, initial_refresh=False, today=TODAY, **kwargs)
+    qtbot.addWidget(tab)
+    return tab
+
+
+def _load(qtbot, tab) -> None:
+    with qtbot.waitSignal(tab.usage_loaded, timeout=5000):
+        tab.refresh()
+
+
+# --------------------------------------------------------------------------- #
+# Pure summary math (no widgets) — the totals the panel renders.
+# --------------------------------------------------------------------------- #
+def test_grand_totals_sum_every_model_bucket():
+    totals = grand_totals(FIXTURE_SNAPSHOT)
+    # 3 + 1 + 1 turns across the three model buckets.
+    assert totals.turns == 5
+    assert totals.total_tokens == (
+        MODEL_OPUS.total_tokens + MODEL_HAIKU.total_tokens + MODEL_UNKNOWN.total_tokens
+    )
+    assert totals.total_cost == pytest.approx(
+        MODEL_OPUS.total_cost + MODEL_HAIKU.total_cost
+    )
+    # The unknown model surfaces as unpriced, not hidden (AC3).
+    assert totals.has_unpriced is True
+    assert totals.unpriced_turns == 1
+    assert "claude-mystery-9" in totals.unpriced_models
+
+
+def test_today_totals_pick_the_today_bucket_only():
+    totals = today_totals(FIXTURE_SNAPSHOT, TODAY)
+    assert totals.total_tokens == DAY_TODAY.total_tokens
+    assert totals.total_cost == pytest.approx(DAY_TODAY.total_cost)
+    # A day with no turns yields empty totals, never a crash.
+    assert today_totals(FIXTURE_SNAPSHOT, "1999-01-01").total_tokens == 0
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — the charts + summary populate from the aggregates.
+# --------------------------------------------------------------------------- #
+def test_time_series_chart_populates_from_days(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingLoad(FIXTURE_SNAPSHOT))
+    _load(qtbot, tab)
+
+    # One point per real calendar day, ascending (unknown-day bucket excluded).
+    assert tab.time_series_days() == [YESTERDAY, TODAY]
+    assert tab.cost_series.count() == 2
+    assert tab.tokens_series.count() == 2
+    # Cost line follows the per-day totals.
+    assert tab.cost_series.at(0).y() == pytest.approx(DAY_YESTERDAY.total_cost)
+    assert tab.cost_series.at(1).y() == pytest.approx(DAY_TODAY.total_cost)
+    # Token line follows the per-day token totals.
+    assert tab.tokens_series.at(1).y() == pytest.approx(DAY_TODAY.total_tokens)
+
+
+def test_per_model_breakdown_populates_with_a_bar_per_model(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingLoad(FIXTURE_SNAPSHOT))
+    _load(qtbot, tab)
+
+    names = tab.model_names()
+    assert len(names) == 3  # every model that produced turns, priced or not
+    # Sorted tokens-desc: opus (2.25M) > haiku (1.05M) > mystery (0.5M).
+    assert names[0].startswith("claude-opus-4-8")
+    # The unknown model appears AND is marked unpriced in its label (AC3).
+    assert any(n.startswith("claude-mystery-9") and "unpriced" in n for n in names)
+    assert tab.model_barset.count() == 3
+    assert tab.model_barset.at(0) == pytest.approx(MODEL_OPUS.total_tokens)
+
+
+def test_summary_shows_today_and_all_time_totals(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingLoad(FIXTURE_SNAPSHOT))
+    _load(qtbot, tab)
+
+    grand = grand_totals(FIXTURE_SNAPSHOT)
+    assert f"{grand.total_tokens:,}" in tab.total_tokens_label.text()
+    assert f"{grand.total_cost:,.2f}" in tab.total_cost_label.text()
+    assert f"{DAY_TODAY.total_tokens:,}" in tab.today_tokens_label.text()
+    assert tab.sessions_label.text() == "2"
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — Refresh re-queries off the GUI thread, non-blocking, and updates.
+# --------------------------------------------------------------------------- #
+def test_refresh_runs_loader_off_the_gui_thread(_app, qtbot):
+    load = RecordingLoad(FIXTURE_SNAPSHOT)
+    tab = _make_tab(qtbot, load)
+    gui_thread = get_ident()
+
+    _load(qtbot, tab)
+
+    assert load.calls == 1
+    # The loader recorded a thread ident that is NOT the GUI thread's (AC2).
+    assert load.thread_idents[0] != gui_thread
+    assert tab.load_ran_off_gui_thread is True
+
+
+def test_refresh_requeries_and_updates_charts(_app, qtbot):
+    # Start with a single-day, single-model snapshot; then the transcripts "grow".
+    small = UsageSnapshot(
+        by_day={YESTERDAY: DAY_YESTERDAY},
+        by_model={"claude-opus-4-8": MODEL_OPUS},
+        by_session={"sess-a": SESSION_A},
+    )
+    load = RecordingLoad(small)
+    tab = _make_tab(qtbot, load)
+
+    _load(qtbot, tab)
+    assert tab.time_series_days() == [YESTERDAY]
+    assert len(tab.model_names()) == 1
+
+    # New turns land under us; a refresh must re-query the loader and re-render.
+    load.snapshot = FIXTURE_SNAPSHOT
+    _load(qtbot, tab)
+
+    assert load.calls == 2
+    assert tab.time_series_days() == [YESTERDAY, TODAY]
+    assert len(tab.model_names()) == 3
+
+
+def test_refresh_in_flight_is_a_noop(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingLoad(FIXTURE_SNAPSHOT))
+    tab._busy = True  # simulate a scan already running
+    tab.refresh()  # must not start a second worker
+    assert tab.snapshot is None  # nothing rendered
+
+
+def test_refresh_failure_is_surfaced_not_raised(_app, qtbot):
+    def boom() -> UsageSnapshot:
+        raise RuntimeError("transcript root exploded")
+
+    tab = _make_tab(qtbot, boom)
+    with qtbot.waitSignal(tab.refresh_failed, timeout=5000) as sig:
+        tab.refresh()
+
+    assert "transcript root exploded" in sig.args[0]
+    assert "failed" in tab.status_label.text().lower()
+    assert tab.snapshot is None  # nothing rendered, no crash
+
+
+def test_auto_refresh_interval_wires_a_running_timer(_app, qtbot):
+    tab = UsageTab(
+        RecordingLoad(FIXTURE_SNAPSHOT),
+        auto_refresh_ms=10_000,
+        initial_refresh=False,
+        today=TODAY,
+    )
+    qtbot.addWidget(tab)
+    assert tab._timer.isActive()
+    assert tab._timer.interval() == 10_000
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — estimate labelling + honest unpriced surfacing.
+# --------------------------------------------------------------------------- #
+def test_estimate_note_is_always_visible(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingLoad(FIXTURE_SNAPSHOT))
+    _load(qtbot, tab)
+    text = tab.estimate_label.text().lower()
+    assert tab.estimate_label.text() == ESTIMATE_NOTE
+    # It must name the estimate nature and the local-transcripts × rates derivation.
+    assert "estimated" in text
+    assert "local transcripts" in text
+    assert "rates" in text
+
+
+def test_unpriced_indicator_is_shown_with_count_and_model(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingLoad(FIXTURE_SNAPSHOT))
+    _load(qtbot, tab)
+
+    assert not tab.unpriced_label.isHidden()
+    text = tab.unpriced_label.text()
+    assert "1" in text  # the count of unpriced turns
+    assert "claude-mystery-9" in text  # the offending unknown model, named
+
+
+def test_unpriced_indicator_hidden_when_all_priced(_app, qtbot):
+    priced_only = UsageSnapshot(
+        by_day={TODAY: DAY_TODAY},  # DAY_TODAY carries an unpriced turn...
+        by_model={"claude-opus-4-8": MODEL_OPUS, "claude-haiku-4-5": MODEL_HAIKU},
+        by_session={"sess-a": SESSION_A},
+    )
+    # ...but grand totals come from by_model, which here is all-priced -> hidden.
+    tab = _make_tab(qtbot, RecordingLoad(priced_only))
+    _load(qtbot, tab)
+
+    assert tab.unpriced_label.isHidden()
+
+
+# --------------------------------------------------------------------------- #
+# Empty transcripts — the panel renders cleanly with nothing to show.
+# --------------------------------------------------------------------------- #
+def test_empty_snapshot_renders_without_crashing(_app, qtbot):
+    tab = _make_tab(qtbot, RecordingLoad(UsageSnapshot()))
+    _load(qtbot, tab)
+
+    assert tab.time_series_days() == []
+    assert tab.model_names() == []
+    assert tab.sessions_label.text() == "0"
+    assert tab.unpriced_label.isHidden()
+
+
+# --------------------------------------------------------------------------- #
+# The default loader wires to the #273 core (read-only), not a re-implementation.
+# --------------------------------------------------------------------------- #
+def test_default_loader_returns_a_snapshot_from_a_missing_root(tmp_path):
+    # A missing/empty root yields empty aggregates rather than raising — proving the
+    # loader delegates to usage.collect_usage (read-only discovery), not a re-parse.
+    snapshot = default_load_usage(tmp_path / "nope")
+    assert snapshot.by_day == {}
+    assert snapshot.by_model == {}
+    assert snapshot.by_session == {}


### PR DESCRIPTION
Closes #274

Wave 2 of epic #262 — the "Usage / cost" tab becomes a live QtCharts dashboard over the #273 usage data core (ADR-0006). It **renders** the content-free `UsageAggregate` dataclasses as-is: no transcript re-parse, no re-implemented pricing (usage.py owns both), no message content.

## Acceptance criteria
- [x] **AC1** — the tab charts tokens + estimated cost over time (QtCharts line chart, per day), plus a per-model token breakdown (bar chart) and a today/all-time summary. Unknown models appear in the breakdown too (marked `(unpriced)`).
- [x] **AC2** — refreshes as new turns are written: on-demand **Refresh** button + optional interval `QTimer`. The slow discover→parse→aggregate runs in a `QThreadPool` worker (reusing the #265 pattern) and marshals results back via a queued signal — the GUI thread never blocks or parses directly. Tests assert the loader ran off the GUI thread (recorded thread ident) and that a second refresh re-queries + re-renders.
- [x] **AC3** — tokens + estimated cost totals are shown, **clearly labelled** as estimates derived from local transcripts × published list rates. Turns on an unknown/`unpriced` model are surfaced honestly (a visible indicator with the count + model id), never hidden.

## Changes
- `forge_cockpit/usage_view.py` — new `UsageTab` (charts + summary + async worker) and pure summary helpers (`grand_totals`/`today_totals`/`sorted_day_keys`) over `UsageSnapshot`.
- `forge_cockpit/app.py` — wires the live `UsageTab` into the shell in place of the "Usage / cost" placeholder.
- `tests/test_usage_panel.py` — new pytest-qt suite (offscreen): charts populate from fixture aggregates (incl. an unpriced/unknown-model entry), refresh runs off the GUI thread and re-renders, estimate labelling + unpriced surfacing render, empty-snapshot and failure paths are clean.
- `tests/test_app_smoke.py` — updated: "Usage / cost" is now a live `UsageTab`, not a TODO placeholder.

## Verification (honest)
- `cd tools/runner-ui; uv sync --frozen` — no lock drift (PySide6 ships QtCharts; **no new dependency**).
- `QT_QPA_PLATFORM=offscreen uv run pytest -q` → **166 passed** (full cockpit suite, matching the `cockpit-python` self-hosted CI job). Did not modify verify.yml.

## Not touched
No transcript re-parsing, no re-priced pricing, no message content surfaced, no GUI-thread parse, verify.yml unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)