### PR TITLE
ci(license): run the enforcing license gate in CI (#343)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -112,6 +112,25 @@ jobs:
       - run: npm install -g @anthropic-ai/claude-code
       - run: claude plugin validate ./plugin --strict
 
+  # Enforcing license-compliance gate (#343). The gate script lives in THIS repo,
+  # so run it directly: it fails (exit non-zero) on any dependency SPDX id outside
+  # the permissive allowlist and on an inconsistent own-license declaration. The
+  # consumer template ships a self-contained inline equivalent instead (the gate
+  # script is not vendored into consumer repos).
+  license:
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, forge-local]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: node plugin/scripts/gates/license.mjs
+
   # Cockpit (tools/runner-ui/) Python suite — Windows self-hosted leg only.
   # PySide6 + the pywinpty terminal dep live on Windows and the CI target for AC4
   # is the native Windows runner; the Linux leg is an ephemeral Docker container

--- a/plugin/templates/verify.yml
+++ b/plugin/templates/verify.yml
@@ -42,6 +42,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Enforcing license check (spec §13 supply-chain). Self-contained — it needs
+  # nothing from forge: `pnpm licenses list` feeds a small inline node script that
+  # FAILS (exit 1) on any production dependency whose SPDX id is outside the
+  # permissive allowlist, and fails closed on an unknown/UNLICENSED/missing
+  # license. Tweak ALLOW below to match your project's policy.
   licenses:
     runs-on: ubuntu-latest
     steps:
@@ -51,4 +56,50 @@ jobs:
         with:
           node-version: 22
       - run: pnpm install --frozen-lockfile
-      - run: pnpm licenses list --prod
+      - name: Enforce dependency license allowlist
+        shell: bash
+        run: |
+          node <<'NODE'
+          const { execFileSync } = require('node:child_process');
+          const ALLOW = new Set([
+            'MIT', 'ISC', 'Apache-2.0', 'BSD-2-Clause', 'BSD-3-Clause',
+            'BlueOak-1.0.0', '0BSD', 'Unlicense', 'CC0-1.0',
+          ]);
+          const UNKNOWN = new Set(['', 'unknown', 'unlicensed', 'see license in license', 'none']);
+          const clean = (s) => s.trim().replace(/^\(+|\)+$/g, '').trim();
+          const allowed = (license) => {
+            const norm = (license || '').trim();
+            if (!norm || UNKNOWN.has(norm.toLowerCase())) return false;
+            if (ALLOW.has(norm)) return true;
+            const inner = norm.replace(/^\(+|\)+$/g, '').trim();
+            if (/\sOR\s/i.test(inner)) return inner.split(/\sOR\s/i).some((p) => ALLOW.has(clean(p)));
+            if (/\sAND\s/i.test(inner)) return inner.split(/\sAND\s/i).every((p) => ALLOW.has(clean(p)));
+            return false;
+          };
+          let raw = '';
+          try {
+            raw = execFileSync('pnpm', ['licenses', 'list', '--prod', '--json'], { encoding: 'utf8' });
+          } catch (e) {
+            raw = String((e && e.stdout) || '');
+          }
+          raw = raw.trim();
+          let data = {};
+          if (raw) {
+            try { data = JSON.parse(raw); }
+            catch { console.error('could not parse `pnpm licenses list --json` — failing closed'); process.exit(1); }
+          }
+          const violations = [];
+          for (const [key, pkgs] of Object.entries(data)) {
+            if (!Array.isArray(pkgs)) continue;
+            for (const p of pkgs) {
+              const name = (p && p.name) || '(unknown package)';
+              const license = (p && typeof p.license === 'string' && p.license.trim()) || (typeof key === 'string' ? key.trim() : '');
+              if (!allowed(license)) violations.push(name + ': ' + (license || '(none)'));
+            }
+          }
+          if (violations.length) {
+            console.error('Disallowed or unknown dependency license(s):\n  ' + violations.join('\n  '));
+            process.exit(1);
+          }
+          console.log('license check: all production dependency licenses are within the allowlist');
+          NODE

