### PR TITLE
feat(mcp): harden forge-core transport — line cap, arg bounds, config teaching (#296)

### DIFF
--- a/plugin/mcp/forge/server.mjs
+++ b/plugin/mcp/forge/server.mjs
@@ -91,10 +91,11 @@ export const TOOLS = [
       type: 'object',
       properties: {
         issue: { type: 'integer' },
-        reason: { type: 'string', minLength: 1 },
-        options: { type: 'array', items: { type: 'string' }, minItems: 2 },
-        recommend: { type: 'string' },
-        context: { type: 'string' },
+        reason: { type: 'string', minLength: 1, maxLength: 2000 },
+        // Bounded fan-out/size (#296/AC2): a decision has a handful of options, each a short label.
+        options: { type: 'array', items: { type: 'string', maxLength: 2000 }, minItems: 2, maxItems: 20 },
+        recommend: { type: 'string', maxLength: 2000 },
+        context: { type: 'string', maxLength: 10000 },
       },
       required: ['issue', 'reason', 'options'],
     },
@@ -114,7 +115,8 @@ export const TOOLS = [
         // union of per-gate args; each gate reads only its own and teaches on a miss
         plan: { type: 'string' },
         ticket: { type: 'integer' },
-        results: { type: 'array', items: { type: 'string' } },
+        // Bounded fan-out (#296/AC2): each entry is a vitest-json path fed to glob/readFile; cap the count and path length.
+        results: { type: 'array', items: { type: 'string', maxLength: 1024 }, maxItems: 256 },
         acs: { type: 'string' },
         base: { type: 'string' },
         manifest: { type: 'string' },
@@ -305,7 +307,14 @@ export function makeHandler({ root, getCtx, deps = DEFAULT_DEPS }) {
 
         case 'release_readiness': {
           const cfg = await deps.loadConfig(root);
-          const config = cfg.ok ? cfg.config : {};
+          // #296/AC3: a missing/broken forge.json used to be swallowed as config:{}, hiding
+          // the breakage and evaluating readiness against empty config. Teach the caller instead.
+          if (!cfg.ok) {
+            const why = cfg.missing ? '.claude/forge.json is missing' : '.claude/forge.json is broken';
+            const detail = (cfg.errors ?? []).join('; ');
+            return teach(id, `release-readiness cannot evaluate: ${why}${detail ? ` (${detail})` : ''} — run /forge:init to repair it`);
+          }
+          const config = cfg.config;
           const r = await deps.computeReadiness({ cwd: root, execFn: deps.execFn, config, verifyCmd: config.conventions?.verify });
           return toolText(id, { ok: r.ok, items: r.items });
         }

--- a/plugin/mcp/lib/rpc.mjs
+++ b/plugin/mcp/lib/rpc.mjs
@@ -14,10 +14,17 @@
  * Per-server tool logic is injected via `onCall`; nothing here is graph- or
  * board-specific, so neither server can regress the other's transport.
  */
-import { createInterface } from 'node:readline';
 import { resolve, sep } from 'node:path';
 
 export const PROTOCOL_VERSION = '2024-11-05';
+
+/**
+ * Cap on a single newline-delimited JSON-RPC line (4 MiB). Large enough for any
+ * legitimate tool payload (a glob fan-out, a batch of file paths, an escalation
+ * body), bounded against an unterminated line that would otherwise buffer without
+ * limit and exhaust memory (#296/AC1 — a DoS vector shared by both servers).
+ */
+export const MAX_LINE_LENGTH = 4 * 1024 * 1024;
 
 /** JSON-RPC response builders (id-parameterized; pure). */
 export const rpcError = (id, code, message) => ({ jsonrpc: '2.0', id, error: { code, message } });
@@ -32,15 +39,20 @@ export function validateInput(schema, args) {
   for (const [key, val] of Object.entries(args)) {
     const prop = schema.properties[key];
     if (!prop) return `unknown argument '${key}'`;
-    if (prop.type === 'string' && (typeof val !== 'string' || val.length < (prop.minLength ?? 0))) {
-      return `'${key}' must be a string of length >= ${prop.minLength ?? 0}`;
+    if (prop.type === 'string') {
+      if (typeof val !== 'string' || val.length < (prop.minLength ?? 0)) return `'${key}' must be a string of length >= ${prop.minLength ?? 0}`;
+      if (prop.maxLength != null && val.length > prop.maxLength) return `'${key}' must be a string of length <= ${prop.maxLength}`;
     }
     if (prop.type === 'integer' && !Number.isInteger(val)) return `'${key}' must be an integer`;
     if (prop.type === 'boolean' && typeof val !== 'boolean') return `'${key}' must be a boolean`;
     if (prop.enum && !prop.enum.includes(val)) return `'${key}' must be one of: ${prop.enum.join(', ')}`;
     if (prop.type === 'array') {
       if (!Array.isArray(val) || val.length < (prop.minItems ?? 0)) return `'${key}' must be an array with >= ${prop.minItems ?? 0} items`;
-      if (prop.items?.type === 'string' && !val.every((v) => typeof v === 'string')) return `'${key}' items must be strings`;
+      if (prop.maxItems != null && val.length > prop.maxItems) return `'${key}' must be an array with <= ${prop.maxItems} items`;
+      if (prop.items?.type === 'string') {
+        if (!val.every((v) => typeof v === 'string')) return `'${key}' items must be strings`;
+        if (prop.items.maxLength != null && !val.every((v) => v.length <= prop.items.maxLength)) return `'${key}' items must each be a string of length <= ${prop.items.maxLength}`;
+      }
     }
     if (prop.type === 'object' && (val == null || typeof val !== 'object' || Array.isArray(val))) return `'${key}' must be an object`;
   }
@@ -89,16 +101,43 @@ export function makeRpcHandler({ serverInfo, tools, onCall, protocolVersion = PR
  * Newline-delimited JSON-RPC stdio loop. `handle(msg)` may return a response
  * object, `null` (notification), or a Promise of either. A malformed line
  * answers with a parse error and never crashes the loop.
+ *
+ * The line splitter is hand-rolled (rather than node:readline) so it can enforce
+ * `maxLineLength`: an unterminated line that grows past the cap is answered with a
+ * parse error and its bytes are dropped up to the next newline, instead of
+ * buffering without bound and exhausting memory (#296/AC1). Windows `\r\n` line
+ * endings are tolerated (a trailing `\r` is stripped before parsing).
  */
-export function serve(handle, { input = process.stdin, output = process.stdout } = {}) {
-  const rl = createInterface({ input, terminal: false });
-  rl.on('line', async (line) => {
+export function serve(handle, { input = process.stdin, output = process.stdout, maxLineLength = MAX_LINE_LENGTH } = {}) {
+  let buf = '';
+  let dropping = false; // current line already exceeded the cap; discard bytes until the next newline
+  input.setEncoding('utf8');
+
+  const processLine = async (raw) => {
+    const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
     if (!line.trim()) return;
     let msg;
     try { msg = JSON.parse(line); }
     catch { output.write(JSON.stringify(rpcError(null, -32700, 'parse error')) + '\n'); return; }
     const res = await handle(msg);
     if (res) output.write(JSON.stringify(res) + '\n');
+  };
+
+  input.on('data', (chunk) => {
+    buf += chunk;
+    let nl;
+    while ((nl = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      if (dropping) { dropping = false; continue; } // tail of an over-long line — already answered
+      processLine(line);
+    }
+    if (buf.length > maxLineLength) {
+      output.write(JSON.stringify(rpcError(null, -32700, `parse error: line exceeds the ${maxLineLength}-byte limit`)) + '\n');
+      buf = '';
+      dropping = true; // everything up to the next newline belongs to the rejected line
+    }
   });
-  return rl;
+
+  return input;
 }

--- a/plugin/mcp/lib/rpc.mjs
+++ b/plugin/mcp/lib/rpc.mjs
@@ -19,10 +19,11 @@ import { resolve, sep } from 'node:path';
 export const PROTOCOL_VERSION = '2024-11-05';
 
 /**
- * Cap on a single newline-delimited JSON-RPC line (4 MiB). Large enough for any
- * legitimate tool payload (a glob fan-out, a batch of file paths, an escalation
- * body), bounded against an unterminated line that would otherwise buffer without
- * limit and exhaust memory (#296/AC1 — a DoS vector shared by both servers).
+ * Cap on a single newline-delimited JSON-RPC line, measured in characters
+ * (4,194,304 — ~4 MiB for ASCII payloads). Large enough for any legitimate tool
+ * payload (a glob fan-out, a batch of file paths, an escalation body), bounded
+ * against a line — terminated or not — that would otherwise buffer without limit
+ * and exhaust memory (#296/AC1 — a DoS vector shared by both servers).
  */
 export const MAX_LINE_LENGTH = 4 * 1024 * 1024;
 
@@ -123,6 +124,9 @@ export function serve(handle, { input = process.stdin, output = process.stdout, 
     if (res) output.write(JSON.stringify(res) + '\n');
   };
 
+  const rejectOverLong = () =>
+    output.write(JSON.stringify(rpcError(null, -32700, `parse error: line exceeds the ${maxLineLength}-character limit`)) + '\n');
+
   input.on('data', (chunk) => {
     buf += chunk;
     let nl;
@@ -130,12 +134,16 @@ export function serve(handle, { input = process.stdin, output = process.stdout, 
       const line = buf.slice(0, nl);
       buf = buf.slice(nl + 1);
       if (dropping) { dropping = false; continue; } // tail of an over-long line — already answered
+      if (line.length > maxLineLength) { rejectOverLong(); continue; } // a complete-but-oversized line: reject, never parse
       processLine(line);
     }
-    if (buf.length > maxLineLength) {
-      output.write(JSON.stringify(rpcError(null, -32700, `parse error: line exceeds the ${maxLineLength}-byte limit`)) + '\n');
+    // buf now holds the unterminated remainder (no newline yet).
+    if (dropping) {
+      buf = ''; // still discarding the tail of an already-rejected line — drop without re-answering
+    } else if (buf.length > maxLineLength) {
+      rejectOverLong(); // an unterminated line grew past the cap: answer ONCE, then drop to the next newline
       buf = '';
-      dropping = true; // everything up to the next newline belongs to the rejected line
+      dropping = true;
     }
   });
 

--- a/tests/mcp-forge/forge-core.test.mjs
+++ b/tests/mcp-forge/forge-core.test.mjs
@@ -226,6 +226,65 @@ describe('AC-288.4: at least one failure path per tool group', () => {
 });
 
 // =========================================================================
+describe('AC-296.2: forge-core arg size bounds cap per-call fan-out and comment size', () => {
+  it('AC-296.2: gate_run.results is capped by count and per-path length', async () => {
+    const h = build();
+    const many = Array.from({ length: 257 }, (_, i) => `r${i}.json`);
+    expect((await call(h, 'gate_run', { gate: 'ac', results: many })).error.message).toMatch(/'results' must be an array with <= 256 items/);
+    expect((await call(h, 'gate_run', { gate: 'ac', results: ['x'.repeat(1100)] })).error.message).toMatch(/'results' items must each be a string of length <= 1024/);
+  });
+
+  it('AC-296.2: board_escalate.options is capped by count and per-option length; reason size is bounded', async () => {
+    const h = build();
+    const opts = Array.from({ length: 21 }, (_, i) => `opt ${i}`);
+    expect((await call(h, 'board_escalate', { issue: 1, reason: 'r', options: opts })).error.message).toMatch(/'options' must be an array with <= 20 items/);
+    expect((await call(h, 'board_escalate', { issue: 1, reason: 'r', options: ['ok', 'x'.repeat(2100)] })).error.message).toMatch(/'options' items must each be a string of length <= 2000/);
+    expect((await call(h, 'board_escalate', { issue: 1, reason: 'x'.repeat(2100), options: ['a', 'b'] })).error.message).toMatch(/'reason' must be a string of length <= 2000/);
+  });
+
+  it('AC-296.2: in-bounds fan-out args still pass (a ceiling was added, not a new floor)', async () => {
+    const h = build({ deps: { runEscalate: async () => ({ ok: true, id: 'e1', boardNote: null, pending: true }) } });
+    expect(body(await call(h, 'board_escalate', { issue: 1, reason: 'ok', options: ['a', 'b'] })).ok).toBe(true);
+  });
+});
+
+// =========================================================================
+describe('AC-296.3: release_readiness teaches on a missing/broken forge.json instead of degrading', () => {
+  it('AC-296.3: a missing config surfaces a teaching error and never evaluates against empty config', async () => {
+    let ran = false;
+    const h = build({ deps: {
+      loadConfig: async () => ({ ok: false, missing: true, errors: ['.claude/forge.json not found — run /forge:init'], config: null }),
+      computeReadiness: async () => { ran = true; return { ok: true, items: [] }; },
+    } });
+    const res = await call(h, 'release_readiness', {});
+    expect(res.result.isError).toBe(true);
+    expect(body(res)).toMatchObject({ ok: false });
+    expect(body(res).error).toMatch(/\.claude\/forge\.json is missing/);
+    expect(body(res).error).toMatch(/forge:init/);
+    expect(ran).toBe(false); // did NOT silently degrade into computeReadiness with config:{}
+  });
+
+  it('AC-296.3: a broken (invalid) config teaches with the validation detail', async () => {
+    const h = build({ deps: {
+      loadConfig: async () => ({ ok: false, missing: false, errors: ['board: missing block'], config: { foo: 1 } }),
+      computeReadiness: async () => ({ ok: true, items: [] }),
+    } });
+    const res = await call(h, 'release_readiness', {});
+    expect(res.result.isError).toBe(true);
+    expect(body(res).error).toMatch(/\.claude\/forge\.json is broken/);
+    expect(body(res).error).toMatch(/board: missing block/);
+  });
+
+  it('AC-296.3: a healthy config still evaluates the checklist as before', async () => {
+    const h = build({ deps: {
+      loadConfig: async () => ({ ok: true, config: { conventions: { verify: 'pnpm verify' } } }),
+      computeReadiness: async () => ({ ok: true, items: [{ name: 'branch', level: 'pass', msg: 'on main' }] }),
+    } });
+    expect(body(await call(h, 'release_readiness', {}))).toEqual({ ok: true, items: [{ name: 'branch', level: 'pass', msg: 'on main' }] });
+  });
+});
+
+// =========================================================================
 describe('makeCtxResolver memoization', () => {
   it('resolves once on success and does NOT cache a failed resolution', async () => {
     let n = 0;

--- a/tests/mcp-lib/rpc.test.mjs
+++ b/tests/mcp-lib/rpc.test.mjs
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { Readable } from 'node:stream';
+import { serve, MAX_LINE_LENGTH, validateInput } from '../../plugin/mcp/lib/rpc.mjs';
+
+// A microtask/IO flush so async processLine writes settle before assertions.
+const flush = () => new Promise((r) => setImmediate(r));
+
+/** Drive serve() over an in-memory stream pair; collect what it writes and what the handler saw. */
+function harness({ maxLineLength } = {}) {
+  const input = new Readable({ read() {} });
+  const written = [];
+  const output = { write: (s) => { written.push(s); return true; } };
+  const handled = [];
+  serve(async (msg) => { handled.push(msg); return { jsonrpc: '2.0', id: msg.id, result: {} }; }, { input, output, maxLineLength });
+  return { input, written, handled };
+}
+
+describe('AC-296.1: serve() caps stdio line length against unbounded buffering', () => {
+  it('AC-296.1: an over-long unterminated line is answered with a parse error and never handled', async () => {
+    const { input, written, handled } = harness({ maxLineLength: 100 });
+    input.push('x'.repeat(250)); // 250 chars, no newline -> exceeds the cap
+    await flush();
+    expect(handled).toHaveLength(0); // never parsed/handled (no OOM buffering, no hang)
+    expect(written.some((w) => /parse error/.test(w) && /limit/.test(w))).toBe(true);
+    // the rejected line's tail is discarded up to the next newline; a valid line after it still works
+    input.push('leftover-garbage\n' + JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'ping' }) + '\n');
+    await flush();
+    expect(handled).toEqual([{ jsonrpc: '2.0', id: 7, method: 'ping' }]);
+  });
+
+  it('AC-296.1: a line exactly at the cap is still accepted (the cap is an over-limit guard, not a floor)', async () => {
+    const payload = { jsonrpc: '2.0', id: 3, method: 'ping' };
+    const line = JSON.stringify(payload);
+    const { input, handled } = harness({ maxLineLength: line.length + 1 });
+    input.push(line + '\n');
+    await flush();
+    expect(handled).toEqual([payload]);
+  });
+
+  it('AC-296.1: normal newline-delimited lines parse and Windows CRLF is tolerated; default cap is 4 MiB', async () => {
+    expect(MAX_LINE_LENGTH).toBe(4 * 1024 * 1024);
+    const { input, handled } = harness();
+    input.push(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }) + '\r\n');
+    input.push(JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'ping' }) + '\n');
+    await flush();
+    expect(handled).toEqual([
+      { jsonrpc: '2.0', id: 1, method: 'ping' },
+      { jsonrpc: '2.0', id: 2, method: 'ping' },
+    ]);
+  });
+
+  it('AC-296.1: a malformed (but bounded) line still answers with a parse error and keeps the loop alive', async () => {
+    const { input, written, handled } = harness();
+    input.push('{not json}\n' + JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'ping' }) + '\n');
+    await flush();
+    expect(written.some((w) => /parse error/.test(w))).toBe(true);
+    expect(handled).toEqual([{ jsonrpc: '2.0', id: 9, method: 'ping' }]); // loop survives the bad line
+  });
+});
+
+describe('AC-296.2: validateInput enforces maxItems / maxLength ceilings', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      tag: { type: 'string', maxLength: 4 },
+      files: { type: 'array', items: { type: 'string', maxLength: 3 }, minItems: 1, maxItems: 2 },
+    },
+    required: [],
+  };
+  it('AC-296.2: an over-long string is rejected', () => {
+    expect(validateInput(schema, { tag: 'toolong' })).toMatch(/'tag' must be a string of length <= 4/);
+  });
+  it('AC-296.2: too many array items are rejected', () => {
+    expect(validateInput(schema, { files: ['a', 'b', 'c'] })).toMatch(/'files' must be an array with <= 2 items/);
+  });
+  it('AC-296.2: an over-long array item is rejected', () => {
+    expect(validateInput(schema, { files: ['abcd'] })).toMatch(/'files' items must each be a string of length <= 3/);
+  });
+  it('AC-296.2: in-bounds values pass (ceilings do not change existing floors)', () => {
+    expect(validateInput(schema, { tag: 'ok', files: ['ab', 'cd'] })).toBe(null);
+  });
+});

--- a/tests/mcp-lib/rpc.test.mjs
+++ b/tests/mcp-lib/rpc.test.mjs
@@ -28,6 +28,31 @@ describe('AC-296.1: serve() caps stdio line length against unbounded buffering',
     expect(handled).toEqual([{ jsonrpc: '2.0', id: 7, method: 'ping' }]);
   });
 
+  it('AC-296.1: a complete, over-cap, newline-terminated line in one chunk is rejected, not handled', async () => {
+    const { input, written, handled } = harness({ maxLineLength: 100 });
+    // The common client pattern: assemble the full JSON payload, then one write(json + "\n").
+    input.push('x'.repeat(250) + '\n');
+    await flush();
+    expect(handled).toHaveLength(0); // the oversized complete line never reaches the handler
+    expect(written.some((w) => /parse error/.test(w) && /limit/.test(w))).toBe(true);
+    // the loop stays alive: a valid line right after it is still parsed
+    input.push(JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'ping' }) + '\n');
+    await flush();
+    expect(handled).toEqual([{ jsonrpc: '2.0', id: 4, method: 'ping' }]);
+  });
+
+  it('AC-296.1: a growing unterminated over-cap line is answered exactly once (no response amplification)', async () => {
+    const { input, written, handled } = harness({ maxLineLength: 100 });
+    // Stream far more than the cap, in several chunks, with no newline until the end.
+    for (let i = 0; i < 5; i++) input.push('y'.repeat(80));
+    await flush();
+    input.push('\n' + JSON.stringify({ jsonrpc: '2.0', id: 5, method: 'ping' }) + '\n');
+    await flush();
+    const errors = written.filter((w) => /parse error/.test(w) && /limit/.test(w));
+    expect(errors).toHaveLength(1); // one rejected line -> one error, not one per chunk
+    expect(handled).toEqual([{ jsonrpc: '2.0', id: 5, method: 'ping' }]);
+  });
+
   it('AC-296.1: a line exactly at the cap is still accepted (the cap is an over-limit guard, not a floor)', async () => {
     const payload = { jsonrpc: '2.0', id: 3, method: 'ping' };
     const line = JSON.stringify(payload);


### PR DESCRIPTION
Closes #296

Follow-up hardening from #288 review (PR #295), parent epic #174. Low-severity, non-blocking; shared MCP transport `plugin/mcp/lib/rpc.mjs` + `plugin/mcp/forge/server.mjs`.

## Acceptance criteria
- [x] **AC296.1 — stdio line-length cap.** `serve()` now caps a single newline-delimited line at 4 MiB (`MAX_LINE_LENGTH`). The `node:readline` loop is replaced by a hand-rolled splitter so an unterminated line past the cap is answered with a JSON-RPC parse error and its bytes dropped up to the next newline — no unbounded buffering / OOM. Windows CRLF tolerated. Shared by both forge-graph and forge-core.
- [x] **AC296.2 — arg size bounds.** `validateInput` gains `maxItems`/`maxLength` ceilings. `gate_run.results` (<=256 paths, <=1024 chars each) and `board_escalate.options` (<=20, <=2000 chars each) plus `reason`/`context` are now bounded — capping per-call glob/readFile fan-out and comment size. Over-cap args are rejected with a teaching -32602.
- [x] **AC296.3 — release_readiness config teaching.** A missing/broken `.claude/forge.json` is no longer swallowed as `config:{}`; `release_readiness` now teaches the caller (missing vs broken + validation detail, "run /forge:init") instead of silently degrading into an empty-config evaluation.

## Verification
- New `tests/mcp-lib/rpc.test.mjs` (serve line cap, CRLF, validator bounds) + new AC-296.2/.3 cases in `tests/mcp-forge/forge-core.test.mjs`.
- `pnpm verify` green (540 tests). forge-graph regression suite green (shares rpc.mjs).
- Gates: acgate (3/3 ACs covered by passing tests), depguard (no new deps), testintent (no weakened assertions) all pass.
- Zero new runtime deps; ASCII-only; Windows-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)