### PR TITLE
feat(gates): license-compliance gate (SPDX allowlist; enforce on deps + validate the plugin)

### DIFF
--- a/plugin/mcp/forge/server.mjs
+++ b/plugin/mcp/forge/server.mjs
@@ -39,6 +39,7 @@ import { runConventions } from '../../scripts/gates/conventions.mjs';
 import { runDepGuard } from '../../scripts/gates/depguard.mjs';
 import { runDocSync } from '../../scripts/gates/docsync.mjs';
 import { runGroundGate } from '../../scripts/gates/groundgate.mjs';
+import { runLicenseGate } from '../../scripts/gates/license.mjs';
 import { runPlanDrift } from '../../scripts/gates/plandrift.mjs';
 import { runGate as runSituationGate } from '../../scripts/gates/situationgate.mjs';
 import { runTestIntent } from '../../scripts/gates/testintent.mjs';
@@ -46,7 +47,7 @@ import { runTestIntent } from '../../scripts/gates/testintent.mjs';
 const noop = () => {};
 
 /** The gate names gate_run dispatches to (spec §b enum). */
-export const GATE_NAMES = ['ac', 'conventions', 'dep', 'docsync', 'ground', 'plandrift', 'situation', 'testintent'];
+export const GATE_NAMES = ['ac', 'conventions', 'dep', 'docsync', 'ground', 'license', 'plandrift', 'situation', 'testintent'];
 
 export const TOOLS = [
   {
@@ -113,7 +114,7 @@ export const TOOLS = [
   },
   {
     name: 'gate_run',
-    description: 'Run one mechanical gate and return its verdict as {level:pass|fail, findings[]}. gate is one of ac|conventions|dep|docsync|ground|plandrift|situation|testintent.',
+    description: 'Run one mechanical gate and return its verdict as {level:pass|fail, findings[]}. gate is one of ac|conventions|dep|docsync|ground|license|plandrift|situation|testintent.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -182,7 +183,7 @@ export const DEFAULT_DEPS = {
   selectNext, actionableQueue, normalize, isShaped,
   evaluateMergeBar, runMerge, computeReadiness, loadConfig,
   execFn: run,
-  gates: { ac: runAcGate, conventions: runConventions, dep: runDepGuard, docsync: runDocSync, ground: runGroundGate, plandrift: runPlanDrift, situation: runSituationGate, testintent: runTestIntent },
+  gates: { ac: runAcGate, conventions: runConventions, dep: runDepGuard, docsync: runDocSync, ground: runGroundGate, license: runLicenseGate, plandrift: runPlanDrift, situation: runSituationGate, testintent: runTestIntent },
 };
 
 /** Per-gate: how to invoke it with root+args, and how to read its verdict into {level,findings}. */
@@ -206,6 +207,10 @@ const GATE_SPEC = {
   ground: {
     invoke: (fn, a, root) => fn({ cwd: root, manifestPath: a.manifest, log: noop }),
     verdict: (r) => ({ level: r.ok ? 'pass' : 'fail', findings: (r.ungrounded ?? []).map((u) => `ungrounded: ${u.claim}`) }),
+  },
+  license: {
+    invoke: (fn, a, root) => fn({ cwd: root, log: noop }),
+    verdict: (r) => ({ level: r.ok ? 'pass' : 'fail', findings: [...(r.plugin?.problems ?? []).map((p) => `plugin-license: ${p}`), ...(r.violations ?? []).map((v) => `${v.name}: ${v.license} — ${v.reason}`)] }),
   },
   plandrift: {
     invoke: (fn, a, root) => fn({ cwd: root, planPath: a.plan, base: a.base ?? 'main', log: noop }),

--- a/plugin/scripts/gates/license.mjs
+++ b/plugin/scripts/gates/license.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * License-compliance gate (#342, spec §13 supply-chain): the *enforcing* license
+ * check forge never had. depguard only proves a dependency EXISTS; the consumer
+ * CI template merely runs `pnpm licenses list` and never fails. This gate reads
+ * the installed dependency licenses (npm via `pnpm licenses list --json`) and
+ * FAILS on any SPDX id outside a configurable allowlist — and it also validates
+ * the plugin's OWN license declaration (a LICENSE file plus a consistent license
+ * field in package.json and plugin/.claude-plugin/plugin.json).
+ *
+ * Fail-closed by construction: an unknown / UNLICENSED / missing license is a
+ * violation, never a pass. It degrades gracefully (skip, don't crash) when there
+ * is no pnpm/node project to inspect. Sibling ticket #343 wires it into CI; this
+ * ticket only builds the gate and registers it in the gate suite (gate_run).
+ *
+ * Pure functions (parseLicenses / evaluate / resolveAllowlist / licenseAllowed)
+ * hold the logic and are unit-tested with canned JSON; the runner shells out to
+ * pnpm through the injected exec so tests never touch the network or real pnpm.
+ */
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { run } from '../lib/exec.mjs';
+import { loadConfig } from '../lib/config.mjs';
+
+/**
+ * The default permissive allowlist (#342/AC.1). SPDX ids that carry no
+ * copyleft/attribution surprise for a plugin that ships zero runtime deps.
+ * Overridable via forge.json `license.allow`.
+ */
+export const DEFAULT_ALLOWLIST = Object.freeze([
+  'MIT', 'ISC', 'Apache-2.0', 'BSD-2-Clause', 'BSD-3-Clause',
+  'BlueOak-1.0.0', '0BSD', 'Unlicense', 'CC0-1.0',
+]);
+
+/** The plugin's own declared license (AC.2) — forge is MIT end to end. */
+export const EXPECTED_LICENSE = 'MIT';
+
+/** License strings that mean "no usable license" — always fail closed (AC.1). */
+const UNKNOWN_MARKERS = new Set(['', 'unknown', 'unlicensed', 'see license in license', 'none']);
+
+/**
+ * Flatten `pnpm licenses list --json` into [{name, license}]. The output is an
+ * object keyed by the SPDX license string, each value an array of package
+ * descriptors ({name, versions, license, ...}). We prefer the per-package
+ * `license` field and fall back to the group key; a package with neither yields
+ * an empty license string, which evaluate() then fails closed. Pure — no I/O.
+ */
+export function parseLicenses(pnpmJson) {
+  const out = [];
+  if (!pnpmJson || typeof pnpmJson !== 'object' || Array.isArray(pnpmJson)) return out;
+  for (const [groupKey, pkgs] of Object.entries(pnpmJson)) {
+    if (!Array.isArray(pkgs)) continue;
+    for (const p of pkgs) {
+      const name = (p && typeof p.name === 'string' && p.name) || '(unknown package)';
+      const perPkg = p && typeof p.license === 'string' ? p.license.trim() : '';
+      const license = perPkg || (typeof groupKey === 'string' ? groupKey.trim() : '');
+      out.push({ name, license });
+    }
+  }
+  return out;
+}
+
+/**
+ * Is a single license string permitted by the allowlist? Handles the common SPDX
+ * compound expressions the right way: `(MIT OR Apache-2.0)` passes if ANY disjunct
+ * is allowed; `(MIT AND CC0-1.0)` passes only if EVERY conjunct is allowed. An
+ * empty / unknown / UNLICENSED marker is never allowed (fail closed).
+ */
+export function licenseAllowed(license, allow) {
+  const norm = (license ?? '').trim();
+  if (!norm || UNKNOWN_MARKERS.has(norm.toLowerCase())) return false;
+  if (allow.has(norm)) return true;
+  const inner = norm.replace(/^\(+|\)+$/g, '').trim();
+  const clean = (s) => s.trim().replace(/^\(+|\)+$/g, '').trim();
+  if (/\sOR\s/i.test(inner)) return inner.split(/\sOR\s/i).some((part) => allow.has(clean(part)));
+  if (/\sAND\s/i.test(inner)) return inner.split(/\sAND\s/i).every((part) => allow.has(clean(part)));
+  return false;
+}
+
+/**
+ * Check a flat [{name, license}] list against an allowlist. Returns
+ * { ok, violations:[{name, license, reason}] }. Pure — no I/O.
+ */
+export function evaluate(licenses, allowlist = DEFAULT_ALLOWLIST) {
+  const allow = new Set(allowlist);
+  const violations = [];
+  for (const { name, license } of licenses) {
+    const norm = (license ?? '').trim();
+    if (!norm || UNKNOWN_MARKERS.has(norm.toLowerCase())) {
+      violations.push({ name, license: norm || '(none)', reason: 'missing/unknown license — fails closed' });
+    } else if (!licenseAllowed(norm, allow)) {
+      violations.push({ name, license: norm, reason: `license '${norm}' is not in the allowlist` });
+    }
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+/** The effective allowlist: forge.json `license.allow` when valid, else the default. */
+export function resolveAllowlist(config) {
+  const allow = config?.license?.allow;
+  if (Array.isArray(allow) && allow.length > 0 && allow.every((x) => typeof x === 'string' && x.trim())) {
+    return allow.map((x) => x.trim());
+  }
+  return [...DEFAULT_ALLOWLIST];
+}
+
+async function readJson(path) {
+  const raw = await readFile(path, 'utf8').catch(() => null);
+  if (raw === null) return null;
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+/**
+ * Validate the plugin's own license declaration (AC.2): a LICENSE file exists at
+ * the repo root, and package.json + plugin/.claude-plugin/plugin.json declare a
+ * license consistent with it (`expected`, MIT). plugin.json is only enforced when
+ * present, so this check is meaningful in a consumer repo too. Returns
+ * { ok, problems[], pkgLicense, pluginLicense }.
+ */
+export async function checkPluginLicense(cwd, { expected = EXPECTED_LICENSE } = {}) {
+  const problems = [];
+  const licenseText = await readFile(resolve(cwd, 'LICENSE'), 'utf8').catch(() => null);
+  if (licenseText === null) problems.push('no LICENSE file at the repo root');
+  else if (expected === 'MIT' && !/\bMIT License\b/i.test(licenseText)) {
+    problems.push('LICENSE file does not declare the MIT License');
+  }
+
+  const pkg = await readJson(resolve(cwd, 'package.json'));
+  const pkgLicense = pkg && typeof pkg.license === 'string' ? pkg.license : null;
+  if (pkgLicense !== expected) problems.push(`package.json license ${pkgLicense ?? '(missing)'} != ${expected}`);
+
+  const pluginJson = await readJson(resolve(cwd, 'plugin/.claude-plugin/plugin.json'));
+  const pluginLicense = pluginJson && typeof pluginJson.license === 'string' ? pluginJson.license : null;
+  // Only enforce plugin.json when the manifest exists (consumer repos have none).
+  if (pluginJson && pluginLicense !== expected) {
+    problems.push(`plugin.json license ${pluginLicense ?? '(missing)'} != ${expected}`);
+  }
+
+  return { ok: problems.length === 0, problems, pkgLicense, pluginLicense };
+}
+
+/**
+ * Parse the exec result of `pnpm licenses list --json` defensively. Empty stdout
+ * (a project with no reportable dependency licenses) is a clean, empty list; a
+ * non-empty but unparseable payload fails closed with a note. Returns
+ * { ok, licenses[] } or { ok:false, error }.
+ */
+export function parsePnpmResult(res) {
+  const stdout = (res?.stdout ?? '').trim();
+  if (!stdout) return { ok: true, licenses: [] };
+  try {
+    return { ok: true, licenses: parseLicenses(JSON.parse(stdout)) };
+  } catch {
+    return { ok: false, error: 'could not parse `pnpm licenses list --json` output — failing closed' };
+  }
+}
+
+/**
+ * Run the license-compliance gate. Degrades gracefully (AC.3): with no
+ * package.json it is not a pnpm/node project, so it SKIPS (a clear note, not a
+ * crash). Otherwise it validates the plugin's own license (AC.2) and every
+ * installed dependency license against the allowlist (AC.1). Returns
+ * { ok, skipped?, violations, plugin, allowlist }.
+ */
+export async function runLicenseGate({ cwd, execFn = run, log = console.log, config = null, expected = EXPECTED_LICENSE } = {}) {
+  // AC.3 — no package.json → not a node project; skip rather than fail/crash.
+  const pkgRaw = await readFile(resolve(cwd, 'package.json'), 'utf8').catch(() => null);
+  if (pkgRaw === null) {
+    log('license: no package.json — not a pnpm/node project, skipping');
+    return { ok: true, skipped: true, violations: [], plugin: null, allowlist: [] };
+  }
+
+  let cfg = config;
+  if (cfg == null) {
+    const loaded = await loadConfig(cwd).catch(() => null);
+    cfg = loaded?.config ?? null;
+  }
+  const allowlist = resolveAllowlist(cfg);
+
+  // AC.2 — the plugin's own license declaration.
+  const plugin = await checkPluginLicense(cwd, { expected });
+  for (const p of plugin.problems) log(`x plugin-license: ${p}`);
+
+  // AC.1 — installed dependency licenses via the injected exec (no real pnpm in tests).
+  const res = await execFn('pnpm', ['licenses', 'list', '--json'], { cwd });
+  const parsed = parsePnpmResult(res);
+  let violations = [];
+  if (!parsed.ok) {
+    violations = [{ name: '(pnpm)', license: '(unparseable)', reason: parsed.error }];
+  } else {
+    violations = evaluate(parsed.licenses, allowlist).violations;
+  }
+
+  for (const v of violations) log(`x ${v.name}: ${v.license} — ${v.reason}`);
+  const ok = plugin.ok && violations.length === 0;
+  if (ok) {
+    log(`license: clean — plugin declares ${expected}; all dependency licenses within the allowlist (${allowlist.length} ids)`);
+  } else {
+    log(`license: ${plugin.problems.length} plugin-declaration issue(s), ${violations.length} disallowed/unknown dependency license(s) — fix or extend license.allow before shipping`);
+  }
+  return { ok, violations, plugin, allowlist };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  runLicenseGate({ cwd: process.cwd() }).then((res) => process.exit(res.ok ? 0 : 1));
+}

--- a/tests/gates/license.test.mjs
+++ b/tests/gates/license.test.mjs
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_ALLOWLIST,
+  parseLicenses,
+  evaluate,
+  licenseAllowed,
+  resolveAllowlist,
+  parsePnpmResult,
+  checkPluginLicense,
+  runLicenseGate,
+} from '../../plugin/scripts/gates/license.mjs';
+
+const noop = () => {};
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+// The real forge dep tree today: 58 packages, all permissive — canned in the
+// `pnpm licenses list --json` shape (SPDX key -> array of package descriptors).
+const PERMISSIVE_JSON = JSON.stringify({
+  MIT: [
+    { name: 'vitest', versions: ['3.2.4'], license: 'MIT' },
+    { name: '@ts-morph/common', versions: ['0.29.0'], license: 'MIT' },
+  ],
+  'Apache-2.0': [{ name: 'ts-morph', versions: ['28.0.0'], license: 'Apache-2.0' }],
+  'BlueOak-1.0.0': [{ name: 'jackspeak', versions: ['3.4.3'], license: 'BlueOak-1.0.0' }],
+  ISC: [{ name: 'semver', versions: ['7.7.2'], license: 'ISC' }],
+  'BSD-3-Clause': [{ name: 'source-map-js', versions: ['1.2.1'], license: 'BSD-3-Clause' }],
+});
+const execPermissive = async () => ({ ok: true, stdout: PERMISSIVE_JSON, stderr: '' });
+
+async function tempDir() {
+  return mkdtemp(join(tmpdir(), 'forge-lic-'));
+}
+
+describe('license gate — SPDX allowlist enforcement (#342)', () => {
+  it('AC-342.1: parses the pnpm shape and passes an all-permissive tree', () => {
+    const licenses = parseLicenses(JSON.parse(PERMISSIVE_JSON));
+    expect(licenses).toContainEqual({ name: 'ts-morph', license: 'Apache-2.0' });
+    expect(licenses).toContainEqual({ name: 'jackspeak', license: 'BlueOak-1.0.0' });
+    const res = evaluate(licenses);
+    expect(res.ok).toBe(true);
+    expect(res.violations).toEqual([]);
+  });
+
+  it('AC-342.1: FAILS on a disallowed (GPL) SPDX id', () => {
+    const gpl = {
+      MIT: [{ name: 'fine', versions: ['1'], license: 'MIT' }],
+      'GPL-3.0-only': [{ name: 'copyleft-lib', versions: ['1'], license: 'GPL-3.0-only' }],
+    };
+    const res = evaluate(parseLicenses(gpl));
+    expect(res.ok).toBe(false);
+    expect(res.violations).toHaveLength(1);
+    expect(res.violations[0]).toMatchObject({ name: 'copyleft-lib', license: 'GPL-3.0-only' });
+    expect(res.violations[0].reason).toMatch(/not in the allowlist/);
+  });
+
+  it('AC-342.1: fails CLOSED on unknown / UNLICENSED / missing license', () => {
+    const bad = {
+      Unknown: [{ name: 'mystery', versions: ['1'], license: 'Unknown' }],
+      UNLICENSED: [{ name: 'proprietary', versions: ['1'], license: 'UNLICENSED' }],
+      // grouped under a key but with no per-package license and an empty key would
+      // still fail; here the key itself is the only signal and is not allowlisted.
+    };
+    const res = evaluate(parseLicenses(bad));
+    expect(res.ok).toBe(false);
+    const names = res.violations.map((v) => v.name).sort();
+    expect(names).toEqual(['mystery', 'proprietary']);
+    for (const v of res.violations) expect(v.reason).toMatch(/fails closed|not in the allowlist/);
+  });
+
+  it('AC-342.1: a package with no license at all fails closed', () => {
+    const res = evaluate([{ name: 'no-license-pkg', license: '' }]);
+    expect(res.ok).toBe(false);
+    expect(res.violations[0].reason).toMatch(/fails closed/);
+  });
+
+  it('AC-342.1: honours SPDX OR/AND compound expressions correctly', () => {
+    const allow = new Set(DEFAULT_ALLOWLIST);
+    expect(licenseAllowed('(MIT OR Apache-2.0)', allow)).toBe(true); // any disjunct allowed
+    expect(licenseAllowed('(MIT OR GPL-3.0)', allow)).toBe(true);
+    expect(licenseAllowed('(MIT AND CC0-1.0)', allow)).toBe(true); // both allowed
+    expect(licenseAllowed('(MIT AND GPL-3.0)', allow)).toBe(false); // one conjunct disallowed
+    expect(licenseAllowed('GPL-3.0-only', allow)).toBe(false);
+  });
+
+  it('AC-342.1: allowlist is overridable via forge.json license.allow, else defaults', () => {
+    expect(resolveAllowlist(null)).toEqual([...DEFAULT_ALLOWLIST]);
+    expect(resolveAllowlist({})).toEqual([...DEFAULT_ALLOWLIST]);
+    expect(resolveAllowlist({ license: { allow: ['MIT', 'ISC'] } })).toEqual(['MIT', 'ISC']);
+    // an empty/invalid override falls back to the default rather than allowing nothing
+    expect(resolveAllowlist({ license: { allow: [] } })).toEqual([...DEFAULT_ALLOWLIST]);
+    // a config that restricts the allowlist then rejects a previously-fine license
+    const restricted = evaluate([{ name: 'ts-morph', license: 'Apache-2.0' }], resolveAllowlist({ license: { allow: ['MIT'] } }));
+    expect(restricted.ok).toBe(false);
+  });
+
+  it('parsePnpmResult: empty stdout is a clean empty list; garbage fails closed', () => {
+    expect(parsePnpmResult({ ok: true, stdout: '   ' })).toEqual({ ok: true, licenses: [] });
+    expect(parsePnpmResult({ ok: true, stdout: 'not json' }).ok).toBe(false);
+    expect(parsePnpmResult({ ok: true, stdout: PERMISSIVE_JSON }).licenses.length).toBe(6);
+  });
+
+  it('AC-342.2: validates the plugin\'s own license declaration on the real repo (LICENSE + package.json + plugin.json all MIT)', async () => {
+    const res = await checkPluginLicense(REPO_ROOT);
+    expect(res.problems).toEqual([]);
+    expect(res.ok).toBe(true);
+    expect(res.pkgLicense).toBe('MIT');
+    expect(res.pluginLicense).toBe('MIT');
+  });
+
+  it('AC-342.2: FAILS when the LICENSE file is missing', async () => {
+    const dir = await tempDir();
+    await writeFile(join(dir, 'package.json'), JSON.stringify({ license: 'MIT' }), 'utf8');
+    const res = await checkPluginLicense(dir);
+    expect(res.ok).toBe(false);
+    expect(res.problems.join(' ')).toMatch(/no LICENSE file/);
+  });
+
+  it('AC-342.2: FAILS when a declared license is inconsistent with MIT', async () => {
+    const dir = await tempDir();
+    await writeFile(join(dir, 'LICENSE'), 'MIT License\n\nCopyright (c) 2026', 'utf8');
+    await writeFile(join(dir, 'package.json'), JSON.stringify({ license: 'Apache-2.0' }), 'utf8');
+    const res = await checkPluginLicense(dir);
+    expect(res.ok).toBe(false);
+    expect(res.problems.join(' ')).toMatch(/package\.json license Apache-2\.0/);
+  });
+
+  it('AC-342.3: SKIPS gracefully (no crash) when there is no package.json (non-node project)', async () => {
+    const dir = await tempDir();
+    let execCalled = false;
+    const res = await runLicenseGate({ cwd: dir, execFn: async () => { execCalled = true; return { ok: true, stdout: '{}' }; }, log: noop });
+    expect(res.ok).toBe(true);
+    expect(res.skipped).toBe(true);
+    expect(res.violations).toEqual([]);
+    expect(execCalled).toBe(false); // never even shells out to pnpm
+  });
+
+  it('AC-342.4: runLicenseGate is GREEN on the current tree (real plugin declaration + all-permissive deps)', async () => {
+    const res = await runLicenseGate({ cwd: REPO_ROOT, execFn: execPermissive, log: noop });
+    expect(res.skipped).toBeFalsy();
+    expect(res.plugin.ok).toBe(true);
+    expect(res.violations).toEqual([]);
+    expect(res.ok).toBe(true);
+    expect(res.allowlist).toEqual([...DEFAULT_ALLOWLIST]);
+  });
+
+  it('AC-342.4: runLicenseGate FAILS the whole gate on a disallowed (GPL) dependency', async () => {
+    const execGpl = async () => ({ ok: true, stdout: JSON.stringify({ 'GPL-3.0-only': [{ name: 'copyleft-lib', versions: ['1'], license: 'GPL-3.0-only' }] }), stderr: '' });
+    const res = await runLicenseGate({ cwd: REPO_ROOT, execFn: execGpl, log: noop });
+    expect(res.ok).toBe(false);
+    expect(res.violations.some((v) => v.name === 'copyleft-lib')).toBe(true);
+  });
+
+  it('AC-342.4: runLicenseGate fails CLOSED on an unknown dependency license', async () => {
+    const execUnknown = async () => ({ ok: true, stdout: JSON.stringify({ Unknown: [{ name: 'mystery', versions: ['1'], license: 'Unknown' }] }), stderr: '' });
+    const res = await runLicenseGate({ cwd: REPO_ROOT, execFn: execUnknown, log: noop });
+    expect(res.ok).toBe(false);
+    expect(res.violations[0]).toMatchObject({ name: 'mystery' });
+    expect(res.violations[0].reason).toMatch(/fails closed/);
+  });
+
+  it('AC-342.4: runLicenseGate FAILS when the plugin LICENSE declaration is missing (node project, permissive deps)', async () => {
+    const dir = await tempDir();
+    await writeFile(join(dir, 'package.json'), JSON.stringify({ license: 'MIT' }), 'utf8');
+    // package.json present (node project) but no LICENSE file → plugin check fails.
+    const res = await runLicenseGate({ cwd: dir, execFn: execPermissive, log: noop });
+    expect(res.skipped).toBeFalsy();
+    expect(res.ok).toBe(false);
+    expect(res.plugin.problems.join(' ')).toMatch(/no LICENSE file/);
+  });
+});

--- a/tests/mcp-forge/forge-core.test.mjs
+++ b/tests/mcp-forge/forge-core.test.mjs
@@ -43,9 +43,9 @@ describe('AC-288.1: rpc.mjs is the shared transport (forge-graph regression-free
     expect(await h({ jsonrpc: '2.0', method: 'notifications/initialized' })).toBe(null);
   });
 
-  it('exposes exactly the 10 documented tools and the 8 gate names', () => {
+  it('exposes exactly the 10 documented tools and the 9 gate names', () => {
     expect(TOOLS).toHaveLength(10);
-    expect(GATE_NAMES).toEqual(['ac', 'conventions', 'dep', 'docsync', 'ground', 'plandrift', 'situation', 'testintent']);
+    expect(GATE_NAMES).toEqual(['ac', 'conventions', 'dep', 'docsync', 'ground', 'license', 'plandrift', 'situation', 'testintent']);
   });
 });
 
@@ -113,6 +113,17 @@ describe('AC-288.2: every tool is callable and returns its documented structured
   it('AC-310.1: gate_run conventions -> fail level surfaces garbage-subject findings', async () => {
     const h = build({ deps: { gates: { conventions: async () => ({ ok: false, violations: [{ sha: 'abc1234', subject: '@ (#297)', reason: 'not a conventional-commit header (expected "type(scope): description")' }] }) } } });
     expect(body(await call(h, 'gate_run', { gate: 'conventions' }))).toEqual({ ok: true, gate: 'conventions', level: 'fail', findings: ['abc1234 "@ (#297)": not a conventional-commit header (expected "type(scope): description")'] });
+  });
+
+  it('AC-342.4: gate_run license -> pass/fail with plugin + dependency findings', async () => {
+    const pass = build({ deps: { gates: { license: async () => ({ ok: true, violations: [], plugin: { ok: true, problems: [] } }) } } });
+    expect(body(await call(pass, 'gate_run', { gate: 'license' }))).toEqual({ ok: true, gate: 'license', level: 'pass', findings: [] });
+
+    const fail = build({ deps: { gates: { license: async () => ({ ok: false, plugin: { ok: false, problems: ['no LICENSE file at the repo root'] }, violations: [{ name: 'copyleft-lib', license: 'GPL-3.0', reason: "license 'GPL-3.0' is not in the allowlist" }] }) } } });
+    expect(body(await call(fail, 'gate_run', { gate: 'license' }))).toEqual({
+      ok: true, gate: 'license', level: 'fail',
+      findings: ['plugin-license: no LICENSE file at the repo root', "copyleft-lib: GPL-3.0 — license 'GPL-3.0' is not in the allowlist"],
+    });
   });
 
   it('AC-288.2: release_readiness -> {ok,items:[{name,level,msg}]}', async () => {


### PR DESCRIPTION
Closes #342 (parent epic #182).

Adds an enforcing **license-compliance gate** — the check forge never had.
depguard only proves a dependency *exists*; the consumer CI template runs
`pnpm licenses list` without ever failing. This gate reads installed dependency
licenses and fails on any SPDX id outside a configurable allowlist, and
validates forge's own license declaration.

## Acceptance criteria

- [x] **AC.1** — a `license` gate reads installed dependency licenses (npm via `pnpm licenses list --json`) and FAILS on any SPDX id not in a configurable allowlist. Default allowlist: MIT, ISC, Apache-2.0, BSD-2-Clause, BSD-3-Clause, BlueOak-1.0.0, 0BSD, Unlicense, CC0-1.0. Unknown / UNLICENSED / missing fails **closed**.
  _Verified:_ `evaluate`/`parseLicenses`/`licenseAllowed` unit tests — allowlisted pass, GPL fail, unknown+UNLICENSED fail-closed, SPDX OR/AND handled, override via `license.allow`.
- [x] **AC.2** — validates the plugin's own license: a LICENSE file exists, and package.json + `plugin/.claude-plugin/plugin.json` declare a license consistent with it (MIT).
  _Verified:_ `checkPluginLicense` passes on the real repo root (both already declare MIT, LICENSE present); missing-LICENSE and inconsistent-license cases fail.
- [x] **AC.3** — degrades gracefully (skip with a clear note, not a crash) when there is no package.json (non-node project).
  _Verified:_ non-node skip test — returns `{ok:true, skipped:true}` and never shells out to pnpm.
- [x] **AC.4** — wired into the gate suite (`gate_run`) alongside depguard, with tests carrying AC ids; green on the current tree.
  _Verified:_ `GATE_NAMES`/`DEFAULT_DEPS.gates`/`GATE_SPEC` updated in the forge-core MCP server; `gate_run license` pass+fail wiring test; AC-342.* ids in `tests/gates/license.test.mjs`.

## Verification

- `node plugin/scripts/gates/license.mjs` on the current tree: **exit 0** — `license: clean — plugin declares MIT; all dependency licenses within the allowlist (9 ids)`. The 58-package tree is all permissive (MIT/Apache-2.0/BlueOak-1.0.0/ISC/BSD-3-Clause), dev-only.
- `pnpm verify`: **650/650 passing** (57 files), including 15 new license-gate tests and the updated forge-core gate-registration tests.

CI wiring is intentionally **out of scope** — sibling ticket #343 does that. This PR is the gate + its gate-suite registration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)