### PR TITLE
fix(agy): resolve ${CLAUDE_PLUGIN_ROOT} in emitted agy skills/commands (#294)

### DIFF
--- a/plugin/scripts/agy/emit.mjs
+++ b/plugin/scripts/agy/emit.mjs
@@ -114,6 +114,59 @@ export function buildPluginMarker(sourceManifest) {
   return marker;
 }
 
+/**
+ * Rewrite Claude-Code runtime variables in emitted agy skill/command prose to an
+ * agy-resolvable form (#294).
+ *
+ * `${CLAUDE_PLUGIN_ROOT}` is a Claude-Code-runtime variable: Claude substitutes it
+ * with the installed plugin's root when a skill shells out. agy does NOT substitute
+ * it, and (verified against the installed agy CLI docs) exposes no plugin-root
+ * variable of its own. The one documented agy rule for a plugin command locating
+ * plugin-relative files is the working directory: agy runs a plugin's shell-out with
+ * CWD set to the plugin root (hooks.md: a hook command's "working directory is set to
+ * the directory containing hooks.json" = the plugin root; skills.md documents plugin
+ * scripts as paths relative to the plugin, e.g. `./scripts/...`). So we DROP the
+ * variable and leave a plugin-root-relative path:
+ *   node "${CLAUDE_PLUGIN_ROOT}/scripts/board/create.mjs"  ->  node "scripts/board/create.mjs"
+ *
+ * Why not an absolute path: `agy plugin install` COPIES the package to
+ * `~/.gemini/config/plugins/forge/`, so any staging-time absolute path would be stale
+ * post-install. Why not the `forge <area> <cmd>` dispatcher on PATH: agy does not add
+ * a plugin's `bin/` to PATH (plugins.md ingests skills/rules/hooks/MCP only), so the
+ * dispatcher is not resolvable inside an agy session. The relative form is install-
+ * location-independent and uniform for skills and commands. Runtime confirmation of the
+ * skill-shell-out CWD is pending the #290 dogfood; this is the most-defensible form now.
+ */
+export function rewriteAgyRuntimePaths(text) {
+  return text
+    // "${CLAUDE_PLUGIN_ROOT}/scripts/x.mjs" -> "scripts/x.mjs" (plugin-root-relative)
+    .replace(/\$\{CLAUDE_PLUGIN_ROOT\}\//g, '')
+    // any bare, non-slash-suffixed reference -> the plugin root itself
+    .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, '.');
+}
+
+/**
+ * Rewrite `${CLAUDE_PLUGIN_ROOT}` (and any other Claude-only runtime vars) in every
+ * emitted `.md` under `root`, in place. Operates only on the emitted COPY tree — the
+ * Claude plugin source is never touched. Returns the count of files changed.
+ */
+async function rewriteRuntimePathsInTree(root) {
+  let changed = 0;
+  const walk = async (dir) => {
+    const entries = await readdir(longPath(dir), { withFileTypes: true }).catch(() => []);
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) { await walk(p); continue; }
+      if (!e.name.toLowerCase().endsWith('.md')) continue;
+      const before = await readFile(longPath(p), 'utf8');
+      const after = rewriteAgyRuntimePaths(before);
+      if (after !== before) { await writeFile(longPath(p), after, 'utf8'); changed++; }
+    }
+  };
+  await walk(root);
+  return changed;
+}
+
 // Component dirs agy ingests natively (skills/agents/commands, zero conversion) + the
 // trees the configs and skills point at: mcp (server), hooks (shims), scripts + bin
 // (the `forge <area> <cmd>` shell tier the skills shell out to — copied so the paths
