### PR TITLE
fix(release): bump the README version badge in lockstep with the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![verify](https://github.com/dngioidev/forge/actions/workflows/verify.yml/badge.svg)](https://github.com/dngioidev/forge/actions/workflows/verify.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![version](https://img.shields.io/badge/version-0.18.0-blue.svg)](CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-0.19.0-blue.svg)](CHANGELOG.md)
 
 ## What is forge?
 

--- a/plugin/scripts/release/release.mjs
+++ b/plugin/scripts/release/release.mjs
@@ -89,13 +89,23 @@ export async function runRelease(ctx, args, log = console.log) {
   for (const t of bumpTargets) {
     await writeFile(join(cwd, t.rel), t.raw.replace(/"version":\s*"[^"]+"/, `"version": "${version}"`), 'utf8');
   }
+  // Keep the README shields.io version badge in lockstep with the release — the
+  // #308 guard test and the #309 docsync gate both fail if it drifts from
+  // package.json, so a release that bumped the JSON but not the badge left main red.
+  const readmeRel = 'README.md';
+  let readmeBumped = false;
+  try {
+    const rd = await readFile(join(cwd, readmeRel), 'utf8');
+    const bumped = rd.replace(/(img\.shields\.io\/badge\/version-)\d+\.\d+\.\d+(-)/, `$1${version}$2`);
+    if (bumped !== rd) { await writeFile(join(cwd, readmeRel), bumped, 'utf8'); readmeBumped = true; }
+  } catch { /* no README in consumer repos — skip */ }
   const clPath = join(cwd, 'CHANGELOG.md');
   let cl = '';
   try { cl = await readFile(clPath, 'utf8'); } catch { cl = '# Changelog\n\n'; }
   const marker = '# Changelog\n\n';
   const updated = cl.startsWith(marker) ? marker + section + '\n' + cl.slice(marker.length) : section + '\n' + cl;
   await writeFile(clPath, updated, 'utf8');
-  const add = await git('add', 'CHANGELOG.md', ...bumpTargets.map((t) => t.rel));
+  const add = await git('add', 'CHANGELOG.md', ...bumpTargets.map((t) => t.rel), ...(readmeBumped ? [readmeRel] : []));
   const commit = add.ok && (await git('commit', '-m', `chore(release): v${version}`));
   if (!commit.ok) return { ok: false, error: 'changelog commit failed' };
 

--- a/tests/release.test.mjs
+++ b/tests/release.test.mjs
@@ -241,6 +241,20 @@ describe('runRelease mutating path (#165)', () => {
     expect(res.notes.some((n) => n.includes('npm publish'))).toBe(false); // private -> no publish note
   });
 
+  it('AC-badge: bumps the README shields.io version badge and stages it (#308 drift guard)', async () => {
+    const cwd = await seedRepo({ changelog: '# Changelog\n\n' });
+    await writeFile(join(cwd, 'README.md'), '# forge\n[![version](https://img.shields.io/badge/version-0.1.0-blue.svg)](CHANGELOG.md)\n', 'utf8');
+    const { git, gh, calls, order } = makeFakes({ cwd });
+    const res = await runRelease({ cwd, gh, execFn: git }, { dryRun: false }, () => {});
+    expect(res.ok).toBe(true);
+    const readme = await readFile(join(cwd, 'README.md'), 'utf8');
+    expect(readme).toContain('version-0.2.0-blue.svg'); // badge bumped in lockstep
+    expect(readme).not.toContain('version-0.1.0-');
+    // README.md is staged alongside the version files + changelog
+    expect(calls.add).toEqual(['add', 'CHANGELOG.md', 'package.json', join('plugin', '.claude-plugin', 'plugin.json'), 'README.md']);
+    expect(order).toEqual(['add', 'commit', 'tag', 'push', 'release']);
+  });
+
   it('AC2: a failed git commit aborts BEFORE tagging/pushing (no dangling tag, no release)', async () => {
     const cwd = await seedRepo({ changelog: '# Changelog\n\n' });
     const { git, gh, order } = makeFakes({ cwd, commitOk: false });


### PR DESCRIPTION
The v0.19.0 release bumped `package.json`/`plugin.json` but not the README shields.io version badge, so it drifted (badge 0.18.0 vs package 0.19.0) — precisely what the **#308** guard test and the **#309** docsync gate watch for, leaving `main` red after every release.

- `release.mjs` now rewrites the `version-X.Y.Z` badge during the version bump and stages `README.md` alongside the JSON version files
- corrects the badge to **0.19.0** for the current release
- test `AC-badge` asserts the badge bump + staging

Closes the recurrence, not just this instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)