### PR TITLE
refactor(hooks): single-source the denylist escalate message (#321)

### DIFF
--- a/plugin/hooks/agy-deny.mjs
+++ b/plugin/hooks/agy-deny.mjs
@@ -12,6 +12,10 @@
  * here has no side effects. The name is kept deny-not-denylist as belt-and-braces.
  */
 import { check } from './denylist.mjs';
+// Single-sourced escalate wording (#321), shared with denylist.mjs so the two host
+// shims cannot drift the message again. Imported with zero side effects. (This shim
+// file stays ASCII-only per the agy emit contract; the message text lives in the lib.)
+import { escalateMessage } from '../scripts/lib/escalate-msg.mjs';
 
 async function main() {
   let raw = '';
@@ -28,9 +32,7 @@ async function main() {
     if (res.blocked) {
       out = {
         decision: 'deny',
-        reason:
-          `forge denylist blocked this command (${res.rule}): ${res.msg}. ` +
-          `Destructive actions require a human decision - escalate instead of forcing them (spec section 7).`,
+        reason: escalateMessage(res.rule, res.msg),
       };
     }
   }

--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -104,6 +104,9 @@ const SUBSTITUTION = /\$\(|`/;
  */
 export { splitSegments as segments } from '../scripts/lib/shell-split.mjs';
 import { splitSegments as segments } from '../scripts/lib/shell-split.mjs';
+// The escalate message is single-sourced (#321) so this hook and the agy deny shim
+// cannot drift the wording again; both import escalateMessage() with zero side effects.
+import { escalateMessage } from '../scripts/lib/escalate-msg.mjs';
 
 export function check(command) {
   if (typeof command !== 'string' || command.length === 0) return { blocked: false };
@@ -129,10 +132,7 @@ export async function handle(payload, appendFn) {
   } catch { /* still block below */ }
   return {
     code: 2,
-    message:
-      `forge denylist blocked this command (${res.rule}): ${res.msg}. ` +
-      `Destructive actions require a human decision — escalate instead: ` +
-      `node plugin/scripts/board/escalate.mjs --issue <n> --reason "..." --options "do it|alternative" (spec §7).`,
+    message: escalateMessage(res.rule, res.msg),
   };
 }
 

--- a/plugin/scripts/lib/escalate-msg.mjs
+++ b/plugin/scripts/lib/escalate-msg.mjs
@@ -1,0 +1,39 @@
+/**
+ * Shared denylist escalate message (#321).
+ *
+ * The "escalate instead" wording that a denylist block surfaces to the model was
+ * copy-pasted into two host shims — the Claude PreToolUse hook (denylist.mjs) and
+ * the agy deny shim (agy-deny.mjs) — and the copies had ALREADY DRIFTED (one wrote
+ * the spec reference as "§7", the other as "section 7"). This module single-sources
+ * the wording so the two hosts cannot drift again (AC-321.1).
+ *
+ * The escalate command is forge's own board tooling and is host-agnostic — the same
+ * `escalate.mjs` invocation is correct from every GAI host — so the WHOLE message is
+ * single-sourced here. Should a genuine per-host tweak ever be needed, pass it in
+ * rather than forking the core sentence.
+ *
+ * Pure, side-effect-free module: it exports strings/functions and nothing else (no
+ * self-exec guard, no I/O), so any hook or host shim can import it with zero side
+ * effects — the same import-safety contract as shell-split.mjs (#320).
+ */
+
+/** Canonical spec reference for the escalate path (spec §7 destructive-action gate). */
+export const SPEC_REF = 'spec §7';
+
+/** The exact command a human/agent runs to request the blocked destructive action. */
+export const ESCALATE_HINT =
+  'node plugin/scripts/board/escalate.mjs --issue <n> --reason "..." --options "do it|alternative"';
+
+/**
+ * Build the denylist block/deny reason string shared by every host shim.
+ * @param {string} rule - the matched denylist rule name (e.g. 'force-push')
+ * @param {string} msg  - the rule's human explanation of why it is destructive
+ * @returns {string} the single-sourced escalate message
+ */
+export function escalateMessage(rule, msg) {
+  return (
+    `forge denylist blocked this command (${rule}): ${msg}. ` +
+    `Destructive actions require a human decision — escalate instead: ` +
+    `${ESCALATE_HINT} (${SPEC_REF}).`
+  );
+}

--- a/tests/hooks/agy-deny.test.mjs
+++ b/tests/hooks/agy-deny.test.mjs
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { escalateMessage } from '../../plugin/scripts/lib/escalate-msg.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SHIM = join(HERE, '..', '..', 'plugin', 'hooks', 'agy-deny.mjs');
@@ -40,6 +41,17 @@ describe('agy-deny shim I/O contract (AC-313.1)', () => {
     const decision = JSON.parse(out);
     expect(decision).toMatchObject({ decision: 'deny' });
     expect(decision.reason).toContain('recursive-delete');
+  });
+
+  it('AC-321.1: the deny reason is the single-sourced escalate wording, identical to the Claude hook', async () => {
+    // recursive-delete is a stable rule name + msg shared via check(); the agy shim
+    // must surface the exact same escalate string as denylist.mjs (no wording drift).
+    const { out } = await runDeny(call('rm -rf src/'));
+    const reason = JSON.parse(out).reason;
+    expect(reason).toBe(escalateMessage('recursive-delete', 'rm -rf (incl. --recursive --force) outside build/temp dirs'));
+    // Uses the canonical "§7" spec reference, not the old drifted "section 7".
+    expect(reason).toContain('spec §7');
+    expect(reason).not.toContain('section 7');
   });
 
   it('AC-313.1: allows a benign command with a bare decision:allow (no reason)', async () => {

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { check, handle, segments } from '../../plugin/hooks/denylist.mjs';
+import { escalateMessage } from '../../plugin/scripts/lib/escalate-msg.mjs';
 
 describe('chained-command segments (AC-B85.*, #85 — iomanage feedback)', () => {
   it('AC-B85.1: a push chained with an unrelated `gh … -f` is NOT force-push', () => {
@@ -178,6 +179,20 @@ describe('recursive-delete long flags (#312, AC-312.*)', () => {
     expect(check('rm -rf node_modules').blocked).toBe(false);
     expect(check('rm --recursive --force node_modules').blocked).toBe(false);
     expect(check('rm --force --recursive dist build coverage').blocked).toBe(false);
+  });
+});
+
+describe('shared escalate message (#321, AC-321.1)', () => {
+  const payload = (cmd) => ({ tool_name: 'Bash', tool_input: { command: cmd }, cwd: '/repo' });
+
+  it('AC-321.1: handle() emits the single-sourced escalate wording verbatim', async () => {
+    const res = await handle(payload('git reset --hard HEAD~3'), async () => {});
+    expect(res.code).toBe(2);
+    // The message is the shared constant, not a drifted local copy.
+    expect(res.message).toBe(escalateMessage('hard-reset', 'git reset --hard discards work irrecoverably'));
+    // Canonical spec reference uses "§7" (not the drifted "section 7"), with the command hint.
+    expect(res.message).toContain('spec §7');
+    expect(res.message).toContain('node plugin/scripts/board/escalate.mjs');
   });
 });
 


### PR DESCRIPTION
Closes #321

## What
The denylist "escalate instead — this is a destructive action requiring a human decision" message was duplicated in `plugin/hooks/denylist.mjs` (Claude PreToolUse hook) and `plugin/hooks/agy-deny.mjs` (agy deny shim), and the copies had **already drifted**:
- Claude copy: `... (spec §7)` **with** the `node plugin/scripts/board/escalate.mjs ...` command hint
- agy copy: `... (spec section 7)` **without** the command hint

## Change
- New `plugin/scripts/lib/escalate-msg.mjs` — a pure, side-effect-free module (same import-safety contract as `shell-split.mjs` from #320) exporting one canonical `escalateMessage(rule, msg)`.
- Both hooks import it. Canonical wording keeps the more complete Claude form: `§7` spec reference + accurate escalate command hint.
- The escalate command is forge's own host-agnostic board tooling, so the whole message is single-sourced (no genuine per-host command-path split).
- `agy-deny.mjs` stays ASCII-only per the agy emit contract — the message text now lives in the lib (outside the ASCII-checked shim surface, exactly like `denylist.mjs`).

## Not changed
No change to the deny/allow decision, block exit codes (2 / deny), the denylist self-exec guard (still basename-anchored, AC-289.3), or agy-deny importing `check()` with zero side effects.

## Acceptance criteria
- [x] **AC-321.1** — one shared escalate-message constant is used by both hooks; no wording drift.
  - *How verified:* both `tests/hooks/denylist.test.mjs` and `tests/hooks/agy-deny.test.mjs` now assert the emitted message is `escalateMessage(rule, msg)` **verbatim** (identical string, contains `spec §7`, and the agy test asserts it does **not** contain the old drifted `section 7`).

## Verification
- `pnpm verify` — 621/621 tests pass (green).
- Affected suites (`denylist.test.mjs`, `agy-deny.test.mjs`, `agy/emit.test.mjs`) pass, including the `ASCII-only emitted shim` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)