### PR TITLE
feat(cockpit): embedded pywinpty terminal + WSL session (#275)

### DIFF
--- a/tools/runner-ui/forge_cockpit/app.py
+++ b/tools/runner-ui/forge_cockpit/app.py
@@ -5,10 +5,11 @@ The shell wires three tabs (ADR-0006 Decision 2 charter): "Runner fleet",
 (:class:`~forge_cockpit.fleet_view.FleetTab`, ticket #265) over the #264 discovery
 core; "Usage / cost" is the live usage/cost dashboard
 (:class:`~forge_cockpit.usage_view.UsageTab`, ticket #274) over the #273 usage
-core; "Terminal" is still a TODO placeholder whose real panel arrives in Wave 3.
-Keeping the shell separate from the panels lets the smoke test construct the
-window headless (QT_QPA_PLATFORM=offscreen) and assert the tab wiring without a
-desktop session.
+core; "Terminal" is the live embedded pywinpty/ConPTY terminal
+(:class:`~forge_cockpit.terminal.TerminalTab`, ticket #275) with a Windows shell
+and a WSL session. Keeping the shell separate from the panels lets the smoke test
+construct the window headless (QT_QPA_PLATFORM=offscreen) and assert the tab
+wiring without a desktop session.
 """
 
 from __future__ import annotations
@@ -24,13 +25,15 @@ from PySide6.QtWidgets import (
 
 from forge_cockpit import discovery
 from forge_cockpit.fleet_view import Discover, FleetTab
+from forge_cockpit.terminal import Spawn, TerminalTab, default_spawn
 from forge_cockpit.usage_view import USAGE_REFRESH_MS, LoadUsage, UsageTab, default_load_usage
 
 #: Fleet auto-refresh interval in the running app (AC3). Off in tests.
 FLEET_REFRESH_MS = 15_000
 
 #: Placeholder tab title -> the TODO note shown on its body, in display order. The
-#: "Runner fleet" and "Usage / cost" tabs are live panels, wired separately.
+#: "Runner fleet", "Usage / cost", and "Terminal" tabs are all live panels, wired
+#: separately; no TODO placeholder remains.
 COCKPIT_TABS: tuple[tuple[str, str], ...] = (
     ("Runner fleet", "TODO: runner fleet control (service/container state, start/stop)."),
     ("Usage / cost", "TODO: Claude usage / cost / token monitor (from local transcripts)."),
@@ -55,14 +58,17 @@ def _placeholder(todo: str) -> QWidget:
 FLEET_TAB_TITLE = "Runner fleet"
 #: Title of the live usage/cost dashboard tab (#274).
 USAGE_TAB_TITLE = "Usage / cost"
+#: Title of the live embedded-terminal tab (#275).
+TERMINAL_TAB_TITLE = "Terminal"
 
 
 class CockpitWindow(QMainWindow):
     """The cockpit shell: a main window whose central widget is a tab bar.
 
-    The "Runner fleet" tab is the live :class:`FleetTab` (#265) and "Usage / cost"
-    is the live :class:`UsageTab` (#274); "Terminal" remains a TODO placeholder
-    until its wave lands.
+    The "Runner fleet" tab is the live :class:`FleetTab` (#265), "Usage / cost" is
+    the live :class:`UsageTab` (#274), and "Terminal" is the live
+    :class:`TerminalTab` (#275) — the embedded pywinpty/ConPTY terminal with a
+    Windows shell and a WSL session.
     """
 
     def __init__(
@@ -74,6 +80,8 @@ class CockpitWindow(QMainWindow):
         usage_load: LoadUsage = default_load_usage,
         usage_auto_refresh_ms: int = USAGE_REFRESH_MS,
         usage_initial_refresh: bool = True,
+        terminal_spawn: Spawn = default_spawn,
+        terminal_autostart: bool = True,
     ) -> None:
         super().__init__()
         self.setWindowTitle(WINDOW_TITLE)
@@ -90,7 +98,15 @@ class CockpitWindow(QMainWindow):
             auto_refresh_ms=usage_auto_refresh_ms,
             initial_refresh=usage_initial_refresh,
         )
-        live = {FLEET_TAB_TITLE: self.fleet_tab, USAGE_TAB_TITLE: self.usage_tab}
+        self.terminal_tab = TerminalTab(
+            spawn=terminal_spawn,
+            autostart=terminal_autostart,
+        )
+        live = {
+            FLEET_TAB_TITLE: self.fleet_tab,
+            USAGE_TAB_TITLE: self.usage_tab,
+            TERMINAL_TAB_TITLE: self.terminal_tab,
+        }
         for title, todo in COCKPIT_TABS:
             body = live.get(title) or _placeholder(todo)
             self.tabs.addTab(body, title)

--- a/tools/runner-ui/forge_cockpit/terminal.py
+++ b/tools/runner-ui/forge_cockpit/terminal.py
@@ -1,0 +1,489 @@
+"""The "Terminal" tab — a real embedded terminal via pywinpty/ConPTY (ticket #275).
+
+This is the Wave-3 panel that lands the last piece of the ADR-0006 cockpit: an
+actual interactive terminal embedded in the window, backed by a **ConPTY**
+pseudo-terminal (pywinpty's :class:`winpty.PtyProcess`). It runs a *real* shell —
+keystrokes are written to the pty and the pty's output is rendered back — not a
+faked transcript.
+
+Two sessions are offered so BOTH runner OS contexts are reachable from one window
+(AC1 + AC2):
+
+* **PowerShell** — a native Windows shell (ConPTY), for the Windows runner side;
+* **WSL (Linux)** — ``wsl.exe``, dropping into the WSL2 Linux side.
+
+Threading: a pty ``read`` blocks, so each session runs a daemon **reader thread**
+that pulls bytes off the pty and marshals them to the GUI thread via a queued Qt
+signal (:pydata:`PtySession.output`). The GUI thread never blocks on I/O. Widget
+resizes are translated to pty ``setwinsize(rows, cols)`` so the shell reflows.
+
+Security (AC3): this is a PLAIN interactive shell. It pre-types nothing, injects
+no environment (``env=None`` — the child simply inherits the user's normal
+environment; no PAT is added), and it NEVER reads ``~/.forge/runner.env`` or any
+secret store. There is no auto-run command and no echoed token — the module has no
+notion of a PAT at all. A full VT100 emulator is out of scope; output is rendered
+pragmatically (ANSI control sequences stripped, newlines normalised) into a
+monospaced view, which is enough for an interactive session.
+
+A note on portability: :mod:`winpty` is Windows-only and imported LAZILY inside
+:func:`default_spawn`, so importing this module (and mocking the pty in tests)
+never requires the native extension. The ``cockpit-python`` CI job runs on Windows
+and mocks the pty; it never spawns a real shell.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtGui import QFont, QFontDatabase, QFontMetrics, QKeyEvent
+from PySide6.QtWidgets import (
+    QLabel,
+    QPlainTextEdit,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+# --------------------------------------------------------------------------- #
+# Shells (AC1 Windows shell, AC2 WSL Linux shell).
+# --------------------------------------------------------------------------- #
+
+#: The Windows shell session (AC1). ``-NoLogo`` keeps the banner quiet; it is NOT
+#: a secret and injects nothing — just a cleaner prompt.
+WINDOWS_SHELL: tuple[str, ...] = ("powershell.exe", "-NoLogo")
+
+#: The WSL2 Linux shell session (AC2) — drops straight into the default distro.
+WSL_SHELL: tuple[str, ...] = ("wsl.exe",)
+
+#: Default pty geometry until the widget's first real resize (rows, cols).
+DEFAULT_ROWS = 24
+DEFAULT_COLS = 80
+
+#: How many bytes a reader pulls per ``read`` call.
+READ_SIZE = 4096
+
+#: Cap on the rendered scrollback so a chatty shell can't grow the view unbounded.
+MAX_SCROLLBACK_BLOCKS = 10_000
+
+
+@dataclass(frozen=True)
+class ShellSpec:
+    """One selectable shell: a display name + the argv to spawn for it."""
+
+    name: str
+    argv: tuple[str, ...]
+
+
+#: The shells offered in the Terminal tab, in display order: the Windows shell
+#: (AC1) first, then the WSL Linux shell (AC2).
+DEFAULT_SHELLS: tuple[ShellSpec, ...] = (
+    ShellSpec("PowerShell", WINDOWS_SHELL),
+    ShellSpec("WSL (Linux)", WSL_SHELL),
+)
+
+
+# --------------------------------------------------------------------------- #
+# The pty spawn seam.
+# --------------------------------------------------------------------------- #
+
+
+@runtime_checkable
+class PtyLike(Protocol):
+    """The slice of :class:`winpty.PtyProcess` this module drives (for typing/mocks)."""
+
+    def read(self, size: int) -> str | bytes: ...
+    def write(self, data: str) -> int: ...
+    def setwinsize(self, rows: int, cols: int) -> None: ...
+    def isalive(self) -> bool: ...
+    def close(self, force: bool = ...) -> None: ...
+
+
+class Spawn(Protocol):
+    """The seam a session spawns through: ``(argv, cols, rows) -> PtyLike``.
+
+    Injectable so tests supply a fake pty and NEVER launch a real shell in CI.
+    """
+
+    def __call__(self, argv: Sequence[str], cols: int, rows: int) -> PtyLike: ...
+
+
+def default_spawn(argv: Sequence[str], cols: int, rows: int) -> PtyLike:
+    """Spawn a real ConPTY shell via pywinpty (the production seam).
+
+    ``winpty`` is imported here, lazily, because it is a Windows-only native
+    extension — importing this module stays portable and unit-testable.
+
+    AC3: ``env=None`` means the child inherits the user's ordinary environment; we
+    add NOTHING — no PAT, no token, no ``runner.env`` — this is a plain shell.
+    """
+    from winpty import PtyProcess  # lazy, Windows-only native extension
+
+    return PtyProcess.spawn(list(argv), dimensions=(rows, cols), env=None)
+
+
+# --------------------------------------------------------------------------- #
+# Output rendering — pragmatic, not a full VT100 emulator.
+# --------------------------------------------------------------------------- #
+
+#: ANSI CSI / SGR sequences (colours, cursor moves, erases). Stripped for display.
+_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+#: OSC sequences (e.g. window-title sets), terminated by BEL or ST.
+_OSC_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+#: Remaining lone escapes (single-char / charset selects) we don't interpret.
+_OTHER_ESC_RE = re.compile(r"\x1b[()#][0-9A-Za-z]|\x1b[=>]")
+
+
+def render_output(text: str) -> str:
+    """Reduce raw pty bytes to displayable text (pragmatic ANSI handling, AC1).
+
+    Strips ANSI CSI/OSC control sequences, normalises CRLF/CR to LF, applies
+    backspaces, and drops the remaining C0 control bytes except tab/newline. This
+    is deliberately NOT a full terminal emulator — it is enough to read an
+    interactive session in a monospaced pane.
+    """
+    text = _OSC_RE.sub("", text)
+    text = _CSI_RE.sub("", text)
+    text = _OTHER_ESC_RE.sub("", text)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+
+    # Apply backspaces so line edits / prompts read sensibly.
+    out: list[str] = []
+    for ch in text:
+        if ch == "\b" or ch == "\x7f":
+            if out and out[-1] != "\n":
+                out.pop()
+            continue
+        if ch == "\t" or ch == "\n":
+            out.append(ch)
+            continue
+        if ord(ch) < 0x20:  # other C0 controls (BEL, etc.) — not rendered
+            continue
+        out.append(ch)
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# Keystroke -> pty bytes.
+# --------------------------------------------------------------------------- #
+
+#: Special keys that don't map to a printable ``text()`` — sent as their terminal
+#: control sequences so the shell sees Enter, arrows, etc.
+_KEY_SEQUENCES: dict[int, str] = {
+    Qt.Key.Key_Return: "\r",
+    Qt.Key.Key_Enter: "\r",
+    Qt.Key.Key_Backspace: "\x7f",
+    Qt.Key.Key_Tab: "\t",
+    Qt.Key.Key_Escape: "\x1b",
+    Qt.Key.Key_Up: "\x1b[A",
+    Qt.Key.Key_Down: "\x1b[B",
+    Qt.Key.Key_Right: "\x1b[C",
+    Qt.Key.Key_Left: "\x1b[D",
+    Qt.Key.Key_Home: "\x1b[H",
+    Qt.Key.Key_End: "\x1b[F",
+    Qt.Key.Key_Delete: "\x1b[3~",
+    Qt.Key.Key_PageUp: "\x1b[5~",
+    Qt.Key.Key_PageDown: "\x1b[6~",
+}
+
+
+def key_to_bytes(event: QKeyEvent) -> str:
+    """Translate a Qt key event to the string to write to the pty (AC1 input).
+
+    Printable keys forward their ``text()`` (which already carries Ctrl-combos such
+    as Ctrl+C -> ``\\x03``); the named editing/navigation keys map to their control
+    sequences. Returns ``""`` for a keypress with nothing to send (bare modifiers).
+    """
+    seq = _KEY_SEQUENCES.get(Qt.Key(event.key()))
+    if seq is not None:
+        return seq
+    return event.text()
+
+
+# --------------------------------------------------------------------------- #
+# The pty session — pty process + reader thread, off the GUI thread.
+# --------------------------------------------------------------------------- #
+
+
+class PtySession(QObject):
+    """A ConPTY-backed shell session: a pty process + a reader thread (AC1).
+
+    The reader thread blocks on ``pty.read`` and emits :pydata:`output` for every
+    chunk; Qt delivers it to the GUI thread via a queued connection, so decoding
+    and rendering never block on I/O. :meth:`write` forwards keystrokes, and
+    :meth:`resize` propagates the new geometry to the pty.
+
+    :param argv: the shell command to spawn.
+    :param spawn: the pty spawn seam (default :func:`default_spawn`; a fake in tests).
+    :param cols/rows: initial pty geometry.
+    """
+
+    #: Emitted (queued, on the GUI thread) with each decoded chunk of pty output.
+    output = Signal(str)
+    #: Emitted (queued) once the shell has exited / the pty closed.
+    exited = Signal()
+
+    def __init__(
+        self,
+        argv: Sequence[str],
+        *,
+        spawn: Spawn = default_spawn,
+        cols: int = DEFAULT_COLS,
+        rows: int = DEFAULT_ROWS,
+        read_size: int = READ_SIZE,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._argv = tuple(argv)
+        self._spawn = spawn
+        self._cols = max(1, cols)
+        self._rows = max(1, rows)
+        self._read_size = read_size
+        self._pty: PtyLike | None = None
+        self._reader: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    @property
+    def argv(self) -> tuple[str, ...]:
+        return self._argv
+
+    @property
+    def started(self) -> bool:
+        return self._pty is not None
+
+    def start(self) -> None:
+        """Spawn the shell and launch the reader thread. Idempotent."""
+        if self._pty is not None:
+            return
+        self._pty = self._spawn(self._argv, self._cols, self._rows)
+        self._reader = threading.Thread(
+            target=self._read_loop, name=f"pty-reader:{self._argv[0]}", daemon=True
+        )
+        self._reader.start()
+
+    def _read_loop(self) -> None:  # pragma: no cover - exercised via the reader thread
+        pty = self._pty
+        assert pty is not None
+        while not self._stop.is_set():
+            try:
+                data = pty.read(self._read_size)
+            except EOFError:
+                break
+            except Exception:
+                break
+            if not data:
+                break
+            text = data if isinstance(data, str) else data.decode("utf-8", "replace")
+            self.output.emit(text)
+        self.exited.emit()
+
+    def write(self, data: str) -> None:
+        """Forward a keystroke / paste to the pty (AC1 input). No-op before start."""
+        if not data or self._pty is None:
+            return
+        try:
+            self._pty.write(data)
+        except Exception:
+            pass  # a write after the shell exits must not crash the GUI
+
+    def resize(self, cols: int, rows: int) -> None:
+        """Propagate a new geometry to the pty so the shell reflows (AC1 resize)."""
+        self._cols = cols = max(1, cols)
+        self._rows = rows = max(1, rows)
+        if self._pty is None:
+            return
+        try:
+            self._pty.setwinsize(rows, cols)
+        except Exception:
+            pass
+
+    @property
+    def size(self) -> tuple[int, int]:
+        """Current ``(cols, rows)`` geometry."""
+        return (self._cols, self._rows)
+
+    def close(self) -> None:
+        """Stop the reader and terminate the shell. Safe to call repeatedly."""
+        self._stop.set()
+        if self._pty is not None:
+            try:
+                self._pty.close(force=True)
+            except Exception:
+                pass
+            self._pty = None
+
+
+# --------------------------------------------------------------------------- #
+# The terminal view — a monospaced pane that renders output + captures keys.
+# --------------------------------------------------------------------------- #
+
+
+class TerminalView(QPlainTextEdit):
+    """A monospaced pane wired to one :class:`PtySession` (render out, capture in).
+
+    Output arrives via the session's queued :pydata:`PtySession.output` signal and
+    is appended (AC1 render). Keystrokes are captured in :meth:`keyPressEvent` and
+    written to the pty rather than edited locally — the shell echoes them back
+    (AC1 input). A resize recomputes the character grid and tells the pty (AC1
+    resize).
+    """
+
+    def __init__(self, session: PtySession, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._session = session
+        self.setReadOnly(False)
+        self.setUndoRedoEnabled(False)
+        self.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        self.setMaximumBlockCount(MAX_SCROLLBACK_BLOCKS)
+        self.setCursorWidth(8)
+
+        font = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
+        font.setStyleHint(QFont.StyleHint.Monospace)
+        self.setFont(font)
+
+        session.output.connect(self._append_output)
+
+    def _append_output(self, text: str) -> None:
+        self.moveCursor(self.textCursor().MoveOperation.End)
+        self.insertPlainText(render_output(text))
+        self.moveCursor(self.textCursor().MoveOperation.End)
+        bar = self.verticalScrollBar()
+        bar.setValue(bar.maximum())
+
+    # -- input (AC1) ------------------------------------------------------- #
+    def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802 - Qt override
+        data = key_to_bytes(event)
+        if data:
+            self._session.write(data)
+            event.accept()
+            return
+        # Bare modifier presses (no text) — swallow so nothing is edited locally.
+        event.accept()
+
+    # -- geometry (AC1) ---------------------------------------------------- #
+    def grid_size(self) -> tuple[int, int]:
+        """The current ``(cols, rows)`` the pane can show, from font metrics."""
+        fm = QFontMetrics(self.font())
+        char_w = fm.horizontalAdvance("M") or 1
+        line_h = fm.lineSpacing() or 1
+        vp = self.viewport()
+        cols = max(1, vp.width() // char_w)
+        rows = max(1, vp.height() // line_h)
+        return (cols, rows)
+
+    def resizeEvent(self, event) -> None:  # noqa: N802 - Qt override
+        super().resizeEvent(event)
+        cols, rows = self.grid_size()
+        self._session.resize(cols, rows)
+
+
+# --------------------------------------------------------------------------- #
+# The tab — a sub-tab per shell (PowerShell + WSL).
+# --------------------------------------------------------------------------- #
+
+
+class TerminalPage(QWidget):
+    """One shell's page: its :class:`PtySession` + :class:`TerminalView`.
+
+    The session is spawned lazily via :meth:`start` (idempotent), so opening the
+    cockpit doesn't launch every shell at once — a page starts when it is first
+    shown.
+    """
+
+    def __init__(
+        self,
+        shell: ShellSpec,
+        *,
+        spawn: Spawn = default_spawn,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.shell = shell
+        self.session = PtySession(shell.argv, spawn=spawn, parent=self)
+        self.view = TerminalView(self.session)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.view)
+        self.session.exited.connect(self._on_exited)
+
+    def start(self) -> None:
+        """Spawn the shell if it hasn't started yet, sized to the current view."""
+        if self.session.started:
+            return
+        cols, rows = self.view.grid_size()
+        self.session.resize(cols, rows)
+        self.session.start()
+
+    def _on_exited(self) -> None:
+        self.view.appendPlainText("\n[process exited]")
+
+    def close_session(self) -> None:
+        self.session.close()
+
+
+class TerminalTab(QWidget):
+    """The "Terminal" cockpit tab: a sub-tab per shell (AC1 Windows + AC2 WSL).
+
+    :param shells: the shells to offer (default :data:`DEFAULT_SHELLS`).
+    :param spawn: the pty spawn seam (default :func:`default_spawn`; a fake in tests
+        so CI never launches a real shell).
+    :param autostart: spawn the visible shell on construction and start each other
+        shell when its sub-tab is first selected (default True). Tests pass False to
+        stay fully hermetic and drive :meth:`TerminalPage.start` explicitly.
+    """
+
+    def __init__(
+        self,
+        *,
+        shells: Sequence[ShellSpec] = DEFAULT_SHELLS,
+        spawn: Spawn = default_spawn,
+        autostart: bool = True,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._autostart = autostart
+        self.pages: list[TerminalPage] = []
+
+        layout = QVBoxLayout(self)
+        note = QLabel(
+            "Plain interactive shells (ConPTY / WSL). No secrets are injected — "
+            "your PAT and runner.env are never read or echoed here."
+        )
+        note.setWordWrap(True)
+        layout.addWidget(note)
+
+        self.shell_tabs = QTabWidget()
+        for shell in shells:
+            page = TerminalPage(shell, spawn=spawn)
+            self.pages.append(page)
+            self.shell_tabs.addTab(page, shell.name)
+        layout.addWidget(self.shell_tabs, 1)
+
+        self.shell_tabs.currentChanged.connect(self._on_current_changed)
+        if autostart and self.pages:
+            self.pages[0].start()
+
+    def _on_current_changed(self, index: int) -> None:
+        if not self._autostart or not (0 <= index < len(self.pages)):
+            return
+        self.pages[index].start()
+
+    def page_for(self, name: str) -> TerminalPage | None:
+        """The page whose shell has this display name (or None)."""
+        for page in self.pages:
+            if page.shell.name == name:
+                return page
+        return None
+
+    def close_all(self) -> None:
+        for page in self.pages:
+            page.close_session()
+
+    def closeEvent(self, event) -> None:  # noqa: N802 - Qt override
+        self.close_all()
+        super().closeEvent(event)

--- a/tools/runner-ui/tests/test_app_smoke.py
+++ b/tools/runner-ui/tests/test_app_smoke.py
@@ -2,9 +2,10 @@
 
 Constructs the real QMainWindow under the offscreen Qt platform, asserts the
 three tabs are wired — the live "Runner fleet" fleet overview (#265), the live
-"Usage / cost" dashboard (#274), and the remaining "Terminal" TODO placeholder —
-then tears down, proving the app launches without a desktop session on the CI
-runner.
+"Usage / cost" dashboard (#274), and the live "Terminal" embedded terminal
+(#275) — then tears down, proving the app launches without a desktop session on
+the CI runner. The terminal is built with a fake pty spawn and autostart off, so
+the smoke test never launches a real shell.
 """
 
 from __future__ import annotations
@@ -14,21 +15,29 @@ import pytest
 from forge_cockpit.app import (
     COCKPIT_TABS,
     FLEET_TAB_TITLE,
+    TERMINAL_TAB_TITLE,
     USAGE_TAB_TITLE,
     WINDOW_TITLE,
     CockpitWindow,
 )
 from forge_cockpit.discovery import Fleet
 from forge_cockpit.fleet_view import FleetTab
+from forge_cockpit.terminal import TerminalTab
 from forge_cockpit.usage_view import UsageSnapshot, UsageTab
 
 #: Tab titles that are live panels (not TODO placeholders) — skipped by the
 #: placeholder assertion below.
-_LIVE_TITLES = {FLEET_TAB_TITLE, USAGE_TAB_TITLE}
+_LIVE_TITLES = {FLEET_TAB_TITLE, USAGE_TAB_TITLE, TERMINAL_TAB_TITLE}
+
+
+def _never_spawn(argv, cols, rows):
+    """A pty spawn seam that fails loudly — the smoke test must never spawn one."""
+    raise AssertionError(f"terminal spawned a real shell in the smoke test: {argv!r}")
 
 
 def _make_window() -> CockpitWindow:
-    """A fully hermetic cockpit window: no discovery, no transcript parse, no timers."""
+    """A fully hermetic cockpit window: no discovery, no transcript parse, no timers,
+    and no real shell (fake pty spawn + terminal autostart off)."""
     return CockpitWindow(
         fleet_discover=lambda: Fleet(runners=()),
         fleet_auto_refresh_ms=0,
@@ -36,6 +45,8 @@ def _make_window() -> CockpitWindow:
         usage_load=lambda: UsageSnapshot(),
         usage_auto_refresh_ms=0,
         usage_initial_refresh=False,
+        terminal_spawn=_never_spawn,
+        terminal_autostart=False,
     )
 
 
@@ -74,6 +85,17 @@ def test_usage_cost_tab_is_the_live_usage_view(app, qtbot):
     idx = next(i for i in range(window.tabs.count()) if window.tabs.tabText(i) == USAGE_TAB_TITLE)
     assert isinstance(window.tabs.widget(idx), UsageTab)
     assert window.usage_tab is window.tabs.widget(idx)
+
+
+def test_terminal_tab_is_the_live_terminal_view(app, qtbot):
+    window = _make_window()
+    qtbot.addWidget(window)
+
+    idx = next(
+        i for i in range(window.tabs.count()) if window.tabs.tabText(i) == TERMINAL_TAB_TITLE
+    )
+    assert isinstance(window.tabs.widget(idx), TerminalTab)
+    assert window.terminal_tab is window.tabs.widget(idx)
 
 
 def test_placeholder_tabs_keep_their_todo(app, qtbot):

--- a/tools/runner-ui/tests/test_terminal.py
+++ b/tools/runner-ui/tests/test_terminal.py
@@ -1,0 +1,331 @@
+"""Tests for the embedded pywinpty/ConPTY terminal (ticket #275).
+
+Hermetic + headless (offscreen): pywinpty is NEVER used — every session spawns
+through a fake pty (:class:`FakePty`) injected via the ``spawn`` seam, so no real
+shell is launched on the CI runner. The suite locks the ACs:
+
+* AC1 — a Windows PTY session spawns the expected shell (``powershell.exe``),
+  keystrokes are written to the pty, pty output is rendered into the view, and a
+  resize propagates the new ``(cols, rows)`` to the pty.
+* AC2 — a second session spawns ``wsl.exe``, reaching the WSL2 Linux side.
+* AC3 — the terminal injects NO secret: the real spawn seam passes ``env=None``
+  (nothing added to the child env), the module never references ``runner.env`` /
+  any PAT, and starting a session reads no such file.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QKeyEvent, QResizeEvent
+
+from forge_cockpit import terminal
+from forge_cockpit.terminal import (
+    WINDOWS_SHELL,
+    WSL_SHELL,
+    PtySession,
+    ShellSpec,
+    TerminalPage,
+    TerminalTab,
+    TerminalView,
+    key_to_bytes,
+    render_output,
+)
+
+
+@pytest.fixture
+def _app(qapp):
+    """Reuse pytest-qt's offscreen QApplication (conftest forces offscreen)."""
+    return qapp
+
+
+# --------------------------------------------------------------------------- #
+# A fake pty — records everything; never touches the OS.
+# --------------------------------------------------------------------------- #
+class FakePty:
+    """A stand-in for :class:`winpty.PtyProcess`.
+
+    ``read`` serves the queued ``chunks`` one at a time, then raises ``EOFError``
+    (as pywinpty does on close), which ends the reader thread cleanly. Writes and
+    resizes are recorded for assertions.
+    """
+
+    def __init__(self, chunks: Sequence[str] = ()) -> None:
+        self._chunks = list(chunks)
+        self.writes: list[str] = []
+        self.winsizes: list[tuple[int, int]] = []  # (rows, cols)
+        self.closed = False
+
+    def read(self, size: int) -> str:
+        if self._chunks:
+            return self._chunks.pop(0)
+        raise EOFError("pty closed")
+
+    def write(self, data: str) -> int:
+        self.writes.append(data)
+        return len(data)
+
+    def setwinsize(self, rows: int, cols: int) -> None:
+        self.winsizes.append((rows, cols))
+
+    def isalive(self) -> bool:
+        return not self.closed
+
+    def close(self, force: bool = False) -> None:
+        self.closed = True
+
+
+class RecordingSpawn:
+    """A spawn seam that records each call and returns a pre-seeded :class:`FakePty`."""
+
+    def __init__(self, *, chunks: Sequence[str] = ()) -> None:
+        self._chunks = chunks
+        self.calls: list[tuple[tuple[str, ...], int, int]] = []
+        self.ptys: list[FakePty] = []
+
+    def __call__(self, argv: Sequence[str], cols: int, rows: int) -> FakePty:
+        self.calls.append((tuple(argv), cols, rows))
+        pty = FakePty(self._chunks)
+        self.ptys.append(pty)
+        return pty
+
+
+def _press(key: Qt.Key, text: str = "") -> QKeyEvent:
+    return QKeyEvent(QKeyEvent.Type.KeyPress, key, Qt.KeyboardModifier.NoModifier, text)
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — Windows session spawns the expected shell.
+# --------------------------------------------------------------------------- #
+def test_windows_session_spawns_powershell(_app):
+    spawn = RecordingSpawn()
+    session = PtySession(WINDOWS_SHELL, spawn=spawn, cols=100, rows=30)
+    session.start()
+
+    assert len(spawn.calls) == 1
+    argv, cols, rows = spawn.calls[0]
+    assert argv[0] == "powershell.exe"
+    assert (cols, rows) == (100, 30)
+    session.close()
+
+
+def test_default_shells_offer_windows_then_wsl():
+    tab_shells = terminal.DEFAULT_SHELLS
+    assert tab_shells[0].argv == WINDOWS_SHELL
+    assert tab_shells[0].argv[0] == "powershell.exe"
+    assert WSL_SHELL[0] == "wsl.exe"
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — keystrokes are written to the pty.
+# --------------------------------------------------------------------------- #
+def test_keystrokes_are_written_to_the_pty(_app):
+    spawn = RecordingSpawn()
+    session = PtySession(WINDOWS_SHELL, spawn=spawn)
+    session.start()
+    pty = spawn.ptys[0]
+
+    session.write("l")
+    session.write("s")
+    session.write("\r")
+
+    assert pty.writes == ["l", "s", "\r"]
+    session.close()
+
+
+def test_view_keypress_writes_to_the_pty(_app, qtbot):
+    spawn = RecordingSpawn()
+    session = PtySession(WSL_SHELL, spawn=spawn)
+    view = TerminalView(session)
+    qtbot.addWidget(view)
+    session.start()
+    pty = spawn.ptys[0]
+
+    view.keyPressEvent(_press(Qt.Key.Key_A, "a"))
+    view.keyPressEvent(_press(Qt.Key.Key_Return))
+
+    assert "a" in pty.writes
+    assert "\r" in pty.writes  # Enter maps to CR (AC1 input)
+    session.close()
+
+
+def test_key_to_bytes_maps_special_keys():
+    assert key_to_bytes(_press(Qt.Key.Key_Return)) == "\r"
+    assert key_to_bytes(_press(Qt.Key.Key_Backspace)) == "\x7f"
+    assert key_to_bytes(_press(Qt.Key.Key_Up)) == "\x1b[A"
+    assert key_to_bytes(_press(Qt.Key.Key_Left)) == "\x1b[D"
+    assert key_to_bytes(_press(Qt.Key.Key_X, "x")) == "x"
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — pty output is rendered into the view (off the GUI thread).
+# --------------------------------------------------------------------------- #
+def test_pty_output_is_rendered_into_the_view(_app, qtbot):
+    spawn = RecordingSpawn(chunks=["hello ", "world\n"])
+    session = PtySession(WINDOWS_SHELL, spawn=spawn)
+    view = TerminalView(session)
+    qtbot.addWidget(view)
+
+    # The reader thread emits `output` (queued) for each chunk; wait for both.
+    with qtbot.waitSignal(session.exited, timeout=5000):
+        session.start()
+
+    assert "hello world" in view.toPlainText()
+    session.close()
+
+
+def test_render_output_strips_ansi_and_normalises_newlines():
+    raw = "\x1b[32mgreen\x1b[0m\r\nline2\r\n"
+    rendered = render_output(raw)
+    assert "green" in rendered
+    assert "\x1b" not in rendered  # colour codes stripped
+    assert "\r" not in rendered  # CRLF normalised to LF
+    assert rendered.count("\n") == 2
+
+
+def test_render_output_applies_backspace():
+    assert render_output("abc\b\bZ") == "aZ"
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — resize propagates new (cols, rows) to the pty.
+# --------------------------------------------------------------------------- #
+def test_resize_propagates_cols_and_rows_to_the_pty(_app):
+    spawn = RecordingSpawn()
+    session = PtySession(WINDOWS_SHELL, spawn=spawn)
+    session.start()
+    pty = spawn.ptys[0]
+
+    session.resize(cols=120, rows=40)
+
+    assert pty.winsizes[-1] == (40, 120)  # setwinsize(rows, cols) — AC1 resize
+    assert session.size == (120, 40)
+    session.close()
+
+
+def test_view_resize_event_propagates_to_the_pty(_app, qtbot):
+    spawn = RecordingSpawn()
+    session = PtySession(WSL_SHELL, spawn=spawn)
+    view = TerminalView(session)
+    qtbot.addWidget(view)
+    session.start()
+    pty = spawn.ptys[0]
+
+    # Drive the override directly (a hidden offscreen widget won't emit a live
+    # resizeEvent) — this is the exact path Qt calls when the pane is resized.
+    view.resizeEvent(QResizeEvent(QSize(640, 480), QSize(0, 0)))
+
+    assert pty.winsizes, "a widget resize must propagate a winsize to the pty"
+    rows, cols = pty.winsizes[-1]
+    assert rows >= 1 and cols >= 1
+    session.close()
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — a second session reaches the WSL2 Linux side (wsl.exe).
+# --------------------------------------------------------------------------- #
+def test_wsl_session_spawns_wsl_exe(_app):
+    spawn = RecordingSpawn()
+    session = PtySession(WSL_SHELL, spawn=spawn)
+    session.start()
+
+    argv, _cols, _rows = spawn.calls[0]
+    assert argv[0] == "wsl.exe"
+    session.close()
+
+
+def test_terminal_tab_wires_windows_and_wsl_pages(_app, qtbot):
+    spawn = RecordingSpawn()
+    tab = TerminalTab(spawn=spawn, autostart=False)
+    qtbot.addWidget(tab)
+
+    names = [tab.shell_tabs.tabText(i) for i in range(tab.shell_tabs.count())]
+    assert names == ["PowerShell", "WSL (Linux)"]
+
+    # Starting each page spawns exactly its own shell (AC1 + AC2).
+    tab.page_for("PowerShell").start()
+    tab.page_for("WSL (Linux)").start()
+    spawned = [call[0][0] for call in spawn.calls]
+    assert "powershell.exe" in spawned
+    assert "wsl.exe" in spawned
+    tab.close_all()
+
+
+def test_terminal_tab_autostart_starts_only_the_first_shell(_app, qtbot):
+    spawn = RecordingSpawn()
+    tab = TerminalTab(spawn=spawn, autostart=True)
+    qtbot.addWidget(tab)
+
+    # Autostart spawns just the visible (Windows) shell, not WSL (lazy per-tab).
+    assert len(spawn.calls) == 1
+    assert spawn.calls[0][0][0] == "powershell.exe"
+
+    # Selecting the WSL sub-tab starts it on demand.
+    tab.shell_tabs.setCurrentIndex(1)
+    assert any(call[0][0] == "wsl.exe" for call in spawn.calls)
+    tab.close_all()
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — no secret / PAT injected; runner.env is never read.
+# --------------------------------------------------------------------------- #
+def test_default_spawn_injects_no_env(monkeypatch):
+    """The real spawn seam passes env=None: nothing (no PAT) is added to the child."""
+    captured: dict[str, object] = {}
+
+    class _FakePtyProcess:
+        @staticmethod
+        def spawn(argv, dimensions=None, env="__unset__"):
+            captured["argv"] = argv
+            captured["dimensions"] = dimensions
+            captured["env"] = env
+            return FakePty()
+
+    import sys
+    import types
+
+    fake_winpty = types.ModuleType("winpty")
+    fake_winpty.PtyProcess = _FakePtyProcess
+    monkeypatch.setitem(sys.modules, "winpty", fake_winpty)
+
+    terminal.default_spawn(["powershell.exe"], cols=80, rows=24)
+
+    assert captured["env"] is None  # AC3: no env injected — no PAT set into the child
+    assert captured["dimensions"] == (24, 80)  # (rows, cols)
+
+
+def test_starting_a_session_opens_no_files(_app, monkeypatch):
+    """AC3: spawning a session reads no file (so runner.env can't be read)."""
+    import builtins
+
+    opened: list[object] = []
+    real_open = builtins.open
+
+    def _tracking_open(file, *args, **kwargs):
+        opened.append(file)
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _tracking_open)
+
+    spawn = RecordingSpawn()
+    session = PtySession(WINDOWS_SHELL, spawn=spawn)
+    session.start()
+    session.write("echo hi\r")
+    session.close()
+
+    assert opened == []  # nothing on disk was read to start the shell
+
+
+def test_pages_do_not_start_until_asked(_app, qtbot):
+    spawn = RecordingSpawn()
+    page = TerminalPage(ShellSpec("PowerShell", WINDOWS_SHELL), spawn=spawn)
+    qtbot.addWidget(page)
+
+    assert spawn.calls == []  # constructing a page spawns nothing
+    page.start()
+    assert len(spawn.calls) == 1
+    page.start()  # idempotent
+    assert len(spawn.calls) == 1
+    page.close_session()


### PR DESCRIPTION
Closes #275

Lands the final Wave-3 panel of the ADR-0006 cockpit (epic #262): a **real** embedded terminal backed by pywinpty/ConPTY, with both runner OS contexts reachable from one window.

## What
- `forge_cockpit/terminal.py`:
  - **`PtySession`** — a ConPTY pty process + a daemon **reader thread** that blocks on `pty.read` and marshals output to the GUI thread via a queued Qt signal (GUI never blocks on I/O). `write()` forwards keystrokes; `resize()` propagates `setwinsize(rows, cols)`.
  - **`TerminalView`** — a monospaced `QPlainTextEdit` that renders pty output (pragmatic ANSI strip + newline/backspace handling — not a full VT100), captures keystrokes and writes them to the pty, and translates widget resizes to a pty winsize.
  - **`TerminalTab`** — a sub-tab per shell: **PowerShell** (AC1) and **`wsl.exe`** WSL session (AC2), each spawned lazily when its sub-tab is first shown.
- `app.py` — the live `TerminalTab` replaces the old "Terminal" TODO placeholder, with an injectable `spawn` seam + `autostart` flag so the shell stays hermetic in tests.

## AC coverage
- **AC1** — embedded real ConPTY terminal running a Windows shell (PowerShell), with working input/output + resize. ✔
- **AC2** — a second session targets WSL2 via `wsl.exe`. ✔
- **AC3** — plain interactive shell: `env=None` (no PAT injected into the child), **never reads `~/.forge/runner.env`**, no pre-typed input, no echoed token — the module has no notion of a PAT. ✔

## Verification (honest note)
- `cd tools/runner-ui; $env:QT_QPA_PLATFORM='offscreen'; uv run pytest` → **183 passed** locally (same as the `cockpit-python` self-hosted Windows CI job).
- Tests **mock pywinpty** via a fake pty `spawn` seam — **no real shell is launched in CI**. They cover: PowerShell spawn + geometry (AC1), keystroke→pty write incl. the view's `keyPressEvent` (AC1), pty output rendered into the view off the GUI thread (AC1), resize→`setwinsize(rows, cols)` (AC1), `wsl.exe` session (AC2), `default_spawn` passing `env=None` and starting a session opening **no files** (AC3).
- **What the offscreen tests do NOT cover** (needs a real Windows desktop): actual ConPTY byte round-trip against a live `powershell.exe`/`wsl.exe`, real ANSI-heavy rendering, and interactive resize reflow. These require a desktop session and are out of scope for headless CI.
- No dependency added (`pywinpty` already present) — `uv.lock` unchanged, `uv sync --frozen` passes. verify.yml untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
