### PR TITLE
feat(release): add --date override for the changelog/release date

### DIFF
--- a/plugin/scripts/release/release.mjs
+++ b/plugin/scripts/release/release.mjs
@@ -14,7 +14,8 @@ import { computeReadiness } from './readiness.mjs';
 import { deriveBump, nextVersion, groupChanges, renderChangelogSection, renderReleaseBody, summarize } from './core.mjs';
 
 export function parseArgs(argv) {
-  return { dryRun: argv.includes('--dry-run') };
+  const dateIdx = argv.indexOf('--date');
+  return { dryRun: argv.includes('--dry-run'), date: dateIdx !== -1 ? (argv[dateIdx + 1] ?? null) : null };
 }
 
 export async function runRelease(ctx, args, log = console.log) {
@@ -58,7 +59,11 @@ export async function runRelease(ctx, args, log = console.log) {
     if (head.ok) imageDigest = `ghcr.io/${repo.owner.toLowerCase()}/${repo.name}:sha-${head.stdout.trim()}`;
   }
 
-  const date = new Date().toISOString().slice(0, 10);
+  // Date stamped on the CHANGELOG section + used verbatim in the release. Defaults
+  // to today's UTC date; --date <YYYY-MM-DD> overrides it (the built-in clock is UTC,
+  // so a late-UTC release can lag the maintainer's local calendar day).
+  if (args.date && !/^\d{4}-\d{2}-\d{2}$/.test(args.date)) return { ok: false, error: `--date must be YYYY-MM-DD, got: ${args.date}` };
+  const date = args.date || new Date().toISOString().slice(0, 10);
   const section = renderChangelogSection(version, date, groups, repoUrl);
   const body = renderReleaseBody({ version, summary: summarize(groups, version), groups, repoUrl, infraChanged, migrations, imageDigest });
 

--- a/tests/release.test.mjs
+++ b/tests/release.test.mjs
@@ -252,10 +252,25 @@ describe('runRelease mutating path (#165)', () => {
     expect(order).toEqual(['add', 'commit']);
   });
 
-  it('AC3: parseArgs reads the --dry-run flag directly', () => {
-    expect(parseArgs(['--dry-run'])).toEqual({ dryRun: true });
-    expect(parseArgs([])).toEqual({ dryRun: false });
-    expect(parseArgs(['--other', '--dry-run', 'x'])).toEqual({ dryRun: true });
-    expect(parseArgs(['--notdryrun'])).toEqual({ dryRun: false });
+  it('AC3: parseArgs reads --dry-run and the optional --date override', () => {
+    expect(parseArgs(['--dry-run'])).toEqual({ dryRun: true, date: null });
+    expect(parseArgs([])).toEqual({ dryRun: false, date: null });
+    expect(parseArgs(['--other', '--dry-run', 'x'])).toEqual({ dryRun: true, date: null });
+    expect(parseArgs(['--notdryrun'])).toEqual({ dryRun: false, date: null });
+    expect(parseArgs(['--date', '2026-08-02'])).toEqual({ dryRun: false, date: '2026-08-02' });
+    expect(parseArgs(['--dry-run', '--date', '2026-08-02'])).toEqual({ dryRun: true, date: '2026-08-02' });
+  });
+
+  it('AC4: --date overrides the changelog date; a malformed --date is refused', async () => {
+    const cwd = await seedRepo({ changelog: '# Changelog\n\n' });
+    const { git, gh } = makeFakes({ cwd });
+    const lines = [];
+    const res = await runRelease({ cwd, gh, execFn: git }, { dryRun: true, date: '2026-08-02' }, (m) => lines.push(m));
+    expect(res.ok).toBe(true);
+    expect(lines.join('\n')).toContain('## v0.2.0 — 2026-08-02');
+
+    const bad = await runRelease({ cwd, gh, execFn: git }, { dryRun: true, date: 'Aug 2 2026' }, () => {});
+    expect(bad).toMatchObject({ ok: false });
+    expect(bad.error).toContain('YYYY-MM-DD');
   });
 });


### PR DESCRIPTION
`release.mjs` stamped the CHANGELOG/release date from `new Date().toISOString()` (UTC), so a release cut late in the UTC day lags the maintainer's local calendar day. Adds an optional, validated `--date <YYYY-MM-DD>` override; behaviour is unchanged when the flag is absent.

- `parseArgs` now returns `{ dryRun, date }`
- malformed `--date` is refused with a clear error before any mutation
- AC3/AC4 tests cover parse + the date flowing into the changelog section + rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)