### PR TITLE
docs(cross-gai): agy guide + parity matrix + README multi-host (#291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # forge
 
-> A portable AI development platform that runs inside Claude Code — turning a backlog into merged, reviewed, gated pull requests.
+> A portable AI development platform that runs inside Claude Code — and now on Antigravity (`agy`) — turning a backlog into merged, reviewed, gated pull requests.
 
 [![verify](https://github.com/dngioidev/forge/actions/workflows/verify.yml/badge.svg)](https://github.com/dngioidev/forge/actions/workflows/verify.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -41,6 +41,25 @@ forge is a plugin for [Claude Code](https://docs.claude.com/en/docs/claude-code)
 - **Mechanical ship gates** — AC mapping, plan-drift, doc-sync, test-intent, and a reviewer + security pass — enforced as scripts, not opinions.
 - **Learning loop + graph RAG** — a distill flow that turns journal evidence into approved lessons, and a SQLite/ts-morph structural index (`graph-rag`) that answers reuse and blast-radius questions before new code is written.
 
+## Runs on your host (Claude Code + Antigravity)
+
+forge's engine — board automation, the seven gates, graph RAG, the safety
+denylist, and the journal-capture learning loop — is host-agnostic Node, so the
+same plugin runs on more than one GAI host. **Claude Code** is the primary host.
+**Antigravity (`agy`)** is proven today: `forge init --host agy` emits a native
+agy plugin package (co-located `plugin.json`, generated `mcp_config.json` +
+`hooks.json`, and the deny/capture I/O shims) that `agy plugin install` ingests
+with zero conversion. Everything load-bearing reaches full parity on agy. **Codex
+is deferred** ([#292](https://github.com/dngioidev/forge/issues/292)) and not yet
+built. See the **[cross-GAI guide](docs/guides/cross-gai.md)** for the end-to-end
+agy flow and the honest capability/parity matrix.
+
+**Auto-merge is Claude-only, by policy.** On non-Claude hosts forge computes the
+merge bar but stops at an open, green PR / awaiting-human — it does not run an
+unattended `gh pr merge`. The live merge stays on Claude Code, where the full
+auto-safety stack is proven. This is a deliberate policy line, not an engine
+limit ([ADR-0007](docs/decisions/0007-cross-gai-mcp-first.md)).
+
 ## The pipeline builds itself
 
 forge is built *by its own pipeline*. Every feature here was ticketed, planned, gated, trailed, and merged through the same skills it ships — so the README, the gates, and the roster you're reading about are also the ones that produced this repo.
@@ -49,12 +68,13 @@ forge is built *by its own pipeline*. Every feature here was ticketed, planned, 
 
 - **[Install guide](docs/guides/install.md)** — prerequisites, adopt-vs-create, per-feature wiring, troubleshooting.
 - **[Handbook](docs/guides/handbook.md)** — daily use: every flow, every gate, and exactly where the human is needed.
+- **[Cross-GAI guide](docs/guides/cross-gai.md)** — running forge on Antigravity (`agy`): the emit flow, plugin layout, hooks/MCP wiring, gotchas, and the capability/parity matrix.
 - **[Docs route index](docs/README.md)** — every spec, plan, ADR, and guide, one line each.
 - **[Platform design spec](docs/specs/2026-07-15-forge-platform-design.md)** — the whole design in one document.
 
 ## Laws worth knowing before you disagree with a gate
 
-Ticket-first, always — silent side-work is forbidden. The owner merges every PR. Situations (incident, security-response) change what's *allowed*, not what's suggested. Gates are mechanical scripts — run them, don't argue with them. `"Unknown" is a valid answer.`
+Ticket-first, always — silent side-work is forbidden. The owner merges every PR — and unattended auto-merge is Claude-only by policy; other hosts stop at a green PR. Situations (incident, security-response) change what's *allowed*, not what's suggested. Gates are mechanical scripts — run them, don't argue with them. `"Unknown" is a valid answer.`
 
 ## Contributing & community
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,10 +35,12 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [C7 — Alerts](plans/2026-07-19-c7-alerts.md) — alerts on session/queue events.
 - [C8 — Quota panel](plans/2026-07-19-c8-quota-panel.md) — Claude Code quota panel in the console.
 - [Batch close](plans/2026-07-20-batch-close.md) — tasks for #123: comma-separated `--issue` in `board/close.mjs`.
+- [#289 — agy init emit](plans/2026-07-26-289-agy-init-emit.md) — tasks for #289 (ADR-0007 AC3): `forge init --host agy` emits the proven agy plugin package (co-located `plugin.json`, generated `mcp_config.json` + `hooks.json`, deny/capture shims, short-path staging).
 
 ## Spikes
 
 - [Plugin capabilities](spikes/2026-07-21-plugin-capabilities.md) — research on the full Claude Code plugin surface vs. forge's usage; the tiered enhancement plan behind epic #148 (monitors, bin/, themes, LSP, manifest, `${CLAUDE_PLUGIN_DATA}`).
+- [forge self-audit](spikes/2026-07-21-forge-self-audit.md) — whole-plugin self-audit at v0.15.0: findings across skills, gates, board, and hooks.
 
 ## Design specs
 
@@ -50,12 +52,16 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [ADR-0002 — Console/control distribution](decisions/0002-console-control-distribution.md) — *(superseded by ADR-0003)* the console + control plane ship as repo tooling run from a checkout, not in the packaged plugin (#91).
 - [ADR-0003 — Remove forge-control + console](decisions/0003-remove-control-console.md) — the local control plane + console are removed (unused for a solo interactive workflow; token/scope reduction). Preserved in the v0.5.0 tag; the pipeline (skills/board/gates/care) is unaffected (#95).
 - [ADR-0004 — Remove the multi-backend plane](decisions/0004-remove-multi-backend-plane.md) — the CLI role-swap / multi-backend plane (Plane B) is removed as unwired dead weight; role subagents stay Claude-native. Preserved in the v0.5.0 tag (#99).
+- [ADR-0005 — Local self-hosted runner](decisions/0005-local-self-hosted-runner.md) — PAT/secret model, sharing path, isolation, OS coverage, and advanced-CI decisions for the local self-hosted runner (epic #180).
 - [ADR-0006 — Runner fleet cockpit](decisions/0006-runner-ui.md) — a native PySide6 (Qt) desktop "cockpit" for the local self-hosted runner fleet: Python 3.12 + `uv`, shell-out-only + WSL2 interop, PAT-free read-only default, in-repo at `tools/runner-ui/` (epic #262).
+- [ADR-0007 — Cross-GAI: MCP-first core + host adapters](decisions/0007-cross-gai-mcp-first.md) — invert forge into a host-agnostic engine + per-host adapter emission; full parity on Antigravity (`agy`, proven), auto-merge Claude-only by policy, Codex deferred to #292 (epic #174).
+- [ADR-0007 agy-adapter reference](decisions/0007-agy-adapter/README.md) — the verified-working spike output (`mcp_config.json`, `hooks.json`, deny/capture shims) that `forge init --host agy` productizes (#174).
 
 ## Guides
 
 - [Install](guides/install.md) — forge into any project: prerequisites, marketplace install, init adopt-vs-create, doctor, per-feature wiring, superpowers migration.
 - [Handbook](guides/handbook.md) — daily use: the laws, the cockpit, the Build loop, every human interaction point, care/knowledge/scale flows, gates + situations tables.
+- [Cross-GAI (agy)](guides/cross-gai.md) — run forge on Antigravity: `forge init --host agy` emit flow, plugin layout, MCP/hooks wiring, the deny/capture shims, Windows gotchas (MAX_PATH), and the honest capability/parity matrix.
 - [Troubleshooting](guides/troubleshooting.md) — known issues: update-not-visible ladder, statusline wiring overwrites, board drift, hooks, environment.
 - [Runner adoption](guides/runner-adoption.md) — give a private repo free CI on a local self-hosted runner: adopt (new + existing), per-OS host setup, the cockpit, the manual service runbook, and a known-issues table.
 - [Runner cockpit](../tools/runner-ui/README.md) — the native PySide6 desktop app (`tools/runner-ui/`) that manages the runner fleet: install (Python 3.12 + `uv`), `uv run forge-cockpit`, fleet view / control / logs / install (ADR-0006).
@@ -65,6 +71,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 ## Security
 
 - [OSS CI & repo hardening](security/oss-ci-hardening.md) — #214: fork-PR safety analysis of `verify.yml` (pwn-request class), self-hosted-runner private-only guard (#180), and the owner runbook to apply branch protection + Dependabot + secret scanning/push protection + private vuln reporting at the public flip (epic #209).
+- [OSS secret scan](security/oss-secret-scan.md) — #210: full-history secret & credential scan of the repo before the public flip.
 
 ## Feedback
 

--- a/docs/guides/cross-gai.md
+++ b/docs/guides/cross-gai.md
@@ -1,0 +1,332 @@
+# Cross-GAI guide: running forge on Antigravity (agy)
+
+forge was built as a Claude Code plugin, but its engine is host-agnostic: the
+board automation, the seven mechanical gates, the graph-RAG index, the safety
+denylist, and the journal-capture learning loop are all plain Node CLIs and
+hook scripts that depend only on `node`, `gh`, `git`, and `.claude/forge.json`.
+[ADR-0007](../decisions/0007-cross-gai-mcp-first.md) inverts the architecture
+into an MCP-first core plus per-host adapter emission so the same plugin runs on
+other GAI (generative-AI dev) hosts.
+
+This guide documents the one host that is **proven today**: Antigravity, driven
+by its `agy` CLI. It was verified end-to-end against live `agy` v1.1.5 on
+2026-07-26 (see ADR-0007, "Spike verification on real agy"). Codex is a
+separate, **deferred** adapter tracked in [#292](https://github.com/dngioidev/forge/issues/292)
+and is **not built** — do not expect it to work yet.
+
+For the honest capability differences between hosts, see the
+[capability / parity matrix](#capability--parity-matrix) at the end of this
+guide.
+
+---
+
+## Prerequisites
+
+| need | check | notes |
+| --- | --- | --- |
+| Antigravity `agy` CLI | `agy --version` | proven on v1.1.5; the plugin system ingests the Claude plugin format directly |
+| Node >= 22.13 | `node --version` | the whole engine runs on Node; the hook shims are ESM |
+| git + `gh` (authenticated) | `git --version`, `gh auth status` | needed by the board/gate/release CLIs, not by the emit step itself |
+| a forge checkout | — | you run `forge init --host agy` from the forge plugin source |
+
+The emit step (`forge init --host agy`) needs only `node` — it writes files and
+does not touch `gh` or the board. `gh`/`git` are needed once you actually drive
+forge inside an agy session (board moves, gates, release readiness).
+
+---
+
+## Step 1 — emit the agy plugin package
+
+From a forge checkout, run the host-emit mode of `init`:
+
+```
+node plugin/scripts/init.mjs --host agy --out C:\agy\forge
+```
+
+- `--host agy` is the only supported host today. Any other value is refused with
+  a message pointing at #292 (Codex deferred).
+- `--out <dir>` sets where the package is staged. If omitted, it defaults to
+  `.agents/plugins/forge/` under the current directory.
+- **Use a short `--out` path.** `agy plugin install` hit Windows `MAX_PATH`
+  (260-char) failures when the source sat under a long temp path during the
+  spike. The emitter itself is long-path aware (it prefixes `\\?\` on win32), but
+  staging at a short path such as `C:\agy\forge` avoids the class of problem
+  entirely. This is the single biggest Windows gotcha.
+
+The emitter is safe to re-run: it fully manages its own output directory and does
+a clean re-emit each run, but it **refuses** to write into a filesystem root, the
+current working directory or any ancestor of it, a directory that contains the
+forge source, or any non-empty directory that does not already carry a forge
+`plugin.json` marker (`{"name":"forge"}`). This blast-radius guard means a
+mistyped `--out .` cannot delete your working tree.
+
+### What gets emitted (the plugin layout)
+
+agy needs `plugin.json` **co-located** with the component directories — unlike
+the Claude layout, which splits `plugin.json` into `.claude-plugin/`. The
+emitted package looks like this:
+
+```
+C:\agy\forge\
+  plugin.json          <- co-located marker: { "name": "forge", ... } ($schema + mcpServers stripped)
+  mcp_config.json      <- GENERATED: agy reads MCP servers from HERE, not plugin.json
+  hooks.json           <- GENERATED: agy named-hook schema (see below)
+  skills/              <- copied verbatim; agy ingests natively (20 skills)
+  agents/              <- copied verbatim; agy ingests natively (12 role cards)
+  commands/            <- copied verbatim; agy auto-converts these to skills
+  mcp/                 <- forge-graph server (+ forge-core when built)
+  hooks/               <- denylist.mjs, capture.mjs, and the agy-deny / agy-capture shims
+  scripts/             <- the `forge <area> <cmd>` shell tier the skills call
+  bin/                 <- the forge dispatcher
+```
+
+Three things are agy-specific and **generated** (not copied), with paths
+computed from the resolved `--out` directory — never hardcoded to one install:
+
+1. **`plugin.json`** — the co-located marker. The emitter strips the Claude-only
+   `$schema` and `mcpServers` keys agy ignores.
+2. **`mcp_config.json`** — the MCP registration (see Step 2).
+3. **`hooks.json`** — the hook registration (see Step 3).
+
+Note the copied `hooks/` tree also carries the original Claude-format
+`hooks/hooks.json` (Claude's `"hooks"` wrapper, `"Bash"` matcher). agy ignores it
+and reads the **plugin-root** `hooks.json` generated above; if you hand-edit
+hooks for agy, edit the root file, not `hooks/hooks.json`.
+
+The `skills/`, `agents/`, and `commands/` trees are copied byte-for-byte. agy
+imports them with **zero conversion code** and auto-converts slash commands to
+skills. `mcp/`, `hooks/`, `scripts/`, and `bin/` are copied so the paths the
+configs and skills reference physically exist inside the package.
+
+---
+
+## Step 2 — MCP registration (`mcp_config.json`)
+
+**agy does NOT read the `mcpServers` key from `plugin.json`.** During the spike,
+`agy plugin validate` reported `mcpServers: skipped (not found)` when the servers
+were declared only in `plugin.json`. agy reads a sibling plugin-root
+**`mcp_config.json`** — same content as Claude's inline block, different file:
+
+```json
+{
+  "mcpServers": {
+    "forge-graph": {
+      "command": "node",
+      "args": ["C:/agy/forge/mcp/graph/server.mjs"]
+    },
+    "forge-core": {
+      "command": "node",
+      "args": ["C:/agy/forge/mcp/forge/server.mjs"]
+    }
+  }
+}
+```
+
+- Paths are computed from the resolved `--out` dir and written with forward
+  slashes (safe on Windows, and agy's env-expansion is buggy so absolute literal
+  paths are used).
+- `forge-graph` is always registered. `forge-core` (the 9-tool board/gate/
+  autopilot server from [#288](https://github.com/dngioidev/forge/issues/288)) is
+  registered **only when its server file exists** in the source — the emitter
+  guards on `mcp/forge/server.mjs` being present. Since #288 merged, a fresh emit
+  registers both.
+- Note that agy's plugin MCP config has **no `httpUrl` / `timeout`** support and
+  buggy env-expansion; both forge servers are plain stdio (`command`/`args`),
+  which sidesteps this.
+
+MCP is a **structured-return enhancement**, not a hard requirement on agy. agy's
+agent has a `run_command` tool, so the entire `forge <area> <cmd>` shell tier
+runs on agy without MCP at all. `forge-core` exists so board/gate/autopilot
+branching gets typed returns (pass/fail, the merge-bar vector) instead of
+stdout-scraping.
+
+---
+
+## Step 3 — hooks (`hooks.json` + the deny/capture shims)
+
+agy reads a plugin-root **`hooks.json`** and auto-wires it when the plugin is
+enabled. Its schema differs from Claude's in three ways that matter:
+
+- Top-level keys are **hook names** (`forge-safety`, `forge-capture`), not
+  Claude's `"hooks"` wrapper.
+- The matcher is on the tool name **`run_command`** — not Claude's `"Bash"`.
+- The command line is read from `toolCall.args.CommandLine` (camelCase JSON on
+  stdin).
+
+The generated file:
+
+```json
+{
+  "forge-safety": {
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          { "type": "command", "command": "node \"C:/agy/forge/hooks/agy-deny.mjs\"", "timeout": 10 }
+        ]
+      }
+    ]
+  },
+  "forge-capture": {
+    "PostToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          { "type": "command", "command": "node \"C:/agy/forge/hooks/agy-capture.mjs\"", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### The host-mode I/O shims
+
+forge's denylist and capture **rules** live in one place
+(`hooks/denylist.mjs`, `hooks/capture.mjs`); only the host I/O contract differs.
+agy reads a **different decision shape** than Claude — Claude uses
+`permissionDecision` / exit-2, agy expects a JSON decision object on stdout — so
+the emitted package includes two thin shims:
+
+- **`hooks/agy-deny.mjs`** (PreToolUse) — reads agy's stdin
+  (`toolCall.args.CommandLine`), calls forge's host-agnostic `check()` from
+  `denylist.mjs`, and emits agy's decision shape:
+  `{ "decision": "deny", "reason": "..." }` on a block, `{ "decision": "allow" }`
+  otherwise. It **fails open** (allow) on any internal error — a safety hook must
+  never wedge the loop.
+- **`hooks/agy-capture.mjs`** (PostToolUse) — appends a **metadata-only** journal
+  line (timestamp, host, step index, a bounded error string — never raw command
+  output) to `<workspace>/.forge/agy-journal.jsonl`, then emits `{}`. It is
+  self-contained because agy does not copy the plugin's `scripts/` tree into the
+  hook's reach.
+
+**The denylist self-exec-guard naming constraint.** The deny shim must **not** be
+named `*denylist.mjs`. `denylist.mjs` self-executes when it is the entry point;
+the original guard `/denylist\.mjs$/` was **unanchored**, so importing `check()`
+from a file whose name ended in `denylist.mjs` would re-fire `main()` and consume
+its stdin. AC-289.3 anchored the guard to the basename
+(`/(^|[\\/])denylist\.mjs$/`), but the shim is deliberately kept named
+`agy-deny.mjs` as belt-and-braces so `check()` can be imported with zero side
+effects.
+
+---
+
+## Step 4 — install and validate with agy
+
+Install the emitted package as an agy plugin (or discover it under
+`.agents/plugins/forge/` / `~/.gemini/config/plugins/forge/`):
+
+```
+agy plugin install "C:\agy\forge"
+agy plugin validate forge
+agy plugin list
+```
+
+When enabled, agy **auto-wires** the MCP servers (from `mcp_config.json`) and the
+hooks (from `hooks.json`) — there is no manual registration step.
+
+### The green `agy plugin validate` output shape
+
+The spike proved this exact shape on live agy v1.1.5 (installed into
+`~/.gemini/config/plugins/forge/`), all five component types green:
+
+```
+skills      : 20 processed
+agents      : 12 processed
+commands    :  8 processed (converted to skills)
+mcpServers  :  1 processed   (forge-graph, via mcp_config.json)
+hooks       :  2 processed   (deny + capture, via hooks.json)
+```
+
+`agy plugin list` then showed forge installed, source `antigravity`, 40
+components.
+
+The spike ran **before** `forge-core` existed ([#288](https://github.com/dngioidev/forge/issues/288)),
+so it registered one MCP server. A fresh emit today registers **both**
+`forge-graph` and `forge-core` (confirmed in the generated `mcp_config.json`), so
+`mcpServers` would validate as **2 processed**. Everything else is unchanged.
+
+The deny shim was exercised directly with agy-shaped payloads and behaved as
+designed:
+
+```
+git push --force ...   ->  {"decision":"deny"}
+rm -rf <repo>          ->  {"decision":"deny"}
+npm test               ->  {"decision":"allow"}
+```
+
+Capture returned `{}`. (During the spike, forge's own Claude denylist even
+blocked one of the operator's `rm -rf` commands mid-run — the rules are real, not
+theoretical.)
+
+---
+
+## Gotchas summary (Windows-first)
+
+| gotcha | what to do |
+| --- | --- |
+| **MAX_PATH (260)** on `agy plugin install` from a long source path | stage/emit at a **short** `--out` path (e.g. `C:\agy\forge`); the emitter is also `\\?\`-prefix aware |
+| agy reads MCP from **`mcp_config.json`**, not `plugin.json`'s `mcpServers` | rely on the generated `mcp_config.json`; do not expect `plugin.json` MCP to load |
+| agy hooks use matcher **`run_command`**, not Claude's `"Bash"` | the generated `hooks.json` already targets `run_command`; the command line is at `toolCall.args.CommandLine` |
+| agy decision shape differs from Claude (`decision` object vs `permissionDecision`/exit-2) | the `agy-deny` / `agy-capture` shims translate the I/O; the rules stay in `denylist.mjs`/`capture.mjs` |
+| deny shim naming | never name it `*denylist.mjs`; keep `agy-deny.mjs` so `check()` imports without re-firing the self-exec guard |
+| `plugin.json` placement | agy needs it **co-located** with the component dirs, not under `.claude-plugin/` |
+| no unattended auto-merge on agy | by owner policy (below) forge stops at an open, green PR / awaiting-human on non-Claude hosts |
+
+---
+
+## Capability / parity matrix
+
+This is the honest matrix from [ADR-0007 §(d)](../decisions/0007-cross-gai-mcp-first.md).
+Full = works as on Claude; Near = model-driven equivalent; Partial = reduced /
+manual; Lost = unavailable. Codex is included as the ADR's researched target but
+is **deferred and unbuilt** ([#292](https://github.com/dngioidev/forge/issues/292)) —
+only the Claude and Antigravity columns are proven.
+
+| Capability | Claude Code | Codex (deferred, #292) | Antigravity / agy (proven) |
+| --- | --- | --- | --- |
+| Board law (create/move/comment/escalate) | Full | Full (MCP+shell) | **Full** (MCP+shell) |
+| Mechanical gates (7) | Full | Full (MCP) | **Full** (MCP) |
+| Graph RAG | Full | Full (register server) | **Full** (register server) |
+| Release readiness + cut | Full | Full | **Full** |
+| Safety denylist (block force-push/hard-reset) | Full | Full (PreToolUse deny hook) | **Full** (PreToolUse deny) |
+| Journal capture (learning loop) | Full | Full (PostToolUse hook) | **Full** (PostToolUse) |
+| Parallel subagent fan-out | Full | Full (native subagents, <=6) | **Full** (subagents / Agent Manager) |
+| Slash-command UX | Full | Full (prompts/Skills) | **Full** (auto-converted to skills) |
+| Pipeline / deliver (spec->plan->execute->ship) | Full (auto) | Near (model orchestrates) | **Near** (model orchestrates) |
+| Skill auto-invocation | Full (runtime trigger) | Near (model-driven) | **Near** (model-driven) |
+| Autopilot unattended auto-merge on green | Full | Stops at green PR (policy) | **Stops at green PR** (policy) |
+| Background monitors (ci-watch/decisions-watch) | Full | Partial (session events / cron) | **Partial** |
+| Statusline | Full | Lost (no API) | **Lost** (no API) |
+
+### What actually differs, honestly
+
+Everything **load-bearing** reaches Full parity on agy: board law, all seven
+gates, graph RAG, release readiness, the safety denylist, journal capture,
+parallel subagent fan-out, and slash-command UX. The only differences are:
+
+1. **Auto-merge is deliberately Claude-only** — a policy line, not an engine
+   limit. `autopilot_merge_bar` computes the merge decision on every host (a host
+   can see whether the bar is green), but forge does **not** wire an unattended
+   `gh pr merge` action on non-Claude hosts. On agy, forge stops at an open,
+   green PR / awaiting-human. The live merge stays where the full auto-safety
+   stack (denylist hook + merge-authority grant) is proven.
+2. **The pipeline / skill auto-flow is model-driven, not runtime-triggered.** On
+   Claude a runtime trigger fires the skill; on agy the model invokes it because
+   the instructions tell it to. Same capability, near-identical in practice for
+   an agent following its instructions file.
+3. **Background monitors degrade** to session events / cron where a persistent
+   watcher API is not available.
+4. **The statusline is cosmetic and Claude-only** — no host exposes a statusline
+   API. Nothing load-bearing depends on it.
+
+---
+
+## References
+
+- [ADR-0007 — Cross-GAI forge](../decisions/0007-cross-gai-mcp-first.md) — the
+  design, the full parity matrix (§d), and the live agy verification.
+- [0007-agy-adapter reference](../decisions/0007-agy-adapter/README.md) — the
+  verified-working spike output the emitter productizes.
+- `plugin/scripts/agy/emit.mjs` — the `forge init --host agy` emitter (#289).
+- `plugin/mcp/forge/server.mjs` — the `forge-core` MCP server, 9 tools (#288).


### PR DESCRIPTION
@
Closes #291 (AC5 of epic #174, ADR-0007).

## What
Docs so an adopter can install and run forge on Antigravity (`agy`).

- **`docs/guides/cross-gai.md`** (new) - the proven end-to-end agy flow:
  prerequisites (agy CLI, node), `forge init --host agy` emit, the co-located
  `plugin.json` + generated `mcp_config.json`/`hooks.json` layout, the
  `agy-deny`/`agy-capture` I/O shims, `agy plugin install`/`validate`/`list`,
  the green validate output shape, and the real gotchas (Windows MAX_PATH ->
  short-path staging; agy reads MCP from `mcp_config.json` not `plugin.json`;
  hooks use matcher `run_command`; the denylist self-exec-guard naming
  constraint). **AC5.1**
- **Capability / parity matrix** from ADR-0007 (d), shipped in the guide: full
  parity on agy for board law / 7 gates / graph / release / denylist / capture /
  fan-out; the honest differences (auto-merge Claude-only by policy; skill
  auto-flow model-driven; statusline cosmetic Claude-only). Codex noted
  deferred (#292). **AC5.2**
- **`README.md`** - multi-host (agy) support section + explicit Claude-only-merge
  policy line (also added to the laws list). **AC5.3**
- **`docs/README.md`** - route-index entries for the new guide, ADR-0007 (+ the
  agy-adapter reference), and a backfill of pre-existing unindexed docs to bring
  the `doc-sync` gate green.

## Verification (honest)
- Ran the emitter (`node plugin/scripts/init.mjs --host agy --out <scratch>`) and
  confirmed the emitted layout matches the guide byte-for-byte: co-located
  `plugin.json` with `$schema`/`mcpServers` stripped; `mcp_config.json` with
  **both** `forge-graph` + `forge-core` (since #288 merged); `hooks.json` with the
  `run_command` matcher pointing at the shims. The `agy plugin validate` output
  shape is quoted from the ADR-0007 spike (live agy v1.1.5); the post-#288
  two-server count is stated as expected (not re-run against agy in CI).
- `pnpm verify` green (523 tests). `doc-sync` clean (52 indexed), `depguard`
  clean, `testintent` clean, `plandrift` N/A (docs ticket, no plan).
- Reviewer pass (4 low findings, addressed the two cheap ones); security pass
  (zero findings) - docs-only, no code/CI/deps/hooks touched.
- agy is described as **proven**; Codex as **deferred/unbuilt** throughout.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@