### PR TITLE
feat(gates): guard README version-badge drift in the docsync gate

### DIFF
--- a/plugin/mcp/forge/server.mjs
+++ b/plugin/mcp/forge/server.mjs
@@ -176,7 +176,7 @@ const GATE_SPEC = {
   },
   docsync: {
     invoke: (fn, a, root) => fn({ cwd: root, base: a.base ?? 'main', log: noop }),
-    verdict: (r) => ({ level: r.ok ? 'pass' : 'fail', findings: [...(r.routeGaps ?? []).map((g) => `unindexed doc: ${g}`), ...(r.skillGaps ?? []).map((s) => `undocumented skill: ${s}`)] }),
+    verdict: (r) => ({ level: r.ok ? 'pass' : 'fail', findings: [...(r.routeGaps ?? []).map((g) => `unindexed doc: ${g}`), ...(r.skillGaps ?? []).map((s) => `undocumented skill: ${s}`), ...(r.badgeDrift ? [`README version badge ${r.badgeDrift.badge} ≠ package.json ${r.badgeDrift.pkg}`] : [])] }),
   },
   ground: {
     invoke: (fn, a, root) => fn({ cwd: root, manifestPath: a.manifest, log: noop }),

--- a/plugin/scripts/gates/docsync.mjs
+++ b/plugin/scripts/gates/docsync.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 /**
- * Doc-sync gate (#136): keep the repo's docs in step with what ships. Two
+ * Doc-sync gate (#136): keep the repo's docs in step with what ships. Three
  * mechanical, fail-closed checks run at ship — so manual `ship`, `forge:deliver`,
  * and `forge:autopilot` all inherit them:
  *   1. every doc under docs/ is listed in the docs/README.md route index;
- *   2. a newly-added skill is mentioned in the handbook.
+ *   2. a newly-added skill is mentioned in the handbook;
+ *   3. the README shields.io version badge equals the package.json version (#309).
  * (Releases stay current on their own — release.mjs derives the CHANGELOG from
  * conventional commits. Wiki publish is a separate post-release step.)
  */
@@ -48,6 +49,33 @@ export function skillHandbookGaps(skillNames, handbookText) {
   return skillNames.filter((n) => !text.includes(n)).sort();
 }
 
+/**
+ * #309: the README shields.io version badge is hand-typed and drifts silently
+ * from the real release version in package.json (it once sat at 0.16.0 while the
+ * package was 0.18.0). The route-index check couldn't catch that, so the stale
+ * badge slipped past this very gate. package.json is the single source of truth;
+ * the badge line looks like:
+ *   [![version](https://img.shields.io/badge/version-0.18.0-blue.svg)](CHANGELOG.md)
+ */
+export const BADGE_VERSION_RE = /img\.shields\.io\/badge\/version-(\d+\.\d+\.\d+)-/;
+
+/** The version encoded in the README shields.io badge, or null if there is none. */
+export function parseBadgeVersion(readmeText) {
+  const m = (readmeText ?? '').match(BADGE_VERSION_RE);
+  return m ? m[1] : null;
+}
+
+/**
+ * Drift between the README version badge and the package.json version. Returns
+ * null when they agree — or when there is simply no badge to guard (repos without
+ * one aren't forced to add it) — otherwise { badge, pkg } describing the mismatch.
+ */
+export function badgeVersionDrift(readmeText, pkgVersion) {
+  const badge = parseBadgeVersion(readmeText);
+  if (badge === null || !pkgVersion) return null;
+  return badge === pkgVersion ? null : { badge, pkg: pkgVersion };
+}
+
 /** Recursively list .md files under docs/, relative to docs/ (posix slashes). */
 async function listDocFiles(docsDir) {
   let entries;
@@ -59,12 +87,25 @@ async function listDocFiles(docsDir) {
     .map((p) => p.slice(docsDir.length + 1).replaceAll('\\', '/'));
 }
 
+/** Read the version field from the repo-root package.json, or null if absent/unparsable. */
+async function readPackageVersion(cwd) {
+  const raw = await readFile(resolve(cwd, 'package.json'), 'utf8').catch(() => null);
+  if (raw === null) return null;
+  try { return JSON.parse(raw)?.version ?? null; } catch { return null; }
+}
+
 export async function runDocSync({ cwd, base = 'main', execFn = run, log = console.log }) {
+  // Badge-vs-package drift (#309) is independent of the docs route index, so it
+  // runs even when a repo has no docs/README.md to enforce.
+  const readmeText = await readFile(resolve(cwd, 'README.md'), 'utf8').catch(() => null);
+  const badgeDrift = badgeVersionDrift(readmeText, await readPackageVersion(cwd));
+  if (badgeDrift) log(`✗ README version badge ${badgeDrift.badge} ≠ package.json ${badgeDrift.pkg} — bump the badge to match the released version`);
+
   const docsDir = resolve(cwd, 'docs');
   const indexText = await readFile(join(docsDir, 'README.md'), 'utf8').catch(() => null);
   if (indexText === null) {
-    log('doc-sync: no docs/README.md route index — skipping (nothing to enforce)');
-    return { ok: true, routeGaps: [], skillGaps: [], skipped: true };
+    log('doc-sync: no docs/README.md route index — skipping route/skill checks');
+    return { ok: !badgeDrift, routeGaps: [], skillGaps: [], badgeDrift, skipped: true };
   }
   const docFiles = await listDocFiles(docsDir);
   const routeGaps = routeIndexGaps(docFiles, parseRouteLinks(indexText));
@@ -77,10 +118,10 @@ export async function runDocSync({ cwd, base = 'main', execFn = run, log = conso
 
   for (const g of routeGaps) log(`✗ docs/${g} is not linked in ${ROUTE_INDEX}`);
   for (const s of skillGaps) log(`✗ new skill '${s}' is not mentioned in ${HANDBOOK}`);
-  const ok = routeGaps.length === 0 && skillGaps.length === 0;
-  if (ok) log(`doc-sync: clean (${docFiles.length} docs indexed${skillGaps.length === 0 ? '' : ''})`);
-  else log(`doc-sync: ${routeGaps.length} unindexed doc(s), ${skillGaps.length} undocumented skill(s) — update the route index / handbook before shipping`);
-  return { ok, routeGaps, skillGaps };
+  const ok = routeGaps.length === 0 && skillGaps.length === 0 && !badgeDrift;
+  if (ok) log(`doc-sync: clean (${docFiles.length} docs indexed)`);
+  else log(`doc-sync: ${routeGaps.length} unindexed doc(s), ${skillGaps.length} undocumented skill(s)${badgeDrift ? ', README version badge drift' : ''} — fix before shipping`);
+  return { ok, routeGaps, skillGaps, badgeDrift };
 }
 
 export function parseArgs(argv) {

--- a/tests/gates/docsync.test.mjs
+++ b/tests/gates/docsync.test.mjs
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   parseRouteLinks, routeIndexGaps, addedSkills, skillHandbookGaps, runDocSync,
+  parseBadgeVersion, badgeVersionDrift,
 } from '../../plugin/scripts/gates/docsync.mjs';
+
+const badgeLine = (v) => `[![version](https://img.shields.io/badge/version-${v}-blue.svg)](CHANGELOG.md)`;
 
 describe('doc-sync gate (#136)', () => {
   it('parseRouteLinks extracts relative .md links, skipping http + anchors', () => {
@@ -68,5 +71,47 @@ describe('doc-sync gate (#136)', () => {
     const execFn = async () => ({ ok: true, stdout: '', stderr: '' });
     const res = await runDocSync({ cwd, execFn, log: () => {} });
     expect(res).toMatchObject({ ok: true, skipped: true });
+  });
+});
+
+describe('doc-sync gate: README version badge vs package.json (#309)', () => {
+  it('parseBadgeVersion / badgeVersionDrift compare the badge to the source-of-truth version', () => {
+    expect(parseBadgeVersion(badgeLine('0.18.0'))).toBe('0.18.0');
+    expect(parseBadgeVersion('# no badge here')).toBeNull();
+    // in sync → no drift
+    expect(badgeVersionDrift(badgeLine('0.18.0'), '0.18.0')).toBeNull();
+    // drifted → the mismatch is reported (package.json is the source of truth)
+    expect(badgeVersionDrift(badgeLine('0.16.0'), '0.18.0')).toEqual({ badge: '0.16.0', pkg: '0.18.0' });
+    // no badge to guard → never a false positive
+    expect(badgeVersionDrift('# no badge here', '0.18.0')).toBeNull();
+  });
+
+  // Build a minimal repo tree so runDocSync exercises the real gate end-to-end:
+  // root README.md + package.json + a clean docs/README.md route index.
+  async function scaffold({ badgeVersion, pkgVersion }) {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-docsync-badge-'));
+    await mkdir(join(cwd, 'docs'), { recursive: true });
+    await writeFile(join(cwd, 'README.md'), `# forge\n${badgeLine(badgeVersion)}\n`);
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ version: pkgVersion }));
+    await writeFile(join(cwd, 'docs', 'README.md'), '# index\n'); // no docs → no route gaps
+    return cwd;
+  }
+  const noAdds = async () => ({ ok: true, stdout: '', stderr: '' });
+
+  it('AC-309.1: runDocSync FAILS when the README badge version drifts from package.json', async () => {
+    const cwd = await scaffold({ badgeVersion: '0.16.0', pkgVersion: '0.18.0' });
+    const res = await runDocSync({ cwd, execFn: noAdds, log: () => {} });
+    expect(res.ok).toBe(false);
+    expect(res.badgeDrift).toEqual({ badge: '0.16.0', pkg: '0.18.0' });
+    // isolate the badge check: routes/skills are clean, so this failure is the drift
+    expect(res.routeGaps).toEqual([]);
+    expect(res.skillGaps).toEqual([]);
+  });
+
+  it('AC-309.2: runDocSync PASSES when the README badge matches package.json', async () => {
+    const cwd = await scaffold({ badgeVersion: '0.18.0', pkgVersion: '0.18.0' });
+    const res = await runDocSync({ cwd, execFn: noAdds, log: () => {} });
+    expect(res.ok).toBe(true);
+    expect(res.badgeDrift).toBeNull();
   });
 });


### PR DESCRIPTION
## What & why

The docsync gate (`plugin/scripts/gates/docsync.mjs`) only verified that docs are listed in the `docs/README.md` route index, so the stale README shields.io **version badge** (`0.16.0` while `package.json` was `0.18.0`) slipped past forge's own gate. #308 fixed the badge value and added a standalone vitest guard (`tests/readme-version.test.mjs`); this ticket wires the **same invariant into the docsync GATE** so it's enforced mechanically at ship + CI, not just as a unit test.

## Changes
- `parseBadgeVersion` / `badgeVersionDrift` pure helpers + a badge-vs-`package.json` check in `runDocSync` (package.json is the source of truth). Runs even when there's no `docs/README.md` route index, and is a no-op when the README carries no badge (no false positives).
- MCP gate verdict (`server.mjs`) surfaces badge drift in its findings.
- `tests/gates/docsync.test.mjs` extended with AC-309.1 / AC-309.2 + helper coverage.

## Acceptance criteria
- [x] **AC.1** docsync FAILS when the README version badge != package.json version — badge check added to `runDocSync`; drift sets `res.ok=false` with a clear message. Verified: `AC-309.1` test + running the gate against a drifted tree.
- [x] **AC.2** unit test covers both in-sync (pass) and drifted (fail) cases — `AC-309.2` (pass) and `AC-309.1` (fail) in `tests/gates/docsync.test.mjs`.

## Verification
- `pnpm verify` — 579/579 green (53 files).
- `node plugin/scripts/gates/docsync.mjs --base main` on the current tree → `doc-sync: clean (52 docs indexed)`, exit 0 (badge 0.18.0 == package.json 0.18.0), so CI stays green.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)