### PR TITLE
fix(hooks): block rm long flags (--recursive --force) in denylist

### DIFF
--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -38,14 +38,20 @@ export const RULES = [
   {
     name: 'recursive-delete',
     test: (c) => {
-      const m = /\brm\s+(-[a-zA-Z]+\s+)*/.exec(c);
-      if (!m) return false;
-      const flags = c.match(/\brm\s+((-[a-zA-Z]+\s*)+)/);
-      if (!flags || !/r/.test(flags[1]) || !/f/.test(flags[1])) return false;
+      if (!/\brm\b/.test(c)) return false;
+      // Collect single-dash SHORT flag clusters (e.g. -rf, -Rf) — the `(?:^|\s)-`
+      // anchor keeps GNU `--recursive`/`--force` (double dash) and mid-word dashes
+      // (`file-r.txt`) out of this bucket so they can't spoof a short flag.
+      const shortFlags = (c.match(/(?:^|\s)-([a-zA-Z]+)/g) || []).join('');
+      // Recursive via short -r/-R OR the long --recursive; force via short -f OR
+      // long --force. Both required (AC-312.1), in any order.
+      const recursive = /[rR]/.test(shortFlags) || /\B--recursive\b/.test(c);
+      const force = /f/.test(shortFlags) || /\B--force\b/.test(c);
+      if (!recursive || !force) return false;
       const rest = c.slice(c.indexOf('rm'));
       return !SAFE_RM_TARGETS.test(rest);
     },
-    msg: 'rm -rf outside build/temp dirs',
+    msg: 'rm -rf (incl. --recursive --force) outside build/temp dirs',
   },
   // The two rules below run against the FULL command string (scope: 'full'), NOT
   // per-segment — segments() deliberately splits on the pipe, which is exactly the

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -154,6 +154,33 @@ describe('pipe-to-shell / RCE (#311, AC.1–AC.4)', () => {
   });
 });
 
+describe('recursive-delete long flags (#312, AC-312.*)', () => {
+  // AC-312.1 — GNU long flags (--recursive AND --force, in ANY order) outside the
+  // SAFE_RM_TARGETS allowlist are blocked, just like the short -rf form.
+  it('AC-312.1: rm --recursive --force outside safe targets is blocked (both orders)', () => {
+    expect(check('rm --recursive --force src/')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    expect(check('rm --force --recursive src/')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    // mixed short/long and the -R short form both count as recursive
+    expect(check('rm -R --force src/').rule).toBe('recursive-delete');
+    expect(check('rm -r --force src/').rule).toBe('recursive-delete');
+    expect(check('npm run build && rm --recursive --force lib/').rule).toBe('recursive-delete');
+  });
+
+  // AC-312.1 — force is still REQUIRED: --recursive alone stays allowed (unchanged
+  // by-design behavior — the rule blocks only forced recursive deletes).
+  it('AC-312.1: --recursive without --force is not blocked (force still required)', () => {
+    expect(check('rm --recursive src/').blocked).toBe(false);
+    expect(check('rm -r src/').blocked).toBe(false);
+  });
+
+  // AC-312.2 — a safe-target delete is allowed via short AND long flags.
+  it('AC-312.2: safe-target deletes are allowed (short -rf and long flags)', () => {
+    expect(check('rm -rf node_modules').blocked).toBe(false);
+    expect(check('rm --recursive --force node_modules').blocked).toBe(false);
+    expect(check('rm --force --recursive dist build coverage').blocked).toBe(false);
+  });
+});
+
 describe('denylist journals blocks (AC-7.3)', () => {
   const payload = (cmd) => ({ tool_name: 'Bash', tool_input: { command: cmd }, cwd: '/repo' });
 


### PR DESCRIPTION
## What & why

The denylist `recursive-delete` rule captured only single-dash combined short flags via `/((-[a-zA-Z]+\s*)+)/`, so GNU long flags never matched — `rm --recursive --force src/` (in any order) slipped past the block outside the safe-target dirs. The uppercase `-R` short form was also missed (the check was `/r/`, lowercase-only).

Now recursive is detected via short `-r`/`-R` **or** long `--recursive`, and force via short `-f` **or** long `--force`; both are required, in any order, still gated by `SAFE_RM_TARGETS`. The `(?:^|\s)-` anchor keeps double-dash long flags and mid-word dashes (`file-r.txt`) out of the short-flag bucket, so no false short-flag match. Short-flag behavior, the `{blocked, rule, msg}` shape, and the fail-open guard are unchanged. #311's full-string pipe-to-shell/eval rules are untouched.

## Acceptance criteria

- [x] **AC.1** — the rm rule blocks long-flag equivalents (`--recursive` AND `--force`, in any order) outside the `SAFE_RM_TARGETS` allowlist. Verified by `AC-312.1` test (`rm --recursive --force src/`, `rm --force --recursive src/`, `-R --force`, chained segment) all → `rule: 'recursive-delete'`. `--recursive` alone (no force) still passes, by design.
- [x] **AC.2** — tests cover `rm --recursive --force src/` (blocked) and a safe-target delete like `rm -rf node_modules` (allowed). Verified by `AC-312.1` and `AC-312.2` tests (`rm -rf node_modules`, `rm --recursive --force node_modules`, `rm --force --recursive dist build coverage` all allowed).

## Verification

`pnpm verify` green: **558/558 tests pass** (50 files), including the agy denylist-parity test (AC-289.2) that exercises recursive-delete. No ReDoS: the new regex `/(?:^|\s)-([a-zA-Z]+)/g` is linear. No false positive on common safe deletes (safe-target gate preserved; `--recursive`-only still allowed).

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
