### PR TITLE
feat(gates): reject empty/garbage commit subjects in a conventions gate (#310)

### DIFF
--- a/plugin/mcp/forge/server.mjs
+++ b/plugin/mcp/forge/server.mjs
@@ -30,6 +30,7 @@ import { isShaped } from '../../scripts/autopilot/readiness.mjs';
 import { evaluateMergeBar } from '../../scripts/autopilot/merge.mjs';
 import { computeReadiness } from '../../scripts/release/readiness.mjs';
 import { runAcGate } from '../../scripts/gates/acgate.mjs';
+import { runConventions } from '../../scripts/gates/conventions.mjs';
 import { runDepGuard } from '../../scripts/gates/depguard.mjs';
 import { runDocSync } from '../../scripts/gates/docsync.mjs';
 import { runGroundGate } from '../../scripts/gates/groundgate.mjs';
@@ -40,7 +41,7 @@ import { runTestIntent } from '../../scripts/gates/testintent.mjs';
 const noop = () => {};
 
 /** The gate names gate_run dispatches to (spec §b enum). */
-export const GATE_NAMES = ['ac', 'dep', 'docsync', 'ground', 'plandrift', 'situation', 'testintent'];
+export const GATE_NAMES = ['ac', 'conventions', 'dep', 'docsync', 'ground', 'plandrift', 'situation', 'testintent'];
 
 export const TOOLS = [
   {
@@ -107,7 +108,7 @@ export const TOOLS = [
   },
   {
     name: 'gate_run',
-    description: 'Run one mechanical gate and return its verdict as {level:pass|fail, findings[]}. gate is one of ac|dep|docsync|ground|plandrift|situation|testintent.',
+    description: 'Run one mechanical gate and return its verdict as {level:pass|fail, findings[]}. gate is one of ac|conventions|dep|docsync|ground|plandrift|situation|testintent.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -161,7 +162,7 @@ export const DEFAULT_DEPS = {
   selectNext, actionableQueue, normalize, isShaped,
   evaluateMergeBar, computeReadiness, loadConfig,
   execFn: run,
-  gates: { ac: runAcGate, dep: runDepGuard, docsync: runDocSync, ground: runGroundGate, plandrift: runPlanDrift, situation: runSituationGate, testintent: runTestIntent },
+  gates: { ac: runAcGate, conventions: runConventions, dep: runDepGuard, docsync: runDocSync, ground: runGroundGate, plandrift: runPlanDrift, situation: runSituationGate, testintent: runTestIntent },
 };
 
 /** Per-gate: how to invoke it with root+args, and how to read its verdict into {level,findings}. */
@@ -169,6 +170,10 @@ const GATE_SPEC = {
   ac: {
     invoke: (fn, a, root) => fn({ acs: a.acs ?? null, plan: a.plan ?? null, ticket: a.ticket ?? null, results: a.results ?? [], cwd: root }, noop),
     verdict: (r) => ({ level: r.ok ? 'pass' : 'fail', findings: [...(r.missing ?? []).map((i) => `AC ${i}: no passing test`), ...(r.failing ?? []).map((i) => `AC ${i}: failing test`)] }),
+  },
+  conventions: {
+    invoke: (fn, a, root) => fn({ cwd: root, base: a.base ?? 'main', log: noop }),
+    verdict: (r) => ({ level: r.ok ? 'pass' : 'fail', findings: (r.violations ?? []).map((v) => `${v.sha} "${v.subject}": ${v.reason}`) }),
   },
   dep: {
     invoke: (fn, a, root) => fn({ cwd: root, base: a.base ?? 'main', log: noop }),

--- a/plugin/scripts/gates/conventions.mjs
+++ b/plugin/scripts/gates/conventions.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Conventions gate (spec §2 git conventions) — commit-subject lint.
+ *
+ * Guards the ship ritual's conventions check (forge:ship step 2) mechanically:
+ * every commit that will land must carry a real conventional-commit subject
+ * `type(scope)?!?: description`. Empty, punctuation-only, or otherwise
+ * non-conventional subjects are rejected outright.
+ *
+ * Root cause this closes (#310): a squash landed with the subject `@ (#297)`
+ * — a single punctuation char plus the PR number, with the real message buried
+ * in the body — and the prose-only conventions lint never caught it.
+ */
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import { run } from '../lib/exec.mjs';
+
+/**
+ * Accepted commit types: the conventional-commit set plus the extra types this
+ * repo's real history uses (`spike`). Kept broader than release/core.mjs's
+ * release-bump TYPES on purpose — this lints authorship, not version bumps, so
+ * it must accept every legitimate subject the log already contains.
+ */
+export const CONVENTIONAL_TYPES = [
+  'feat', 'fix', 'docs', 'chore', 'refactor', 'test',
+  'perf', 'build', 'ci', 'style', 'revert', 'spike',
+];
+
+/** `type(scope)?!?: description` — scope and the `!` breaking marker optional. */
+const SUBJECT_RE = /^([a-z]+)(\(([^)]*)\))?(!)?:\s+(.+)$/;
+
+/**
+ * Lint one commit subject. Returns { ok: true } for a valid conventional
+ * header, or { ok: false, reason } naming why it was rejected. Pure — no I/O.
+ */
+export function lintSubject(rawSubject) {
+  const subject = (rawSubject ?? '').trim();
+  if (!subject) return { ok: false, reason: 'empty subject' };
+
+  const m = SUBJECT_RE.exec(subject);
+  if (!m) {
+    // No conventional header at all. Call out the pure-garbage case explicitly.
+    if (!/[A-Za-z0-9]/.test(subject)) return { ok: false, reason: 'punctuation-only subject (no conventional-commit header)' };
+    return { ok: false, reason: 'not a conventional-commit header (expected "type(scope): description")' };
+  }
+
+  const type = m[1];
+  if (!CONVENTIONAL_TYPES.includes(type)) {
+    return { ok: false, reason: `unknown type "${type}" (expected one of ${CONVENTIONAL_TYPES.join('|')})` };
+  }
+
+  const description = (m[5] ?? '').trim();
+  if (!description) return { ok: false, reason: 'empty description after type' };
+  // A description that is only punctuation / issue refs (e.g. "@", "...", "(#297)")
+  // carries no meaning — reject it the same as an empty one.
+  const meaningful = description.replace(/\(?#\d+\)?/g, '').trim();
+  if (!/[A-Za-z0-9]/.test(meaningful)) return { ok: false, reason: 'punctuation-only description (no words)' };
+
+  return { ok: true };
+}
+
+/**
+ * Read the subjects of the commits on this branch (base..HEAD, merges excluded)
+ * and lint each. Returns { ok, violations:[{sha,subject,reason}] }.
+ */
+export async function runConventions({ cwd, base = 'main', execFn = run, log = console.log } = {}) {
+  const res = await execFn('git', ['-C', cwd, 'log', '--no-merges', '--format=%H %s', `${base}..HEAD`]);
+  if (!res.ok) return { ok: false, error: `git log failed: ${res.stderr}` };
+
+  const violations = [];
+  for (const line of res.stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const gap = line.indexOf(' ');
+    const sha = gap === -1 ? line : line.slice(0, gap);
+    const subject = gap === -1 ? '' : line.slice(gap + 1);
+    const verdict = lintSubject(subject);
+    if (!verdict.ok) violations.push({ sha: sha.slice(0, 7), subject, reason: verdict.reason });
+  }
+
+  for (const v of violations) log(`x ${v.sha} "${v.subject}" - ${v.reason}`);
+  if (violations.length) {
+    log(`conventions: ${violations.length} commit subject(s) fail the conventional-commit rule (spec §2) — reword before shipping`);
+  } else {
+    log('conventions: clean — every commit subject is a valid conventional-commit header');
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const base = process.argv.includes('--base') ? process.argv[process.argv.indexOf('--base') + 1] : 'main';
+  runConventions({ cwd: process.cwd(), base }).then((r) => {
+    if (r.error) console.error(r.error);
+    process.exit(r.ok ? 0 : 1);
+  });
+}

--- a/plugin/skills/ship/SKILL.md
+++ b/plugin/skills/ship/SKILL.md
@@ -10,7 +10,7 @@ Branch → PR with gates, then the post-merge ritual. Since SP5 the core gates a
 ## Pre-PR checklist (in order — a failed gate stops the ritual)
 
 1. **Situation gate** (spec §7): `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/situationgate.mjs" --action ship --branch <branch>` — during an incident only `hotfix/*` ships; during security-response nothing ships. A refusal names the unlocking command; don't argue with it.
-2. **Conventions lint** (spec §2): branch matches `<type>/<issue#>-<slug>`; every commit `type(scope): subject (#issue)` ≤72 chars; intended PR title is conventional-format with the issue ref. **Spike branches never ship** — a `spike/…` branch asking for a PR is refused outright (spec §4 item 12: findings merge as ADRs, code is re-implemented via plan/execute).
+2. **Conventions lint** (spec §2): branch matches `<type>/<issue#>-<slug>`; every commit `type(scope): subject (#issue)` ≤72 chars; intended PR title is conventional-format with the issue ref. The commit-subject rule is enforced mechanically — `node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/conventions.mjs" --base main` rejects any empty, punctuation-only, or non-conventional subject (e.g. a squash that landed as `@ (#297)`). **Spike branches never ship** — a `spike/…` branch asking for a PR is refused outright (spec §4 item 12: findings merge as ADRs, code is re-implemented via plan/execute).
 3. **Rebase on main**; run the configured verify command — must pass locally.
 4. **Commits→issues map**: every commit has a ticket; otherwise apply the unplanned-work rule (trail `note` or triage).
 5. **Mechanical gates** (spec §13):

--- a/tests/gates/conventions.test.mjs
+++ b/tests/gates/conventions.test.mjs
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { lintSubject, runConventions, CONVENTIONAL_TYPES } from '../../plugin/scripts/gates/conventions.mjs';
+
+const noop = () => {};
+
+describe('conventions gate — commit-subject lint (#310)', () => {
+  it('AC-310.2: rejects a garbage subject ("@") and accepts a valid one ("fix(hooks): block pipe-to-shell")', () => {
+    const garbage = lintSubject('@');
+    expect(garbage.ok).toBe(false);
+    expect(garbage.reason).toMatch(/punctuation-only/);
+
+    expect(lintSubject('fix(hooks): block pipe-to-shell')).toEqual({ ok: true });
+  });
+
+  it('AC-310.1: rejects empty, whitespace-only, and punctuation-only subjects', () => {
+    expect(lintSubject('').ok).toBe(false);
+    expect(lintSubject('   ').ok).toBe(false);
+    expect(lintSubject('...').ok).toBe(false);
+    expect(lintSubject('!!!').ok).toBe(false);
+  });
+
+  it('AC-310.1: rejects the exact #310 root-cause subject "@ (#297)"', () => {
+    const v = lintSubject('@ (#297)');
+    expect(v.ok).toBe(false);
+  });
+
+  it('AC-310.1: rejects a header whose description is only an issue ref / punctuation', () => {
+    expect(lintSubject('fix: (#297)').ok).toBe(false); // no words after the type
+    expect(lintSubject('feat: ...').ok).toBe(false);
+  });
+
+  it('AC-310.1: rejects a non-conventional prose subject and an unknown type', () => {
+    expect(lintSubject('just fixed some stuff').ok).toBe(false);
+    const bad = lintSubject('wibble: do a thing');
+    expect(bad.ok).toBe(false);
+    expect(bad.reason).toMatch(/unknown type/);
+  });
+
+  it('AC-310.1: accepts real historical subject shapes (scope, !, spike, refs)', () => {
+    const valid = [
+      'feat(gates): guard README version-badge drift in the docsync gate (#327)',
+      'fix(hooks): block rm long flags (--recursive --force) in denylist (#324)',
+      'test(hooks): contract-test agy safety shims (agy-deny + agy-capture) (#313) (#325)',
+      'spike(cross-gai): scope agy-only + decompose #174 into build tickets',
+      'chore: release v0.18.0',
+      'feat!: drop the legacy roster format',
+      'refactor(mcp): factor rpc transport',
+    ];
+    for (const s of valid) expect(lintSubject(s), s).toEqual({ ok: true });
+  });
+
+  it('every accepted type is a lowercase conventional/known type', () => {
+    expect(CONVENTIONAL_TYPES).toContain('feat');
+    expect(CONVENTIONAL_TYPES).toContain('spike');
+    for (const t of CONVENTIONAL_TYPES) expect(t).toMatch(/^[a-z]+$/);
+  });
+
+  it('AC-310.1: runConventions wires git log and fails on a garbage subject, passes when clean', async () => {
+    const withGarbage = async () => ({
+      ok: true,
+      stdout: 'abc1234567 @ (#297)\ndef8901234 feat(x): a real change (#5)\n',
+      stderr: '',
+    });
+    const bad = await runConventions({ cwd: '.', execFn: withGarbage, log: noop });
+    expect(bad.ok).toBe(false);
+    expect(bad.violations).toHaveLength(1);
+    expect(bad.violations[0]).toMatchObject({ sha: 'abc1234', subject: '@ (#297)' });
+
+    const clean = async () => ({ ok: true, stdout: 'aaa1111222 fix(hooks): block pipe-to-shell (#311)\n', stderr: '' });
+    const good = await runConventions({ cwd: '.', execFn: clean, log: noop });
+    expect(good.ok).toBe(true);
+    expect(good.violations).toEqual([]);
+  });
+
+  it('runConventions surfaces a git error instead of throwing', async () => {
+    const boom = async () => ({ ok: false, stdout: '', stderr: 'fatal: bad revision' });
+    const res = await runConventions({ cwd: '.', execFn: boom, log: noop });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/git log failed/);
+  });
+});

--- a/tests/mcp-forge/forge-core.test.mjs
+++ b/tests/mcp-forge/forge-core.test.mjs
@@ -43,9 +43,9 @@ describe('AC-288.1: rpc.mjs is the shared transport (forge-graph regression-free
     expect(await h({ jsonrpc: '2.0', method: 'notifications/initialized' })).toBe(null);
   });
 
-  it('exposes exactly the 9 documented tools and the 7 gate names', () => {
+  it('exposes exactly the 9 documented tools and the 8 gate names', () => {
     expect(TOOLS).toHaveLength(9);
-    expect(GATE_NAMES).toEqual(['ac', 'dep', 'docsync', 'ground', 'plandrift', 'situation', 'testintent']);
+    expect(GATE_NAMES).toEqual(['ac', 'conventions', 'dep', 'docsync', 'ground', 'plandrift', 'situation', 'testintent']);
   });
 });
 
@@ -108,6 +108,11 @@ describe('AC-288.2: every tool is callable and returns its documented structured
   it('AC-288.2: gate_run dep -> fail level surfaces findings', async () => {
     const h = build({ deps: { gates: { dep: async () => ({ ok: false, violations: [{ name: 'left-pad', reason: 'too new (3d old)' }] }) } } });
     expect(body(await call(h, 'gate_run', { gate: 'dep' }))).toEqual({ ok: true, gate: 'dep', level: 'fail', findings: ['left-pad: too new (3d old)'] });
+  });
+
+  it('AC-310.1: gate_run conventions -> fail level surfaces garbage-subject findings', async () => {
+    const h = build({ deps: { gates: { conventions: async () => ({ ok: false, violations: [{ sha: 'abc1234', subject: '@ (#297)', reason: 'not a conventional-commit header (expected "type(scope): description")' }] }) } } });
+    expect(body(await call(h, 'gate_run', { gate: 'conventions' }))).toEqual({ ok: true, gate: 'conventions', level: 'fail', findings: ['abc1234 "@ (#297)": not a conventional-commit header (expected "type(scope): description")'] });
   });
 
   it('AC-288.2: release_readiness -> {ok,items:[{name,level,msg}]}', async () => {


### PR DESCRIPTION
Closes #310

## What & why
forge's conventions lint (forge:ship step 2) was **prose-only**, so a squash
merged with the subject `@ (#297)` — a single punctuation char plus the PR
number, with the real conventional message buried in the body. Nothing
mechanical caught it.

This adds a focused **`conventions` gate** (`plugin/scripts/gates/conventions.mjs`)
that lints every commit subject on the branch (`base..HEAD`, merges excluded)
against the conventional-commit header rule and rejects empty, punctuation-only,
or otherwise non-conventional subjects.

- `lintSubject(subject)` — pure verdict `{ok, reason}`; rejects empty /
  whitespace / punctuation-only subjects, missing or unknown types, and
  descriptions that carry no words (e.g. `fix: (#297)`).
- `runConventions({cwd, base, execFn})` — reads `git log --no-merges --format=%H %s`
  and collects violations.
- Accepted type list is a **superset** of `release/core.mjs`'s bump types
  (adds `spike`, `build`, `ci`, `style`, `revert`) so it accepts every
  legitimate subject already in this repo's history — verified against the
  last 40 subjects.
- Wired into the forge-core MCP `gate_run` dispatch (`GATE_NAMES`, `gates`,
  `GATE_SPEC`) and referenced from the ship ritual's step-2 lint.

## Acceptance criteria
- [x] **AC-310.1** — the lint fails a commit whose subject is empty,
  punctuation-only, or not a valid conventional-commit header.
  *Verified:* `tests/gates/conventions.test.mjs` covers empty / whitespace /
  `...` / `!!!` / `@ (#297)` / `fix: (#297)` / prose / unknown-type, plus
  `runConventions` failing on a garbage subject; dogfooded via
  `node plugin/scripts/gates/conventions.mjs --base main` (exit 0 on this
  branch's real commit).
- [x] **AC-310.2** — test covers a garbage subject (`@`) and a valid subject
  (`fix(hooks): block pipe-to-shell`).
  *Verified:* named test `AC-310.2` asserts both; MCP-level `AC-310.1` test
  asserts `gate_run conventions` surfaces the `@ (#297)` finding.

## Verification
- `pnpm verify` — **589 passed / 589** (full suite), locally, on the rebased branch.
- New tests: `tests/gates/conventions.test.mjs` (9) + `tests/mcp-forge/forge-core.test.mjs` (updated GATE_NAMES + new AC-310.1 gate_run case).
- Gate CLI dogfooded green against `main`.
- **Not verified:** live CI runner (delegated to the CI checks on this PR); no runtime UI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)