### PR TITLE
fix(autopilot): watchdog for the return-then-resume stall (#319)

### DIFF
--- a/plugin/scripts/autopilot/watchdog.mjs
+++ b/plugin/scripts/autopilot/watchdog.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * autopilot return-then-resume watchdog (#319, epic #183).
+ *
+ * The headline autopilot stall: a delivery subagent opens a PR, watches CI to
+ * green, and then RETURNS reporting `awaiting-merge` — awaiting a re-invocation
+ * that never comes. Its context is discarded on return and nothing re-drives it,
+ * so the ticket parks at an open, green PR forever. There was no detection today:
+ * the loop read the report and moved on, silently leaving the ticket un-merged —
+ * and a subagent that never moved the board status may never be re-selected.
+ *
+ * This is the mechanical detector the loop runs the moment it reads a delivery
+ * subagent's terminal report. It is PURE — it maps a returned report to a single
+ * action, so the invariant is testable in isolation from GitHub:
+ *
+ *   INVARIANT: an `awaiting-merge` report is NEVER left as a silent terminal
+ *   state. On a green PR it either MERGES (auto-merge authority → funnel the PR
+ *   through the tested bar, `runMerge`) or is SURFACED (pr-only / can't-merge →
+ *   escalate, recording awaiting-human/escalated visibly) — never silently parked
+ *   as if resolved.
+ *
+ * Every other outcome (merged/escalated/awaiting-human/skipped) is already a
+ * resolved, recordable state, so the watchdog passes it through as `continue`.
+ * The merge action funnels to `merge.mjs` `runMerge`, which RE-checks CI itself
+ * (fail-closed), so the watchdog's `ciGreen` is a gate on even attempting it, not
+ * a substitute for the bar.
+ */
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { isAutoMergeMode } from './preflight.mjs';
+
+/** The one returned outcome that is NOT a resolved terminal state — the stall this guards. */
+export const STALL_OUTCOME = 'awaiting-merge';
+
+/**
+ * Resolve a delivery subagent's terminal report into a loop action.
+ *
+ * @param {object} report
+ * @param {string} report.outcome          the subagent's returned outcome.
+ * @param {number|null} [report.pr]         the open PR number, when one exists.
+ * @param {boolean} [report.ciGreen]        did the subagent observe CI green in-run?
+ * @param {string|null} [report.mergeMode]  the run's effective merge mode
+ *   (`auto-merge`|`pr-only`) as recorded by the preflight in run.json.
+ * @returns {{ action:'merge'|'escalate'|'continue', pr?:number, outcome:(string|null), reason:string }}
+ *   `merge`    → funnel `pr` through `runMerge` (the tested bar re-checks CI).
+ *   `escalate` → surface visibly; `outcome` is the state the loop records —
+ *                `awaiting-human` for a green PR with no merge authority (pr-only),
+ *                else `escalated` for a genuinely un-mergeable return.
+ *   `continue` → already resolved; record the reported `outcome` and move on.
+ */
+export function resolveReturnedTicket({ outcome, pr = null, ciGreen = false, mergeMode = null } = {}) {
+  if (outcome !== STALL_OUTCOME) {
+    return {
+      action: 'continue',
+      outcome: outcome ?? null,
+      reason: `outcome '${outcome ?? 'none'}' is already a resolved state — record it and continue`,
+    };
+  }
+  // From here: an awaiting-merge report — the return-then-resume stall. Never leave it silent.
+  if (!Number.isInteger(pr)) {
+    return {
+      action: 'escalate',
+      outcome: 'escalated',
+      reason: 'awaiting-merge returned with no PR — cannot verify or merge; surfacing rather than silently parking',
+    };
+  }
+  if (ciGreen !== true) {
+    return {
+      action: 'escalate',
+      outcome: 'escalated',
+      reason:
+        `awaiting-merge returned before PR #${pr} CI was green — the subagent did not watch CI to conclusion in-run; ` +
+        'surfacing rather than silently parking',
+    };
+  }
+  if (isAutoMergeMode(mergeMode)) {
+    return {
+      action: 'merge',
+      pr,
+      outcome: 'merged',
+      reason: `awaiting-merge on green PR #${pr} with auto-merge authority — re-driving through the merge bar (runMerge)`,
+    };
+  }
+  // Green PR but no merge authority (pr-only / no in-session grant): surface as awaiting-human, visibly.
+  return {
+    action: 'escalate',
+    outcome: 'awaiting-human',
+    reason:
+      `awaiting-merge on green PR #${pr} but merge mode is '${mergeMode ?? 'unset'}' (no auto-merge authority) — ` +
+      'recording awaiting-human visibly, not silently parking',
+  };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  const argv = process.argv.slice(2);
+  const val = (flag) => (argv.includes(flag) ? argv[argv.indexOf(flag) + 1] : undefined);
+  const prRaw = val('--pr');
+  const dec = resolveReturnedTicket({
+    outcome: val('--outcome'),
+    pr: prRaw != null ? Number(prRaw) : null,
+    ciGreen: argv.includes('--ci-green'),
+    mergeMode: val('--mode') ?? null,
+  });
+  console.log(`watchdog: ${dec.action}${dec.pr ? ` (PR #${dec.pr})` : ''} → record ${dec.outcome ?? '—'} — ${dec.reason}`);
+  process.exit(dec.action === 'escalate' ? 3 : 0);
+}

--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -40,8 +40,11 @@ SPAWN a delivery subagent (Task tool) for this ticket ────────�
   return {issue, outcome, pr, notes}                            │
   ▼                                                             │
 main loop reads ONLY that terminal report ◀────────────────────┘
-  ├─ outcome=escalated / awaiting-human ─▶ record + park, continue with next ticket
-  ├─ outcome=merged ─────────────────────▶ record to run.json · trail --phase merged
+  │  WATCHDOG: resolveReturnedTicket(report) (§ Return-then-resume watchdog)  ← run on EVERY report
+  ├─ action=merge ───────────────────────▶ funnel the PR through the merge bar (autopilot_merge/runMerge)
+  ├─ action=escalate ────────────────────▶ surface visibly (record awaiting-human / escalate) — never a silent park
+  ├─ action=continue: outcome=escalated / awaiting-human ─▶ record + park, continue with next ticket
+  ├─ action=continue: outcome=merged ────▶ record to run.json · trail --phase merged
   └─ subagent filed new work ────────────▶ already on the board — re-enters the queue
   ▼
 loop  (main context unchanged — ~O(1) per ticket)
@@ -54,10 +57,20 @@ Per ticket, the main loop does exactly three things: **spawn**, **record**, **co
 1. **Spawn a delivery subagent** with the Task tool — `subagent_type: general-purpose` (or a dedicated delivery agent if the roster has one). The brief is self-contained so the subagent needs no main-loop context: the ticket ref + body, the route (deliver, or shape-first under `--shape`), the merge bar (§ auto-merge), the escalation triggers (§ human gates), and this instruction — *do the whole ticket in your own context (branch, plan, implement, test, gates, ship, open the PR, **watch CI to green in this same run with `gh pr checks <pr> --watch`**, auto-merge on green, post-merge ritual); file follow-ups directly with `board/create.mjs`; escalate with `escalate.mjs`; then return a compact terminal report and nothing else.*
 
    **Forbidden — the return-then-resume stall:** the brief must NOT tell the subagent to open the PR and then return awaiting an external/background completion notification (e.g. "await the CI watcher's notification"). The subagent's context is discarded on return and **nothing re-invokes it when CI goes green** — that stalls the ticket until a manual resume. The background CI monitor notifies the **main loop**, not a returned subagent. The subagent must therefore watch CI to conclusion **in-run itself** (`gh pr checks <pr> --watch`) and merge within the **same invocation** — never return on the assumption it will be re-spawned on green.
-2. **Read only the terminal report** — `{issue, outcome: merged|escalated|awaiting-human|skipped, pr, notes}`. The main loop consumes that JSON, writes it to `run.json`, trails the ticket, and never re-reads the subagent's work.
+2. **Read only the terminal report** — `{issue, outcome: merged|escalated|awaiting-human|skipped, pr, notes}` — and **run it through the watchdog** (`watchdog.mjs` `resolveReturnedTicket`, § Return-then-resume watchdog) before recording. A subagent that returns `awaiting-merge` (opened a green PR, then returned awaiting a re-invocation) must NOT be recorded as a silent terminal state — the watchdog turns that into a `merge` (funnel to the bar) or an `escalate` (surface awaiting-human / escalate). Every already-resolved outcome passes through as `continue`. The main loop then writes the resolved outcome to `run.json`, trails the ticket, and never re-reads the subagent's work.
 3. **Continue** to the next ticket. Because the delivery context is discarded, the main window is unchanged between tickets — a 5-ticket and a 50-ticket run cost the same orchestration overhead, and the run never compacts mid-loop.
 
 A subagent that can't finish (deadlock, a gate failing twice, an ungrounded shape) returns `outcome: escalated` with the reason; the loop parks that one ticket and moves on. Never fall back to delivering inline — a missing/broken delivery subagent is itself an escalation.
+
+## Return-then-resume watchdog — awaiting-merge is never silently parked (#319)
+
+The forbidden pattern above (§ Orchestration) is a *briefing* rule; this is its **mechanical backstop**. Even a correctly-briefed subagent can return `awaiting-merge` — it opened a PR, watched CI green, then returned at the open green PR awaiting a re-invocation that never comes. Its context is discarded on return and nothing re-drives it, so without detection the ticket parks at a green PR **forever** (and a subagent that never moved the board status may never be re-selected). So the loop runs **every** returned report through `watchdog.mjs` `resolveReturnedTicket({ outcome, pr, ciGreen, mergeMode })` — a pure decision that maps the report to one action:
+
+- **`merge`** — `awaiting-merge` on a **green** PR with **auto-merge** authority (the run's recorded `mergeMode`): funnel the PR through the tested bar (`autopilot_merge` / `runMerge`), which re-checks CI itself. The stall becomes a merge.
+- **`escalate`** — `awaiting-merge` that can't merge: a green PR under **pr-only** (no in-session grant) is recorded **awaiting-human visibly**; a return with **no PR** or a **not-yet-green** PR (the subagent skipped its in-run `--watch`) is **escalated**. Either way it is *surfaced*, never silently parked.
+- **`continue`** — every already-resolved outcome (`merged`/`escalated`/`awaiting-human`/`skipped`): record the reported outcome and move on.
+
+**The invariant:** an `awaiting-merge` report is NEVER left as a silent terminal state — it either merges or is surfaced. Selection is resume-safe by the same token: a ticket returned at an open green PR is still at a resume-tier board status (`inReview`/`inProgress`), so `selectNext` re-picks it as `resume` on the next iteration (and even a ticket left at `ready`/`backlog` is re-delivered, never dropped) — the watchdog and the resume path are belt-and-suspenders against the same stall.
 
 ## Permissions — required for a continuous run
 
@@ -167,6 +180,7 @@ The loop is prose the orchestrator runs, but its mechanical decisions are real, 
 - `merge.mjs` — `evaluateMergeBar(signals)` + `runMerge(ctx,{issue,pr,signals,mode})`: the auto-merge bar. Fail-closed — a missing signal is red; `features.autopilotAutoMerge:false` **or** the preflight's `mode:'pr-only'` parks at the PR. This is where "nothing merges on red" lives. `runMerge` is the **canonical, enforced merge entry point**, exposed to hosts as the `autopilot_merge` MCP tool (forge-core) so the live merge is executed through the bar by construction — never via a raw `gh pr merge`.
 - `preflight.mjs` — `mergeAuthPreflight({authorized,config})`: the run-start merge-authorization decision (§ Merge-authorization preflight). Pure — returns the effective merge `mode` (`auto-merge` only on an explicit in-session grant + config-enabled; else `pr-only` with the notice to surface). `startRun` records it into `run.json`; `runMerge` gates on it. This is what stops an unattended run from delivering a whole ticket and then silently wedging at the first merge (#316).
 - `ledger.mjs` — the run ledger (`.forge/autopilot/run.json`): `applyOutcome`/`applyFiled`/`guardTripped`/`nextIteration`/`renderReport`, plus `ledger.mjs report`. `nextIteration(run, boardSize)` is the per-iteration **runaway backstop** the loop calls first each iteration — the real caller for `guardTripped` (halt + escalate on trip; #317). The resume point too.
+- `watchdog.mjs` — `resolveReturnedTicket({outcome,pr,ciGreen,mergeMode})`: the return-then-resume watchdog (§ Return-then-resume watchdog). Pure — the loop runs it on **every** subagent report so an `awaiting-merge` on a green PR is re-driven to the merge bar or surfaced, never silently parked (#319).
 - `newwork.mjs` — `fileWork(ctx,{title,kind,from})`: files a linked follow-up (bug/spike/item) mid-run.
 - `perms.mjs` — prints the `.claude/settings.local.json` allowlist autopilot needs to run continuously (non-destructive; opt-in).
 

--- a/tests/autopilot/engine.test.mjs
+++ b/tests/autopilot/engine.test.mjs
@@ -8,6 +8,7 @@ import { selectNext, actionFor, actionableQueue, normalize } from '../../plugin/
 import { evaluateMergeBar, autoMergeEnabled, ciGreen, runMerge, BAR_SIGNALS } from '../../plugin/scripts/autopilot/merge.mjs';
 import { applyOutcome, applyFiled, guardTripped, nextIteration, renderReport, freshRun, startRun, recordOutcome, loadRun, RUN_RELPATH } from '../../plugin/scripts/autopilot/ledger.mjs';
 import { mergeAuthPreflight, isAutoMergeMode, MERGE_MODES } from '../../plugin/scripts/autopilot/preflight.mjs';
+import { resolveReturnedTicket, STALL_OUTCOME } from '../../plugin/scripts/autopilot/watchdog.mjs';
 import { toType, fileWork, KIND_TO_TYPE } from '../../plugin/scripts/autopilot/newwork.mjs';
 import { isShaped, DEFAULT_AC_HEADINGS } from '../../plugin/scripts/autopilot/readiness.mjs';
 import { ALLOW, permsBlock } from '../../plugin/scripts/autopilot/perms.mjs';
@@ -341,6 +342,92 @@ describe('autopilot merge-auth preflight (#316, AC-316.1/AC-316.2) — no silent
     const parked = await runMerge({ config: { features: { autopilotAutoMerge: false } }, gh: disabled.gh }, { issue: 5, pr: 42, signals: heldVerdicts }, () => {});
     expect(parked).toMatchObject({ merged: false, parked: true, outcome: 'awaiting-human' });
     expect(disabled.calls.some((c) => c.startsWith('pr merge'))).toBe(false);
+  });
+});
+
+describe('autopilot return-then-resume watchdog (#319, AC-319.1/AC-319.2) — awaiting-merge is never silently parked', () => {
+  const heldVerdicts = { ship: true, gates: true, reviewer: true, security: true };
+
+  // AC-319.1: a returned awaiting-merge on a green PR resolves to merge/escalate — never a silent park.
+  it('AC-319.1: awaiting-merge on a green PR with auto-merge authority → merge (funnel to runMerge), not a silent park', () => {
+    const dec = resolveReturnedTicket({ outcome: 'awaiting-merge', pr: 42, ciGreen: true, mergeMode: 'auto-merge' });
+    expect(dec.action).toBe('merge');
+    expect(dec.pr).toBe(42);
+    expect(dec.outcome).toBe('merged');
+    expect(dec.action).not.toBe('continue'); // the stall guard: never silently parked
+    expect(STALL_OUTCOME).toBe('awaiting-merge');
+  });
+
+  it('AC-319.1: awaiting-merge on a green PR without merge authority (pr-only) → escalate, recorded awaiting-human (surfaced, not parked)', () => {
+    for (const mergeMode of ['pr-only', null, undefined]) {
+      const dec = resolveReturnedTicket({ outcome: 'awaiting-merge', pr: 42, ciGreen: true, mergeMode });
+      expect(dec.action, `mode=${mergeMode}`).toBe('escalate');
+      expect(dec.outcome, `mode=${mergeMode}`).toBe('awaiting-human'); // surfaced visibly, not a silent park
+      expect(dec.action).not.toBe('continue');
+      expect(dec.reason).toMatch(/not silently parking/i);
+    }
+  });
+
+  it('AC-319.1: awaiting-merge that is NOT actually mergeable (no PR, or PR not green) → escalate, never silent', () => {
+    // returned awaiting-merge but no PR at all — cannot verify or merge.
+    const noPr = resolveReturnedTicket({ outcome: 'awaiting-merge', pr: null, ciGreen: true, mergeMode: 'auto-merge' });
+    expect(noPr.action).toBe('escalate');
+    expect(noPr.outcome).toBe('escalated');
+    expect(noPr.reason).toMatch(/no PR/i);
+    // returned awaiting-merge before CI concluded — the subagent skipped the in-run --watch.
+    const notGreen = resolveReturnedTicket({ outcome: 'awaiting-merge', pr: 42, ciGreen: false, mergeMode: 'auto-merge' });
+    expect(notGreen.action).toBe('escalate');
+    expect(notGreen.outcome).toBe('escalated');
+    expect(notGreen.reason).toMatch(/before PR #42 CI was green/i);
+  });
+
+  it('AC-319.1: every OTHER (already-resolved) outcome passes through as continue — the watchdog only fires on the stall', () => {
+    for (const outcome of ['merged', 'escalated', 'awaiting-human', 'skipped']) {
+      const dec = resolveReturnedTicket({ outcome, pr: 42, ciGreen: true, mergeMode: 'auto-merge' });
+      expect(dec.action, outcome).toBe('continue');
+      expect(dec.outcome, outcome).toBe(outcome); // record the outcome the subagent already reported
+    }
+    // an absent/unknown outcome is likewise not the stall — pass through.
+    expect(resolveReturnedTicket({}).action).toBe('continue');
+  });
+
+  it("AC-319.1: the watchdog's merge action actually drives runMerge to a squash-merge on a green bar", async () => {
+    // Prove the resolved `merge` action funnels to the tested bar and merges (end-to-end with the returned report).
+    const calls = [];
+    const gh = async (args) => {
+      calls.push(args.join(' '));
+      if (args[0] === 'pr' && args[1] === 'view') return { ok: true, json: { statusCheckRollup: [{ conclusion: 'SUCCESS' }] } };
+      return { ok: true };
+    };
+    const dec = resolveReturnedTicket({ outcome: 'awaiting-merge', pr: 9, ciGreen: true, mergeMode: 'auto-merge' });
+    expect(dec.action).toBe('merge');
+    const res = await runMerge({ config: {}, gh }, { issue: 1, pr: dec.pr, signals: heldVerdicts, mode: 'auto-merge' }, () => {});
+    expect(res).toMatchObject({ ok: true, merged: true, outcome: 'merged' });
+    expect(calls).toContain('pr merge 9 --squash --delete-branch');
+  });
+
+  // AC-319.2: a ticket returned at a green PR is PICKED BACK UP by selection (resume path), not skipped.
+  it('AC-319.2: a returned-at-green-PR ticket (board still inReview/inProgress) re-enters selection as resume', () => {
+    // The board status for an open PR is a resume-tier status; selection must re-pick it, not skip it.
+    for (const status of ['inReview', 'inProgress']) {
+      const pick = selectNext([t(319, status)]);
+      expect(pick, `status=${status} must be selectable`).not.toBeNull();
+      expect(pick.ticket.number).toBe(319);
+      expect(pick.action).toBe('resume'); // reuses the existing resume path — re-driven, never silently parked
+    }
+    // even if the subagent never moved the board off ready/backlog, it is still picked back up (re-delivered),
+    // i.e. the returned ticket is NEVER dropped from selection.
+    expect(selectNext([t(319, 'ready')]).action).toBe('deliver');
+    expect(selectNext([t(319, 'backlog')]).action).toBe('triage');
+  });
+
+  it('AC-319.2: the returned green-PR ticket sits ahead of fresh work — resume beats ready/backlog so it is re-driven first', () => {
+    const tickets = [t(400, 'ready', 'p0'), t(319, 'inReview', 'p2'), t(500, 'backlog', 'p0')];
+    // despite its low priority, the resumed green-PR ticket wins the tier and is picked back up first.
+    const pick = selectNext(tickets);
+    expect(pick.ticket.number).toBe(319);
+    expect(pick.action).toBe('resume');
+    expect(actionableQueue(tickets).map((q) => q.ticket.number)).toEqual([319, 400, 500]);
   });
 });
 


### PR DESCRIPTION
Closes #319 · parent epic #183

## Problem
The headline autopilot failure mode: a delivery subagent opens a PR, watches CI to green, then **returns reporting `awaiting-merge`** — awaiting a re-invocation that never comes. Its context is discarded on return, nothing re-drives it, and a subagent that never moved the board status may never be re-selected. Result: the ticket silently stalls at an open, green PR forever. There was **no detection** today — the loop read the report and moved on.

## Change
A thin, pure watchdog the loop runs on **every** returned report, consistent with the #315–#318 helper patterns.

`plugin/scripts/autopilot/watchdog.mjs` — `resolveReturnedTicket({ outcome, pr, ciGreen, mergeMode })` → one action:
- **`merge`** — `awaiting-merge` on a **green** PR with **auto-merge** authority (run's recorded `mergeMode`): funnel the PR through the tested bar (`autopilot_merge`/`runMerge`), which re-checks CI itself.
- **`escalate`** — `awaiting-merge` that can't merge: a green PR under **pr-only** is recorded **awaiting-human visibly**; **no PR** / **not-yet-green** is escalated. Surfaced, never silently parked.
- **`continue`** — every already-resolved outcome (`merged`/`escalated`/`awaiting-human`/`skipped`) passes through.

**Invariant:** an `awaiting-merge` report is NEVER left as a silent terminal state. Selection is resume-safe by the same token — a ticket returned at a green PR is at a resume-tier board status (`inReview`/`inProgress`), so `selectNext` re-picks it as `resume` (reusing the existing resume path); a ticket left at `ready`/`backlog` is re-delivered, never dropped.

`plugin/skills/autopilot/SKILL.md` — the loop step that reads the subagent report now **mechanically invokes the watchdog** (not just the prose warning): loop diagram, Orchestration step 2, a dedicated section, and the driver-scripts list.

## Acceptance criteria
- [x] **AC.1** — the loop detects a ticket left at an open, green PR without a merge and re-drives it to merge (or escalates) rather than silently parking it. *Verified:* `resolveReturnedTicket` returns `merge` (auto-merge) / `escalate` (pr-only or un-mergeable), never `continue`, for an `awaiting-merge` report; an AC-319.1 test drives the resolved `merge` action end-to-end through `runMerge` to a `pr merge --squash`.
- [x] **AC.2** — test covers a returned-at-green-PR ticket being picked back up. *Verified:* AC-319.2 asserts `selectNext` re-picks an `inReview`/`inProgress` ticket as `resume` (and `ready`/`backlog` as re-deliver), and that it wins the resume tier ahead of fresh work.

## Verification
- `pnpm verify` — **618/618 green** (6 new #319 tests; all prior autopilot tests preserved).
- Watchdog CLI smoke-tested across `auto-merge` / `pr-only` / already-resolved reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)