@@ -156,6 +209,17 @@ export async function emitAgyPlugin({ srcRoot = pluginRoot(), destRoot, cwd = pr
     written.push(`${d}/`);
   }
 
+  // #294: the copied skill/command prose hardcodes `${CLAUDE_PLUGIN_ROOT}` (a Claude-
+  // only runtime variable agy does not substitute). Rewrite the emitted COPIES to a
+  // plugin-root-relative form agy resolves via CWD; the Claude plugin source stays
+  // untouched. Skills and commands only — agents carry no such shell-outs.
+  let rewritten = 0;
+  for (const d of ['skills', 'commands']) {
+    const t = join(dest, d);
+    try { await access(L(t)); } catch { continue; }
+    rewritten += await rewriteRuntimePathsInTree(t);
+  }
+
   // Co-located plugin.json marker.
   const manifest = JSON.parse(await readFile(L(join(srcRoot, '.claude-plugin', 'plugin.json')), 'utf8'));
   await writeFile(L(join(dest, 'plugin.json')), JSON.stringify(buildPluginMarker(manifest), null, 2) + '\n', 'utf8');
@@ -174,8 +238,9 @@ export async function emitAgyPlugin({ srcRoot = pluginRoot(), destRoot, cwd = pr
 
   log(`agy: emitted forge plugin package at ${dest}`);
   log(`agy: wrote ${written.join(', ')}${hasForgeCore ? ' (forge-graph + forge-core)' : ' (forge-graph)'}`);
+  log(`agy: rewrote \${CLAUDE_PLUGIN_ROOT} -> plugin-root-relative in ${rewritten} emitted skill/command file(s)`);
   log('agy: install with  agy plugin install "' + dest + '" (or discover under .agents/plugins/forge/)');
-  return { ok: true, dest, written, hasForgeCore };
+  return { ok: true, dest, written, hasForgeCore, rewritten };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/plugin/scripts/agy/emit.mjs
+++ b/plugin/scripts/agy/emit.mjs
@@ -156,6 +156,10 @@ async function rewriteRuntimePathsInTree(root) {
     const entries = await readdir(longPath(dir), { withFileTypes: true }).catch(() => []);
     for (const e of entries) {
       const p = join(dir, e.name);
+      // Never follow a symlink: readFile/writeFile dereference, so a *.md symlink
+      // could turn this read-modify-write loop into an arbitrary-file write. The
+      // forge source tree carries none; skip defensively regardless (Dirent guard).
+      if (e.isSymbolicLink()) continue;
       if (e.isDirectory()) { await walk(p); continue; }
       if (!e.name.toLowerCase().endsWith('.md')) continue;
       const before = await readFile(longPath(p), 'utf8');

--- a/tests/agy/emit.test.mjs
+++ b/tests/agy/emit.test.mjs
@@ -4,8 +4,10 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawn } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
 import {
   emitAgyPlugin, buildMcpConfig, buildHooksConfig, buildPluginMarker, toPosix, longPath, pluginRoot, unsafeDestReason,
+  rewriteAgyRuntimePaths,
 } from '../../plugin/scripts/agy/emit.mjs';
 import { runInit, parseArgs } from '../../plugin/scripts/init.mjs';
 
@@ -294,5 +296,70 @@ describe('AC-289.4: paths are computed, ASCII-only, Windows-first, long-path awa
     expect(res.ok).toBe(true);
     expect(dest.length).toBeGreaterThan(260);
     await expect(access(longPath(join(dest, 'hooks.json')))).resolves.toBeUndefined();
+  });
+});
+
+// Recursively collect every `.md` file under `root`.
+async function collectMd(root) {
+  const out = [];
+  const walk = async (dir) => {
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) await walk(p);
+      else if (e.name.toLowerCase().endsWith('.md')) out.push(p);
+    }
+  };
+  await walk(root);
+  return out;
+}
+
+describe('AC-294: emitted agy skills/commands carry no unresolved ${CLAUDE_PLUGIN_ROOT}', () => {
+  it('AC-294.1: no emitted skill/command file contains ${CLAUDE_PLUGIN_ROOT} after emit', async () => {
+    const { dest, res } = await emitTo();
+    expect(res.ok).toBe(true);
+    // the emitter actually rewrote real files (guards against a silent no-op transform).
+    expect(res.rewritten).toBeGreaterThan(0);
+
+    const files = [
+      ...await collectMd(join(dest, 'skills')),
+      ...await collectMd(join(dest, 'commands')),
+    ];
+    expect(files.length).toBeGreaterThan(0);
+    for (const f of files) {
+      const body = await readFile(f, 'utf8');
+      expect(body, `${f} still hardcodes the Claude-only runtime variable`).not.toContain('${CLAUDE_PLUGIN_ROOT}');
+    }
+  });
+
+  it('AC-294.2: the emitted shell-out form is plugin-root-relative (agy resolves via CWD)', async () => {
+    const { dest } = await emitTo();
+    // a known offender in the source: skills/board/SKILL.md shells out to scripts/board/*.
+    const board = await readFile(join(dest, 'skills', 'board', 'SKILL.md'), 'utf8');
+    expect(board).toContain('node "scripts/board/');       // rewritten, root-relative
+    expect(board).not.toContain('${CLAUDE_PLUGIN_ROOT}');   // variable gone
+
+    // pure, deterministic transform — the exact mapping the emitter applies.
+    expect(rewriteAgyRuntimePaths('node "${CLAUDE_PLUGIN_ROOT}/scripts/board/create.mjs" --title x'))
+      .toBe('node "scripts/board/create.mjs" --title x');
+    // covers every area uniformly, including scripts the `forge` dispatcher does not map.
+    expect(rewriteAgyRuntimePaths('node "${CLAUDE_PLUGIN_ROOT}/scripts/runner/check.mjs"'))
+      .toBe('node "scripts/runner/check.mjs"');
+    // a bare, non-slash reference collapses to the plugin root itself.
+    expect(rewriteAgyRuntimePaths('cd ${CLAUDE_PLUGIN_ROOT} && ls')).toBe('cd . && ls');
+    // idempotent + a no-var string is unchanged.
+    const once = rewriteAgyRuntimePaths('node "${CLAUDE_PLUGIN_ROOT}/scripts/x.mjs"');
+    expect(rewriteAgyRuntimePaths(once)).toBe(once);
+    expect(rewriteAgyRuntimePaths('forge board create')).toBe('forge board create');
+  });
+
+  it('AC-294.3: the Claude plugin source is untouched by the emitter (only the copy changes)', async () => {
+    const src = join(pluginRoot(), 'skills', 'board', 'SKILL.md');
+    const before = await readFile(src, 'utf8');
+    expect(before).toContain('${CLAUDE_PLUGIN_ROOT}'); // sanity: source really is the Claude form
+    await emitTo();
+    const after = await readFile(src, 'utf8');
+    expect(after).toBe(before); // byte-identical: emit reads source, writes only into dest
+    expect(after).toContain('${CLAUDE_PLUGIN_ROOT}');
   });
 });


