### PR TITLE
docs(hooks): narrow denylist header comment to its actual scope (#314)

### DIFF
--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -1,9 +1,18 @@
 #!/usr/bin/env node
 /**
  * PreToolUse denylist hook (spec §7 trigger + §13 blast-radius; plan T4).
- * Blocks destructive commands with an escalate-instead message. Exit 2 =
- * block (stderr shown to the model); any internal error fails OPEN (exit 0)
- * — a safety hook must never take the session down (AC-3.4).
+ *
+ * A TARGETED backstop — NOT a general destructive-command sandbox. It matches a
+ * fixed set of high-blast-radius shell patterns and nothing else: git history/
+ * branch operations (force-push, protected-branch delete, hard-reset, clean -f,
+ * filter-branch/-repo), `rm` recursive-force outside build/temp dirs, and
+ * pipe-to-shell / eval-of-substitution RCE (see RULES). Anything not in that list
+ * — including most ways to destroy data — passes through untouched.
+ *
+ * It FAILS OPEN by design: a matched command exits 2 (block; stderr shown to the
+ * model), but a non-match, unknown input, or any internal error returns exit 0 so
+ * a safety hook can never take the session down (AC-3.4). Treat it as a tripwire
+ * for a few known-catastrophic commands, not a security boundary.
  */
 
 const SAFE_RM_TARGETS = /(node_modules|\.forge|dist|build|coverage|te?mp|\$TMP|\$TEMP|scratchpad)/i;


### PR DESCRIPTION
## What & why

The `plugin/hooks/denylist.mjs` header comment overstated coverage — "Blocks
destructive commands" reads as a general destructive-command sandbox. In reality
the hook is a **targeted backstop** over a fixed pattern set (git history/branch
operations, `rm` recursive-force outside build/temp dirs, and pipe-to-shell /
eval-of-substitution RCE) that **FAILS OPEN**. This rewrites the header doc
comment to state the real scope and the fail-open stance, so it is not mistaken
for a security boundary.

Documentation-accuracy fix only. **No rule logic or runtime behavior changed** —
only the header comment block was edited.

Closes #314

## Acceptance criteria

- [x] **AC.1** — the denylist.mjs header comment accurately states it is a
  TARGETED backstop (git history/branch/reset/clean + rm recursive-force +
  pipe-to-shell/eval) that FAILS OPEN, not a general destructive-command sandbox.
  _Verified: new header enumerates the exact RULES set, explicitly says "NOT a
  general destructive-command sandbox" and "FAILS OPEN by design ... exit 0 ...
  can never take the session down"; behavior unchanged._

## Verification

- `pnpm verify` (vitest) — 54 files / 618 tests, all green (comment-only change,
  no test drift).
- `claude plugin validate ./plugin --strict` — validation passed.
- Diff is a single 12-insertion/3-deletion comment block; `git diff` confirms no
  code lines touched.
- No new test added: this is a doc-accuracy AC; the CI verify job runs `vitest
  run` only (acgate is not a CI gate here and there is no plan file mapping
  AC-314.1), so scope was kept minimal per ticket guidance.
