### PR TITLE
ci(deps): bump actions/checkout to v7.0.1 and actions/setup-node to v7.0.0

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -25,7 +25,7 @@ jobs:
   gitleaks:
     runs-on: [self-hosted, linux, forge-local]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # fetch-depth: 0 is what gives full history (unshallow) so gitleaks scans
           # every commit reachable from the checked-out ref, not just the tip.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,9 +31,9 @@ jobs:
       contents: read
     runs-on: [self-hosted, linux, forge-local]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: pnpm
@@ -49,9 +49,9 @@ jobs:
       contents: read
     runs-on: [self-hosted, windows, forge-local]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: pnpm
@@ -86,7 +86,7 @@ jobs:
       contents: read
     runs-on: [self-hosted, linux, forge-local]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install actionlint (pinned v1.7.7, SHA-256 verified)
         run: |
           version=1.7.7
@@ -105,8 +105,8 @@ jobs:
       contents: read
     runs-on: [self-hosted, linux, forge-local]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       - run: npm install -g @anthropic-ai/claude-code
@@ -127,7 +127,7 @@ jobs:
     env:
       QT_QPA_PLATFORM: offscreen
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Show uv + resolved Python
         # The self-hosted runner service does not inherit the full Machine PATH,
         # so each step (a fresh shell) prepends the known toolchain dirs itself:


### PR DESCRIPTION
Applies the two Dependabot action bumps that conflicted after #221 merged:

- `actions/checkout` 5.0.0 → **7.0.1** (`3d3c42e5…`)
- `actions/setup-node` 4.4.0 → **7.0.0** (`820762786…`)

Same SHA-pinned targets Dependabot proposed in #220 / #222 — both were already green on the current self-hosted CI in their own runs. Supersedes and closes #220 and #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)