### PR DESCRIPTION
Closes #294 (follow-up from #289 review, parent epic #174).

## Problem
`forge init --host agy` (`plugin/scripts/agy/emit.mjs`) copies skill/command prose byte-for-byte, so the emitted agy package still hardcoded `node "${CLAUDE_PLUGIN_ROOT}/scripts/<area>/<script>.mjs"`. `${CLAUDE_PLUGIN_ROOT}` is a **Claude-Code runtime variable agy does not substitute**, so those shell-outs would not resolve when a forge skill is driven from inside an agy session.

## Investigation (source-verified on this machine)
Read the installed agy CLI docs at `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/` (hooks.md, skills.md, plugins.md, mcp_servers.md) and inspected the live installed plugin:
- **No plugin-root variable.** agy exposes none; the hook stdin payload carries `workspacePaths`/`transcriptPath`/`artifactDirectoryPath` but no plugin root, and a full-tree search of the agy CLI found no `*_PLUGIN_ROOT` definition.
- **The documented rule for a plugin command to locate plugin files is CWD.** hooks.md: a hook command's "working directory is set to the directory containing hooks.json" (= the plugin root). skills.md documents plugin scripts as paths relative to the plugin.
- **agy does not add a plugin's `bin/` to PATH** (plugins.md ingests skills/rules/hooks/MCP only) — so the `forge <area> <cmd>` dispatcher is **not** resolvable in-session (and its area list does not even cover every referenced script, e.g. `runner`).
- **An absolute path is wrong** because `agy plugin install` copies the package to `~/.gemini/config/plugins/forge/`.

## Chosen form
Drop the variable, leaving a **plugin-root-relative** path: `node "${CLAUDE_PLUGIN_ROOT}/scripts/board/create.mjs"` -> `node "scripts/board/create.mjs"` (bare, non-slash refs collapse to `.`). Install-location-independent, uniform for skills and commands, and works for every script. The emitter rewrites **only the emitted copies**; the Claude plugin source prose is untouched.

## Runtime confirmation pending #290
The exact CWD an agy skill shell-out runs in can only be confirmed by the live #290 dogfood. This is the most-defensible form (grounded in agy's documented hooks-CWD rule) implemented and deterministically unit-tested now; #290 will confirm at runtime.

## Verification
- `pnpm verify` green (526 tests, 49 files).
- New AC294 tests (`tests/agy/emit.test.mjs`): AC294.1 no unresolved `${CLAUDE_PLUGIN_ROOT}` in emitted skills/commands; AC294.2 emitted form is plugin-root-relative (+ pure-function mapping, idempotence, runner coverage); AC294.3 Claude source byte-identical after emit.
- acgate: all 3 ACs covered by passing tests. testintent/depguard clean.
- Live `forge init --host agy` emit: 26 skill/command files rewritten, zero unresolved vars, source unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)