### PR TITLE
fix(mcp): board_escalate options bypass + escape decision-comment markdown (#300)

### DIFF
--- a/plugin/mcp/forge/server.mjs
+++ b/plugin/mcp/forge/server.mjs
@@ -279,8 +279,9 @@ export function makeHandler({ root, getCtx, deps = DEFAULT_DEPS }) {
 
         case 'board_escalate':
           return board(id, async (ctx) => {
-            // The engine parses options from a pipe-joined string; the MCP surface takes a typed array.
-            const r = await deps.runEscalate(ctx, { issue: args.issue, reason: args.reason, options: args.options.join('|'), recommend: args.recommend ?? null, context: args.context ?? '' }, noop);
+            // Pass the typed array straight through (#300 AC.1): the schema's maxItems
+            // bound then genuinely holds — no pipe-join for an embedded '|' to re-split past.
+            const r = await deps.runEscalate(ctx, { issue: args.issue, reason: args.reason, options: args.options, recommend: args.recommend ?? null, context: args.context ?? '' }, noop);
             if (!r.ok) return teach(id, r.error);
             return toolText(id, { ok: true, id: r.id, boardNote: r.boardNote ?? null, pending: r.pending ?? true });
           });

--- a/plugin/scripts/board/escalate.mjs
+++ b/plugin/scripts/board/escalate.mjs
@@ -28,10 +28,33 @@ export function parseArgs(argv) {
   return a;
 }
 
+/**
+ * The CLI passes a pipe-joined string (`--options "a|b|c"`); the MCP surface
+ * passes a structured array. Only the string form is split on '|' — an array
+ * element keeps any embedded '|' as literal text, so it cannot reconstitute
+ * into extra downstream options and defeat the caller's maxItems bound (#300 AC.1).
+ */
+export function normalizeOptions(raw) {
+  const arr = Array.isArray(raw) ? raw : String(raw ?? '').split('|');
+  return arr.map((s) => String(s).trim()).filter(Boolean);
+}
+
+/**
+ * Neutralize caller-supplied text before it lands in the trusted decision
+ * comment (#300 AC.2). Escapes backslash + Markdown/HTML control punctuation so
+ * caller text cannot forge block structure (headings, list items, a fake
+ * "recommended" tag) or inject a `<!-- forge:... -->` marker.
+ */
+export function escapeMd(s) {
+  return String(s ?? '')
+    .replace(/\\/g, '\\\\')
+    .replace(/([`*_{}\[\]()#+.<>|~-])/g, '\\$1');
+}
+
 export async function runEscalate(ctx, args, log = console.log) {
   if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
   if (!args.reason) return { ok: false, error: '--reason is required' };
-  const options = (args.options ?? '').split('|').map((s) => s.trim()).filter(Boolean);
+  const options = normalizeOptions(args.options);
   if (options.length < 2) return { ok: false, error: '--options "a|b[|c…]" needs at least two options' };
 
   const id = `esc-${args.issue}-${Date.now().toString(36)}`;
@@ -49,11 +72,11 @@ export async function runEscalate(ctx, args, log = console.log) {
   const lines = [
     `🚩 **Decision needed** (\`${id}\`)`,
     '',
-    `**Why halted:** ${args.reason}`,
-    ...(args.context ? ['', args.context] : []),
+    `**Why halted:** ${escapeMd(args.reason)}`,
+    ...(args.context ? ['', escapeMd(args.context)] : []),
     '',
     '**Options:**',
-    ...options.map((o, i) => `${i + 1}. ${o}${args.recommend === o || args.recommend === String(i + 1) ? ' ← **recommended**' : ''}`),
+    ...options.map((o, i) => `${i + 1}. ${escapeMd(o)}${args.recommend === o || args.recommend === String(i + 1) ? ' ← **recommended**' : ''}`),
     '',
     '_Reply in this thread with your choice (number or text). The pipeline is halted until then (spec §7)._',
   ];

--- a/plugin/scripts/board/escalate.mjs
+++ b/plugin/scripts/board/escalate.mjs
@@ -43,12 +43,14 @@ export function normalizeOptions(raw) {
  * Neutralize caller-supplied text before it lands in the trusted decision
  * comment (#300 AC.2). Escapes backslash + Markdown/HTML control punctuation so
  * caller text cannot forge block structure (headings, list items, a fake
- * "recommended" tag) or inject a `<!-- forge:... -->` marker.
+ * "recommended" tag) or inject a `<!-- forge:... -->` marker. Includes both
+ * setext underline chars (`-` and `=`) so an embedded-newline payload cannot
+ * forge an H1/H2 heading.
  */
 export function escapeMd(s) {
   return String(s ?? '')
     .replace(/\\/g, '\\\\')
-    .replace(/([`*_{}\[\]()#+.<>|~-])/g, '\\$1');
+    .replace(/([`*_{}\[\]()#+.<>|~=-])/g, '\\$1');
 }
 
 export async function runEscalate(ctx, args, log = console.log) {

--- a/tests/escalate.test.mjs
+++ b/tests/escalate.test.mjs
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { makeBoardCtx } from '../plugin/scripts/lib/boardctx.mjs';
-import { runEscalate, runCheck, parseArgs } from '../plugin/scripts/board/escalate.mjs';
+import { runEscalate, runCheck, parseArgs, normalizeOptions, escapeMd } from '../plugin/scripts/board/escalate.mjs';
 import { read as readJournal } from '../plugin/scripts/lib/journal.mjs';
 import { fakeGh, REPO_VIEW } from './helpers/fakegh.mjs';
 
@@ -127,6 +127,79 @@ describe('escalate (AC-3.2)', () => {
     const ctx = await makeBoardCtx({ gh: f.gh, cwd });
     const res = await runCheck(ctx, { issue: 9 }, noop);
     expect(res.resolved).toEqual([{ id: 'esc-9-nb', issue: 9, answer: 'option 1' }]);
+  });
+
+  it('AC-300.1: array option elements are not re-split on "|" (embedded pipe cannot fabricate options)', async () => {
+    // Captures the posted decision-comment body so we can assert the rendered option count.
+    let postedBody = null;
+    let status = 'In progress';
+    const f = fakeGh([
+      ['repo view', REPO_VIEW],
+      [(j) => j.startsWith('project item-list'), () => ({ stdout: JSON.stringify({ items: [{ id: 'IT3', content: { number: 3 }, status }] }) })],
+      [(j) => j.startsWith('project item-edit'), () => { status = 'Blocked / Needs decision'; return { stdout: '' }; }],
+      [(j) => j.includes('/comments?'), { stdout: '[]' }],
+      [(j) => j.includes('/issues/3/comments'), (j, args) => {
+        postedBody = (args.find((a) => a.startsWith('body=')) ?? '').slice(5);
+        return { stdout: JSON.stringify({ id: 501 }) };
+      }],
+    ]);
+    const cwd = await cwdWithConfig();
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd });
+    // A structured array whose second element is packed with pipes.
+    const res = await runEscalate(ctx, { issue: 3, reason: 'r', options: ['legit', 'a|b|c|d|e'], context: '' }, noop);
+    expect(res.ok).toBe(true);
+    const pending = JSON.parse(await readFile(join(cwd, '.forge', 'decisions', `${res.id}.json`), 'utf8'));
+    expect(pending.options).toEqual(['legit', 'a|b|c|d|e']); // exactly 2, not 6
+    // Only two numbered option lines in the human-facing comment (pipes escaped, no re-split).
+    expect(postedBody).toMatch(/^1\. legit/m);
+    expect(postedBody).toMatch(/^2\. a/m);
+    expect(postedBody).not.toMatch(/^3\. /m);
+  });
+
+  it('AC-300.2: the CLI --options "a|b|c" pipe form still parses into exactly [a, b, c]', () => {
+    // Regression: the CLI contract is preserved — a pipe-joined string is still split.
+    expect(normalizeOptions('a|b|c')).toEqual(['a', 'b', 'c']);
+    expect(normalizeOptions(' a | b ')).toEqual(['a', 'b']); // trims, drops empties
+    const parsed = parseArgs(['--issue', '3', '--reason', 'x', '--options', 'a|b']);
+    expect(normalizeOptions(parsed.options)).toEqual(['a', 'b']);
+  });
+
+  it('AC-300.3: caller-supplied reason/context/options are escaped in the decision comment', async () => {
+    let postedBody = null;
+    let status = 'In progress';
+    const f = fakeGh([
+      ['repo view', REPO_VIEW],
+      [(j) => j.startsWith('project item-list'), () => ({ stdout: JSON.stringify({ items: [{ id: 'IT3', content: { number: 3 }, status }] }) })],
+      [(j) => j.startsWith('project item-edit'), () => { status = 'Blocked / Needs decision'; return { stdout: '' }; }],
+      [(j) => j.includes('/comments?'), { stdout: '[]' }],
+      [(j) => j.includes('/issues/3/comments'), (j, args) => {
+        postedBody = (args.find((a) => a.startsWith('body=')) ?? '').slice(5);
+        return { stdout: JSON.stringify({ id: 501 }) };
+      }],
+    ]);
+    const cwd = await cwdWithConfig();
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd });
+    const res = await runEscalate(ctx, {
+      issue: 3,
+      reason: '# Fake heading',
+      context: 'inject <!-- forge:decision:evil --> and\n3. a forged option',
+      options: ['real one', '**bold** and 1. list'],
+    }, noop);
+    expect(res.ok).toBe(true);
+    // Structure-forming characters are backslash-escaped, so none render as Markdown/HTML structure.
+    expect(postedBody).toContain('\\# Fake heading');
+    expect(postedBody).not.toContain('<!-- forge:decision:evil'); // injected marker neutralized ('<' escaped)
+    expect(postedBody).toContain('3\\. a forged option');
+    expect(postedBody).toContain('\\*\\*bold\\*\\* and 1\\. list');
+    // The genuine forge marker (added by upsertMarkedComment) is still present and unescaped.
+    expect(postedBody).toContain('<!-- forge:decision:esc-');
+  });
+
+  it('escapeMd neutralizes markdown/HTML control punctuation', () => {
+    expect(escapeMd('a|b')).toBe('a\\|b');
+    expect(escapeMd('# h')).toBe('\\# h');
+    expect(escapeMd('a\\b')).toBe('a\\\\b'); // backslash escaped first, once
+    expect(escapeMd(null)).toBe('');
   });
 
   it('check: stays pending when only forge-marked comments follow', async () => {

--- a/tests/escalate.test.mjs
+++ b/tests/escalate.test.mjs
@@ -202,6 +202,12 @@ describe('escalate (AC-3.2)', () => {
     expect(escapeMd(null)).toBe('');
   });
 
+  it('escapeMd blocks embedded-newline setext headings (both === H1 and --- H2)', () => {
+    // Neither underline survives as an all-underline line → no forged heading.
+    expect(escapeMd('Fake H1\n===')).toBe('Fake H1\n\\=\\=\\=');
+    expect(escapeMd('Fake H2\n---')).toBe('Fake H2\n\\-\\-\\-');
+  });
+
   it('check: stays pending when only forge-marked comments follow', async () => {
     const cwd = await cwdWithConfig();
     await mkdir(join(cwd, '.forge', 'decisions'), { recursive: true });

--- a/tests/mcp-forge/forge-core.test.mjs
+++ b/tests/mcp-forge/forge-core.test.mjs
@@ -71,12 +71,22 @@ describe('AC-288.2: every tool is callable and returns its documented structured
     expect(seen).toMatchObject({ title: 'a new ticket', type: 'item', priority: 'p1', size: 'm', status: 'backlog' });
   });
 
-  it('AC-288.2: board_escalate -> {ok,id,boardNote,pending}; array options are pipe-joined for the engine', async () => {
+  it('AC-288.2: board_escalate -> {ok,id,boardNote,pending}; array options pass through structured (#300)', async () => {
     let seen;
     const h = build({ deps: { runEscalate: async (_ctx, a) => { seen = a; return { ok: true, id: 'esc-288-x', boardNote: 'board -> blocked', pending: true }; } } });
     const out = body(await call(h, 'board_escalate', { issue: 288, reason: 'infra choice', options: ['keep bash', 'rewrite in node'] }));
     expect(out).toEqual({ ok: true, id: 'esc-288-x', boardNote: 'board -> blocked', pending: true });
-    expect(seen.options).toBe('keep bash|rewrite in node');
+    // Structured array end-to-end (#300 AC.1): no pipe-join for an embedded '|' to re-split past.
+    expect(seen.options).toEqual(['keep bash', 'rewrite in node']);
+  });
+
+  it('AC-300.1: an option element containing "|" cannot fabricate extra downstream options', async () => {
+    let seen;
+    const h = build({ deps: { runEscalate: async (_ctx, a) => { seen = a; return { ok: true, id: 'esc-300-x', boardNote: null, pending: true }; } } });
+    // A malicious single element packed with pipes: array pass-through keeps it as ONE option.
+    const out = body(await call(h, 'board_escalate', { issue: 300, reason: 'r', options: ['legit', 'a|b|c|d|e|f'] }));
+    expect(out.ok).toBe(true);
+    expect(seen.options).toEqual(['legit', 'a|b|c|d|e|f']); // still 2 options, not 7
   });
 
   it('AC-288.2: board_status -> {ok,items[]} filtered by issue', async () => {


### PR DESCRIPTION
Closes #300

Follow-up from #296's security review (parent epic #174). Fixes both findings on the halt-and-ask escalation flow.

## Findings fixed
1. **MEDIUM — `board_escalate.options` `'|'`-delimiter bypass.** The MCP handler pipe-joined its `options` array and `escalate.mjs` re-split on `'|'`, so an option element containing an embedded `'|'` reconstituted into extra options downstream — defeating the `maxItems: 20` bound and injecting fabricated options into the human-facing GitHub decision comment.
2. **INFO→fix — unescaped Markdown.** `reason`/`context`/`options` were interpolated unescaped into the trusted Markdown decision comment.

## Approach
- **Structured array end-to-end.** The MCP `board_escalate` handler now passes `args.options` straight through to `runEscalate` (no pipe-join). New `normalizeOptions` splits only the *string* form, so the CLI `--options "a|b|c"` contract is preserved while an array element's embedded `'|'` stays literal and cannot fabricate options. The schema's `maxItems: 20` bound now genuinely holds.
- **`escapeMd`** escapes backslash + Markdown/HTML control punctuation on `reason`/`context`/`options` before they render, so caller text cannot forge block structure, a fake "recommended" tag, or a `<!-- forge:... -->` marker. Recommend-matching stays on the raw option values.
- Zero new runtime deps. ASCII-only additions. Windows-first.

## Acceptance criteria
- [x] **AC300.1** an option element containing `'|'` cannot fabricate extra downstream options — structured pass-through makes it impossible (MCP-handler test + engine test assert the count holds).
- [x] **AC300.2** the CLI `--options "a|b|c"` form still parses into exactly `[a, b, c]` (regression test).
- [x] **AC300.3** caller-supplied `reason`/`context`/`options` are escaped in the decision comment; injected Markdown/HTML-comment structure is neutralized (test).

## Verification
- `pnpm verify` green locally: 547 passed (50 files).
- New tests in `tests/escalate.test.mjs` (AC300.1/.2/.3 + `escapeMd` unit) and updated `tests/mcp-forge/forge-core.test.mjs` (structured pass-through + AC300.1 at the MCP surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)