--- a/tests/ci-template.test.mjs
+++ b/tests/ci-template.test.mjs
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { mkdtemp, mkdir, writeFile, readFile, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { runInit, parseArgs } from '../plugin/scripts/init.mjs';
+import { runLicenseGate } from '../plugin/scripts/gates/license.mjs';
 import { fakeGh, fieldsResponse, REPO_VIEW, AUTH_OK } from './helpers/fakegh.mjs';
 
 const noop = () => {};
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 const FULL_FIELDS = [
   { id: 'PVTSSF_1', name: 'Status', options: [
@@ -69,5 +72,61 @@ describe('consumer CI template (AC-3.5)', () => {
     expect(res.ok).toBe(true);
     const wf = await readFile(join(cwd, '.github', 'workflows', 'verify.yml'), 'utf8');
     expect(wf).toContain('run: npm run check');
+  });
+});
+
+// #343 — wire the enforcing license gate (#342) into CI: forge's own verify.yml
+// runs the gate script directly; the consumer template ships a self-contained
+// inline enforcing equivalent (the gate script is NOT vendored into consumers).
+describe('license gate CI wiring (#343)', () => {
+  const ALLOWLIST_IDS = ['MIT', 'ISC', 'Apache-2.0', 'BSD-2-Clause', 'BSD-3-Clause', 'BlueOak-1.0.0', '0BSD', 'Unlicense', 'CC0-1.0'];
+
+  it('AC-343.1: forge\'s own verify.yml has a `license` job that runs the gate script on the self-hosted linux runner', async () => {
+    const wf = await readFile(join(REPO_ROOT, '.github', 'workflows', 'verify.yml'), 'utf8');
+    // A dedicated job keyed `license:` exists.
+    expect(wf).toMatch(/^ {2}license:$/m);
+    // It runs the in-repo gate script directly (the script lives in this repo).
+    expect(wf).toContain('node plugin/scripts/gates/license.mjs');
+    // Modelled on the other jobs: same free self-hosted linux runner + pinned actions.
+    const licenseJob = wf.slice(wf.indexOf('\n  license:'));
+    expect(licenseJob).toContain('runs-on: [self-hosted, linux, forge-local]');
+    expect(licenseJob).toContain('actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1');
+    expect(licenseJob).toContain('pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda');
+    expect(licenseJob).toContain('actions/setup-node@820762786026740c76f36085b0efc47a31fe5020');
+    expect(licenseJob).toContain('pnpm install --frozen-lockfile');
+  });
+
+  it('AC-343.2: the consumer template `licenses` job is upgraded from non-enforcing to an enforcing, self-contained check', async () => {
+    const tpl = await readFile(join(REPO_ROOT, 'plugin', 'templates', 'verify.yml'), 'utf8');
+    // No longer merely lists licenses — the old non-enforcing terminal step is gone.
+    expect(tpl).not.toMatch(/- run: pnpm licenses list --prod\s*$/m);
+    // It now FAILS on a violation (fail-closed enforcement).
+    expect(tpl).toContain('process.exit(1)');
+    // It carries the SAME permissive allowlist the gate uses — inline & self-contained.
+    for (const id of ALLOWLIST_IDS) expect(tpl).toContain(`'${id}'`);
+    // Self-contained: it must NOT depend on forge's gate script being present.
+    expect(tpl).not.toContain('plugin/scripts/gates/license.mjs');
+    // Still drives it off `pnpm licenses list` output.
+    expect(tpl).toContain("'licenses', 'list'");
+  });
+
+  it('AC-343.3: the exact gate the CI job runs FAILS (exit non-zero) on a disallowed (GPL) dependency', async () => {
+    // Mirrors #342: drive the real gate with an injected fake pnpm returning a GPL
+    // license. This is the same script `node plugin/scripts/gates/license.mjs` runs
+    // in the AC-343.1 CI job, so a green tree + this failing fixture proves the wiring
+    // is genuinely enforcing (not merely present).
+    const execGpl = async () => ({ ok: true, stdout: JSON.stringify({ 'GPL-3.0-only': [{ name: 'copyleft-lib', versions: ['1'], license: 'GPL-3.0-only' }] }), stderr: '' });
+    const bad = await runLicenseGate({ cwd: REPO_ROOT, execFn: execGpl, log: noop });
+    expect(bad.ok).toBe(false);
+    expect(bad.violations.some((v) => v.name === 'copyleft-lib')).toBe(true);
+
+    // ...and stays GREEN on the current all-permissive tree (the CI job's happy path).
+    const permissive = JSON.stringify({
+      MIT: [{ name: 'vitest', versions: ['3'], license: 'MIT' }],
+      'Apache-2.0': [{ name: 'ts-morph', versions: ['28'], license: 'Apache-2.0' }],
+    });
+    const good = await runLicenseGate({ cwd: REPO_ROOT, execFn: async () => ({ ok: true, stdout: permissive, stderr: '' }), log: noop });
+    expect(good.ok).toBe(true);
+    expect(good.violations).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #343

Wires the #342 license-compliance gate into CI on both targets.

## What changed
- **forge's own CI** (`.github/workflows/verify.yml`): new `license` job runs `node plugin/scripts/gates/license.mjs` directly on the free `[self-hosted, linux, forge-local]` runner, modelled verbatim on the existing jobs' pinned actions (checkout/pnpm/setup-node). Fails on any disallowed or unknown SPDX id.
- **Consumer template** (`plugin/templates/verify.yml`): the `licenses` job is upgraded from the non-enforcing `pnpm licenses list --prod` to a self-contained inline enforcing check — `pnpm licenses list --json` piped into a small node script that exits 1 on any production dependency outside the same permissive allowlist (MIT, ISC, Apache-2.0, BSD-2/3-Clause, BlueOak-1.0.0, 0BSD, Unlicense, CC0-1.0), fail-closed on unknown. Vendors nothing from forge — the gate script is not present in a consumer repo.
- **Tests** (`tests/ci-template.test.mjs`, `AC-343.*`).

## Acceptance criteria
- [x] **AC.1** forge's own CI gains a `license` job that runs the gate and fails on a disallowed license; green on the current tree. Verified: `node plugin/scripts/gates/license.mjs` exits 0 locally; AC-343.1 asserts the job's presence, runner, pinned SHAs, and gate invocation.
- [x] **AC.2** consumer template `licenses` job upgraded to an ENFORCING check. Verified: extracted the inline script and ran it against this repo's real prod dep tree — exits 0 on the permissive tree; AC-343.2 asserts allowlist + `process.exit(1)` + no bare `pnpm licenses list`, and that it does not reference the gate script.
- [x] **AC.3** a test proves the enforcing behavior; the tree stays green. Verified: AC-343.3 drives the real gate with an injected GPL fixture (`ok=false`) and a permissive fixture (`ok=true`).

## Verification
- `pnpm verify`: 653/653 tests pass across 57 files.
- `node plugin/scripts/gates/license.mjs` → exit 0 on current tree.
- Consumer inline check run against real prod deps → exit 0.

Design note: the consumer template uses the intended pragmatic inline enforcing check (not a vendored script), per the ticket's design guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SATRHKa6mDHDuirhP6QuwL
