### PR TITLE
refactor(hooks): single shared shell-segment splitter (#320)

### DIFF
--- a/plugin/hooks/capture.mjs
+++ b/plugin/hooks/capture.mjs
@@ -12,6 +12,7 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { append } from '../scripts/lib/journal.mjs';
 import { parseBranch } from '../scripts/lib/ticket.mjs';
+import { splitSegments } from '../scripts/lib/shell-split.mjs';
 
 const READ_ONLY = new Set([
   'grep', 'rg', 'ls', 'cat', 'head', 'tail', 'find', 'which', 'echo', 'pwd',
@@ -38,7 +39,9 @@ function segmentIsReadOnly(segment) {
 }
 
 export function isReadOnly(command) {
-  const segments = command.split(/&&|\|\||[;|\n]/).filter((s) => s.trim());
+  // Shared splitter (#320) — one copy of the shell-segment regex across both hooks.
+  // It trims each segment; segmentIsReadOnly also trims, so behavior is unchanged.
+  const segments = splitSegments(command);
   return segments.length > 0 && segments.every(segmentIsReadOnly);
 }
 

--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -97,10 +97,13 @@ const SUBSTITUTION = /\$\(|`/;
  * tripped force-push because `git push` and an unrelated `-f` were both present
  * somewhere in the string (#85). Over-splitting is safe: a destructive command is
  * still fully contained in its own segment.
+ *
+ * The splitter itself lives in one shared module (#320) so this copy and the
+ * capture hook's copy can't drift; re-exported here under the historical `segments`
+ * name that tests and importers already depend on.
  */
-export function segments(command) {
-  return command.split(/&&|\|\||[;|\n]/).map((s) => s.trim()).filter(Boolean);
-}
+export { splitSegments as segments } from '../scripts/lib/shell-split.mjs';
+import { splitSegments as segments } from '../scripts/lib/shell-split.mjs';
 
 export function check(command) {
   if (typeof command !== 'string' || command.length === 0) return { blocked: false };

--- a/plugin/scripts/lib/shell-split.mjs
+++ b/plugin/scripts/lib/shell-split.mjs
@@ -1,0 +1,26 @@
+/**
+ * Shared shell-segment splitter (#320).
+ *
+ * Splits a command line into sub-commands on shell separators (&& || ; | newline)
+ * so a caller can test ONE sub-command at a time, not the whole string. This is
+ * security-relevant parsing — the denylist (PreToolUse) and the capture hook
+ * (PostToolUse) both depend on it, so it lives in ONE place to keep the two copies
+ * from drifting.
+ *
+ * Over-splitting is safe by design: a destructive command is still fully contained
+ * in its own segment (denylist rationale, #85). NOTE: rules that must see a
+ * separator (e.g. denylist's pipe-to-shell RCE match, #311) run against the FULL
+ * command string, NOT these segments — splitting on `|` is exactly what such a
+ * payload hides behind.
+ *
+ * Pure, side-effect-free module: it exports a function and nothing else (no
+ * self-exec guard), so any hook or host shim can import it with zero side effects.
+ */
+
+/**
+ * @param {string} command - the raw command line
+ * @returns {string[]} trimmed, non-empty sub-command segments
+ */
+export function splitSegments(command) {
+  return command.split(/&&|\|\||[;|\n]/).map((s) => s.trim()).filter(Boolean);
+}

--- a/tests/lib/shell-split.test.mjs
+++ b/tests/lib/shell-split.test.mjs
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { splitSegments } from '../../plugin/scripts/lib/shell-split.mjs';
+
+describe('splitSegments (#320 — shared shell-segment splitter)', () => {
+  it('AC-320.1: splits on &&, ||, ;, |, and newlines, trimming and dropping empties', () => {
+    expect(splitSegments('a && b || c ; d | e\nf')).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+    expect(splitSegments('git push origin main')).toEqual(['git push origin main']);
+    expect(splitSegments('  foo  ;;  bar  ')).toEqual(['foo', 'bar']);
+    expect(splitSegments('')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #320

## What

The shell-segment splitter (split a command on shell separators `&& || ; | newline`) was DUPLICATED in two security-relevant hooks:
- `plugin/hooks/denylist.mjs` — `segments()`
- `plugin/hooks/capture.mjs` — inline in `isReadOnly()`

Two copies of the same parsing regex can drift. This extracts it into ONE shared, side-effect-free module `plugin/scripts/lib/shell-split.mjs` (co-located with the other hook utilities `journal.mjs` / `ticket.mjs`, which both hooks already import from `../scripts/lib/`).

- `capture.mjs` imports `splitSegments`.
- `denylist.mjs` imports it AND re-exports it under the historical `segments` name (tests + the agy deny shim depend on that name).
- Identical regex and trim/filter semantics — pure DRY refactor, **zero behavior change**.
- The shared module is a pure lib with **no self-exec guard**, so any hook or host shim imports it with zero side effects (anchored-guard lesson from #289).

## Acceptance criteria

- [x] **AC.1 — both modules import ONE shared splitter; behavior unchanged, all existing tests pass.**
  Verified: `denylist.mjs` and `capture.mjs` both import `splitSegments` from `plugin/scripts/lib/shell-split.mjs`; the sole remaining regex copy lives in that module. `pnpm verify` green — **619/619** tests pass, including every existing `tests/hooks/denylist.test.mjs` and `tests/hooks/capture.test.mjs` case UNCHANGED, plus the agy emit suite (which copies the `scripts/lib/` tier and exercises the denylist shim through the same import chain).
- [x] **AC-320.1 (optional) — one tiny splitter test added** (`tests/lib/shell-split.test.mjs`) asserting split points on `&& || ; | newline`, trimming, and empty-drop. No existing test expectation altered.

## Verification

- `pnpm verify`: 55 files, 619 tests, all green.
- Behavior-equivalence note: `capture`'s old splitter filtered on `s.trim()` (kept untrimmed segments), then `segmentIsReadOnly` trimmed internally; the shared splitter trims up-front — same non-empty segment set, identical result.
- `#311` pipe-to-shell rules still run on the FULL command string (unchanged), not on segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
