### PR TITLE
fix(gates): license gate sees the Python dep tree — PySide6/LGPL no longer invisible (#349)

### DIFF
--- a/plugin/scripts/gates/license.mjs
+++ b/plugin/scripts/gates/license.mjs
@@ -36,6 +36,51 @@ export const DEFAULT_ALLOWLIST = Object.freeze([
 /** The plugin's own declared license (AC.2) — forge is MIT end to end. */
 export const EXPECTED_LICENSE = 'MIT';
 
+/**
+ * #349 — the Python side of the tree. The license gate historically saw only the
+ * npm tree (`pnpm licenses list`), so the one genuinely non-permissive dependency
+ * in the repo — PySide6 (LGPL-3.0), pulled in by the cockpit `tools/runner-ui/` —
+ * was invisible to the very gate built to catch copyleft.
+ *
+ * uv.lock carries NO per-package license metadata (verified on the committed
+ * lock), and the license CI job runs on the Linux runner where the Python env
+ * may not be installed — so we do NOT shell out to pip/uv. Instead we read the
+ * committed `tools/runner-ui/pyproject.toml` deterministically for the declared
+ * dependency names and resolve each against this small curated SPDX map. A
+ * declared package absent from the map resolves to '' and FAILS CLOSED — the same
+ * fail-closed contract the npm side already enforces, so a newly-added Python dep
+ * cannot slip through unclassified.
+ */
+export const PYTHON_LICENSES = Object.freeze({
+  pyside6: 'LGPL-3.0',      // Qt for Python — LGPLv3 (declared `LGPL-3.0-or-later` in pyproject)
+  pywinpty: 'MIT',
+  psutil: 'BSD-3-Clause',
+  pytest: 'MIT',
+  'pytest-qt': 'MIT',
+});
+
+/**
+ * AC-349.2 — PySide6 ships under LGPL-3.0, which is intentionally NOT on the
+ * permissive allowlist. Rather than let it pass silently (the exact blind spot
+ * this ticket fixes) OR red the current tree with a hard failure, it is allowed
+ * as an EXPLICIT, DOCUMENTED, TEMPORARY exception, keyed to the specific package
+ * so no other LGPL dependency (npm or Python) is waved through.
+ *
+ * Rationale: PySide6 is consumed source-only and dynamically linked, and the
+ * cockpit re-architecture decision (docs/decisions/0008, Option C) removes
+ * PySide6 entirely in cockpit-v2. When that work (#355) lands and the LGPL
+ * declaration leaves pyproject.toml, DELETE this exception — it should not
+ * outlive the dependency it excuses.
+ */
+export const PYTHON_LICENSE_EXCEPTIONS = Object.freeze([
+  Object.freeze({
+    package: 'pyside6',
+    license: 'LGPL-3.0',
+    reason: 'source-only distribution, dynamically linked; temporary — remove when PySide6 is retired in cockpit-v2 (#355, ADR-0008 Option C)',
+    removeWhen: '#355',
+  }),
+]);
+
 /** License strings that mean "no usable license" — always fail closed (AC.1). */
 const UNKNOWN_MARKERS = new Set(['', 'unknown', 'unlicensed', 'see license in license', 'none']);
 
@@ -94,6 +139,107 @@ export function evaluate(licenses, allowlist = DEFAULT_ALLOWLIST) {
     }
   }
   return { ok: violations.length === 0, violations };
+}
+
+/**
+ * Extract the declared dependency package names from a `pyproject.toml` string
+ * (#349). Pure, no toml library: we scan `[project] dependencies = [...]` and
+ * every `[dependency-groups] <group> = [...]` array, taking each quoted requirement
+ * and stripping the version specifier / environment marker so `"PySide6>=6.7"` and
+ * `"pywinpty>=2.0; sys_platform == 'win32'"` both reduce to a bare name. Names are
+ * lower-cased and de-duplicated (PEP 503 normalises case). Robust to absent
+ * sections — returns whatever it finds, [] on none.
+ */
+export function parsePyprojectDeps(tomlText) {
+  const text = typeof tomlText === 'string' ? tomlText : '';
+  const names = new Set();
+  const harvest = (body) => {
+    // Match whole TOML strings by their own quote type, so inner opposite-quotes
+    // (e.g. the `'win32'` marker inside a double-quoted requirement) don't split it.
+    const strRe = /"([^"]*)"|'([^']*)'/g;
+    let s;
+    while ((s = strRe.exec(body)) !== null) {
+      const raw = (s[1] ?? s[2] ?? '').trim();
+      // A requirement name is the leading run before any version op / marker / extra.
+      const name = raw.split(/[\s;<>=!~\[\(]/)[0].trim().toLowerCase();
+      if (name) names.add(name);
+    }
+  };
+  // Runtime deps: the `[project] dependencies = [ ... ]` array only (NOT build-system
+  // `requires`, hatch `packages`, or pytest `testpaths`).
+  const projDeps = /(?:^|\n)\s*dependencies\s*=\s*\[([^\]]*)\]/.exec(text);
+  if (projDeps) harvest(projDeps[1]);
+  // Dev/optional deps: every array declared inside the `[dependency-groups]` table,
+  // scoped to that section so nothing outside it is harvested.
+  // Capture the section body up to the next table header (a `[name]` at line
+  // start), NOT the first `[` — array brackets like `dev = [` live inside it.
+  const groups = /(?:^|\n)\s*\[dependency-groups\]([\s\S]*?)(?=\n\s*\[[\w.-]+\]\s*(?:\n|$)|$)/.exec(text);
+  if (groups) {
+    const groupArrayRe = /=\s*\[([^\]]*)\]/g;
+    let g;
+    while ((g = groupArrayRe.exec(groups[1])) !== null) harvest(g[1]);
+  }
+  return [...names];
+}
+
+/**
+ * Resolve a list of Python package names to `[{name, license}]` via the curated
+ * SPDX map (#349). An unmapped package yields an empty license string, which
+ * evaluatePython() then fails closed on. Pure — no I/O.
+ */
+export function resolvePythonLicenses(names, map = PYTHON_LICENSES) {
+  return (names ?? []).map((name) => {
+    const key = String(name).trim().toLowerCase();
+    return { name: key, license: typeof map[key] === 'string' ? map[key] : '' };
+  });
+}
+
+/**
+ * Check a flat Python `[{name, license}]` list against the permissive allowlist,
+ * honouring the documented per-package exceptions (AC-349.1/.2/.3). A package that
+ * matches an exception (same name AND same license) is recorded under `exceptions`
+ * and NOT counted as a violation; everything else is evaluated exactly like the
+ * npm side — unknown/missing fails closed, non-permissive fails, permissive passes.
+ * Returns { ok, violations, exceptions }. Pure — no I/O.
+ */
+export function evaluatePython(licenses, allowlist = DEFAULT_ALLOWLIST, exceptions = PYTHON_LICENSE_EXCEPTIONS) {
+  const allow = new Set(allowlist);
+  const violations = [];
+  const applied = [];
+  for (const { name, license } of licenses) {
+    const norm = (license ?? '').trim();
+    const key = String(name).trim().toLowerCase();
+    const ex = exceptions.find((e) => e.package.toLowerCase() === key && e.license === norm);
+    if (ex) {
+      applied.push({ name: key, license: norm, reason: ex.reason, removeWhen: ex.removeWhen });
+      continue;
+    }
+    if (!norm || UNKNOWN_MARKERS.has(norm.toLowerCase())) {
+      violations.push({ name: key, license: norm || '(none)', reason: 'missing/unknown Python license — fails closed' });
+    } else if (!licenseAllowed(norm, allow)) {
+      violations.push({ name: key, license: norm, reason: `Python license '${norm}' is not in the allowlist` });
+    }
+  }
+  return { ok: violations.length === 0, violations, exceptions: applied };
+}
+
+/**
+ * Inspect the Python dependency tree of `tools/runner-ui` (#349, AC-349.1). Reads
+ * the committed pyproject.toml (deterministic, no network, no Python env needed in
+ * CI), resolves declared deps through the curated SPDX map, and evaluates them —
+ * with PySide6's LGPL-3.0 as the one documented exception. Degrades gracefully:
+ * with no pyproject.toml (consumer repos, or the cockpit removed) it SKIPS. Returns
+ * { ok, skipped?, names, violations, exceptions }.
+ */
+export async function checkPythonLicenses(cwd, { allowlist = DEFAULT_ALLOWLIST, relPath = 'tools/runner-ui/pyproject.toml' } = {}) {
+  const toml = await readFile(resolve(cwd, relPath), 'utf8').catch(() => null);
+  if (toml === null) {
+    return { ok: true, skipped: true, names: [], violations: [], exceptions: [] };
+  }
+  const names = parsePyprojectDeps(toml);
+  const licenses = resolvePythonLicenses(names);
+  const { ok, violations, exceptions } = evaluatePython(licenses, allowlist);
+  return { ok, skipped: false, names, violations, exceptions };
 }
 
 /** The effective allowlist: forge.json `license.allow` when valid, else the default. */
@@ -193,13 +339,23 @@ export async function runLicenseGate({ cwd, execFn = run, log = console.log, con
   }
 
   for (const v of violations) log(`x ${v.name}: ${v.license} — ${v.reason}`);
-  const ok = plugin.ok && violations.length === 0;
+
+  // #349 (AC-349.1/.2/.3) — the Python dependency tree (tools/runner-ui), which
+  // the npm-only gate never saw. Reported distinctly from the npm violations.
+  const python = await checkPythonLicenses(cwd, { allowlist });
+  for (const e of python.exceptions) log(`~ python ${e.name}: ${e.license} — allowlisted exception (${e.reason})`);
+  for (const v of python.violations) log(`x python ${v.name}: ${v.license} — ${v.reason}`);
+
+  const ok = plugin.ok && violations.length === 0 && python.ok;
   if (ok) {
-    log(`license: clean — plugin declares ${expected}; all dependency licenses within the allowlist (${allowlist.length} ids)`);
+    const pyNote = python.skipped
+      ? 'no Python tree'
+      : `${python.names.length} Python dep(s), ${python.exceptions.length} documented exception(s)`;
+    log(`license: clean — plugin declares ${expected}; all npm dependency licenses within the allowlist (${allowlist.length} ids); ${pyNote}`);
   } else {
-    log(`license: ${plugin.problems.length} plugin-declaration issue(s), ${violations.length} disallowed/unknown dependency license(s) — fix or extend license.allow before shipping`);
+    log(`license: ${plugin.problems.length} plugin-declaration issue(s), ${violations.length} disallowed/unknown npm license(s), ${python.violations.length} disallowed/unknown Python license(s) — fix or extend license.allow before shipping`);
   }
-  return { ok, violations, plugin, allowlist };
+  return { ok, violations, plugin, allowlist, python };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/tests/gates/license.test.mjs
+++ b/tests/gates/license.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,6 +12,12 @@ import {
   parsePnpmResult,
   checkPluginLicense,
   runLicenseGate,
+  PYTHON_LICENSES,
+  PYTHON_LICENSE_EXCEPTIONS,
+  parsePyprojectDeps,
+  resolvePythonLicenses,
+  evaluatePython,
+  checkPythonLicenses,
 } from '../../plugin/scripts/gates/license.mjs';
 
 const noop = () => {};
@@ -172,3 +178,167 @@ describe('license gate — SPDX allowlist enforcement (#342)', () => {
     expect(res.plugin.problems.join(' ')).toMatch(/no LICENSE file/);
   });
 });
+
+// #349 — the license gate was blind to the Python dependency tree
+// (tools/runner-ui/pyproject.toml), so the one genuinely non-permissive dep,
+// PySide6 (LGPL-3.0), was invisible to the gate built to catch copyleft.
+describe('license gate — Python dependency tree (#349)', () => {
+  // The real cockpit pyproject shape: PySide6 (the LGPL exception) + a marker
+  // string carrying inner single quotes, plus a dev group.
+  const PYPROJECT = `[project]
+name = "forge-cockpit"
+version = "0.1.0"
+license = { text = "LGPL-3.0-or-later" }
+dependencies = [
+    "PySide6>=6.7",
+    "pywinpty>=2.0; sys_platform == 'win32'",
+    "psutil>=5.9",
+]
+
+[project.scripts]
+forge-cockpit = "forge_cockpit.__main__:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-qt>=4.4",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["forge_cockpit"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+`;
+
+  it('AC-349.1: parses ONLY declared/dev deps from pyproject.toml (not build requires, packages, testpaths)', () => {
+    const names = parsePyprojectDeps(PYPROJECT);
+    expect(names).toEqual(['pyside6', 'pywinpty', 'psutil', 'pytest', 'pytest-qt']);
+    // the marker's inner 'win32' and the non-dependency arrays must NOT leak in.
+    expect(names).not.toContain('win32');
+    expect(names).not.toContain('hatchling');
+    expect(names).not.toContain('forge_cockpit');
+    expect(names).not.toContain('tests');
+  });
+
+  it('AC-349.1: resolves declared deps through the curated SPDX map; unmapped → empty (fails closed)', () => {
+    const resolved = resolvePythonLicenses(['pyside6', 'psutil', 'mystery-dep']);
+    expect(resolved).toContainEqual({ name: 'pyside6', license: 'LGPL-3.0' });
+    expect(resolved).toContainEqual({ name: 'psutil', license: 'BSD-3-Clause' });
+    expect(resolved).toContainEqual({ name: 'mystery-dep', license: '' });
+  });
+
+  it('AC-349.1: the whole real Python tree is inspected + allowlist applied (gate is not blind to it)', async () => {
+    const res = await checkPythonLicenses(REPO_ROOT);
+    expect(res.skipped).toBeFalsy();
+    // every declared dep is actually evaluated, not silently skipped.
+    expect(res.names).toEqual(['pyside6', 'pywinpty', 'psutil', 'pytest', 'pytest-qt']);
+    expect(res.ok).toBe(true);
+  });
+
+  it('AC-349.2: PySide6 LGPL-3.0 is EXPLICITLY allowlisted with a documented rationale — never a silent pass', async () => {
+    // The map deliberately classifies PySide6 as LGPL-3.0 (non-permissive)...
+    expect(PYTHON_LICENSES.pyside6).toBe('LGPL-3.0');
+    expect(DEFAULT_ALLOWLIST).not.toContain('LGPL-3.0'); // ...and LGPL is NOT permissive.
+
+    // ...so it only passes via a visible, package-scoped exception carrying a
+    // rationale that references the removal ticket / ADR (AC.2).
+    const res = await checkPythonLicenses(REPO_ROOT);
+    expect(res.violations).toEqual([]); // not a violation...
+    const ex = res.exceptions.find((e) => e.name === 'pyside6');
+    expect(ex).toBeTruthy(); // ...because it is recorded as an explicit exception
+    expect(ex.license).toBe('LGPL-3.0');
+    expect(ex.reason).toMatch(/#355|ADR-0008/); // rationale points at the removal plan
+    expect(ex.removeWhen).toBe('#355');
+
+    // The exception is package-scoped: an LGPL dep that is NOT PySide6 still fails.
+    const other = evaluatePython([{ name: 'some-lgpl-lib', license: 'LGPL-3.0' }]);
+    expect(other.ok).toBe(false);
+    expect(other.violations[0]).toMatchObject({ name: 'some-lgpl-lib', license: 'LGPL-3.0' });
+  });
+
+  it('AC-349.3: a disallowed (GPL-3.0) Python dependency is CAUGHT — the gate fails', () => {
+    const res = evaluatePython([
+      { name: 'psutil', license: 'BSD-3-Clause' },
+      { name: 'copyleft-py', license: 'GPL-3.0-only' },
+    ]);
+    expect(res.ok).toBe(false);
+    expect(res.violations).toHaveLength(1);
+    expect(res.violations[0]).toMatchObject({ name: 'copyleft-py', license: 'GPL-3.0-only' });
+    expect(res.violations[0].reason).toMatch(/not in the allowlist/);
+  });
+
+  it('AC-349.3: an unmapped/unknown Python dep fails CLOSED (never silently passes)', () => {
+    const res = evaluatePython(resolvePythonLicenses(['pytest', 'brand-new-unmapped-dep']));
+    expect(res.ok).toBe(false);
+    expect(res.violations.map((v) => v.name)).toEqual(['brand-new-unmapped-dep']);
+    expect(res.violations[0].reason).toMatch(/fails closed/);
+  });
+
+  it('AC-349.3: checkPythonLicenses FAILS on a fixture pyproject carrying a GPL dep', async () => {
+    const dir = await tempDir();
+    await writeFile(join(dir, 'pyproject.toml'), `[project]
+dependencies = ["psutil>=5.9"]
+`, 'utf8');
+    // map psutil→BSD (fine) but inject a GPL dep via a one-off map to prove the pipeline fails.
+    const gplMap = { psutil: 'GPL-3.0-only' };
+    const resolved = resolvePythonLicenses(parsePyprojectDeps(await readFileFixture(dir)), gplMap);
+    const res = evaluatePython(resolved);
+    expect(res.ok).toBe(false);
+    expect(res.violations[0]).toMatchObject({ name: 'psutil', license: 'GPL-3.0-only' });
+  });
+
+  it('AC-349.1: checkPythonLicenses SKIPS gracefully when there is no pyproject.toml', async () => {
+    const dir = await tempDir();
+    const res = await checkPythonLicenses(dir);
+    expect(res.skipped).toBe(true);
+    expect(res.ok).toBe(true);
+    expect(res.violations).toEqual([]);
+  });
+
+  it('AC-349.2: the documented exception set is package-scoped and self-documenting', () => {
+    expect(PYTHON_LICENSE_EXCEPTIONS).toHaveLength(1);
+    const [ex] = PYTHON_LICENSE_EXCEPTIONS;
+    expect(ex.package).toBe('pyside6');
+    expect(ex.license).toBe('LGPL-3.0');
+    expect(ex.reason).toMatch(/#355|ADR-0008|cockpit-v2/);
+  });
+
+  it('AC-349.1: runLicenseGate now covers BOTH trees and stays GREEN on the real repo', async () => {
+    const res = await runLicenseGate({ cwd: REPO_ROOT, execFn: execPermissive, log: noop });
+    expect(res.ok).toBe(true);
+    expect(res.python).toBeTruthy();
+    expect(res.python.skipped).toBeFalsy();
+    expect(res.python.exceptions.some((e) => e.name === 'pyside6')).toBe(true);
+    expect(res.python.violations).toEqual([]);
+  });
+
+  it('AC-349.3: runLicenseGate FAILS overall when the Python tree carries a non-permissive dep (end to end)', async () => {
+    // A full mini-repo: MIT plugin declaration + all-permissive npm (execPermissive),
+    // but a cockpit pyproject that declares an unmapped/non-permissive Python dep.
+    const dir = await tempDir();
+    await writeFile(join(dir, 'LICENSE'), 'MIT License\n\nCopyright (c) 2026', 'utf8');
+    await writeFile(join(dir, 'package.json'), JSON.stringify({ license: 'MIT' }), 'utf8');
+    const pyDir = join(dir, 'tools', 'runner-ui');
+    await mkdir(pyDir, { recursive: true });
+    await writeFile(join(pyDir, 'pyproject.toml'), `[project]
+dependencies = ["some-copyleft-lib>=1.0"]
+`, 'utf8');
+    const res = await runLicenseGate({ cwd: dir, execFn: execPermissive, log: noop });
+    expect(res.plugin.ok).toBe(true);       // plugin declaration fine
+    expect(res.violations).toEqual([]);     // npm side fine
+    expect(res.python.ok).toBe(false);      // Python side catches the unmapped dep
+    expect(res.ok).toBe(false);             // → whole gate reds
+    expect(res.python.violations[0]).toMatchObject({ name: 'some-copyleft-lib' });
+  });
+});
+
+// Small helper: read the fixture pyproject written into a temp dir.
+async function readFileFixture(dir) {
+  const { readFile } = await import('node:fs/promises');
+  return readFile(join(dir, 'pyproject.toml'), 'utf8');
+}


### PR DESCRIPTION
## What & why

The license gate (`plugin/scripts/gates/license.mjs`, shipped in #342/#343) inspected only the **npm** tree (`pnpm licenses list`) plus the plugin's own MIT declaration. It had **no visibility into the Python side** (`tools/runner-ui/pyproject.toml` + `uv.lock`), so the single genuinely non-permissive dependency in the repo — **PySide6 (LGPL-3.0)** — was invisible to the very gate built to catch copyleft.

This teaches the gate to inspect the Python dependency tree too, so `node plugin/scripts/gates/license.mjs` now covers **both** trees and reports them distinctly.

## Approach (deterministic, CI-safe)

- `uv.lock` carries **no per-package license metadata** (verified on the committed lock), and the license CI job runs on the Linux runner where the Python env may not be installed — so we **do not** shell out to `pip`/`uv`.
- `parsePyprojectDeps` reads the committed `pyproject.toml` for declared runtime + dev-group dep names; a small curated SPDX map (`PYTHON_LICENSES`) classifies them; unmapped deps resolve to `''` and **fail closed** (same contract as the npm side).
- `evaluatePython` checks each against the same permissive allowlist. npm + plugin-declaration behavior is unchanged.

## PySide6 / LGPL decision (AC.2)

Per **ADR-0008 (Option C)**, PySide6 is being removed in cockpit-v2 (**#355**). So PySide6's LGPL-3.0 is an **explicit, documented, temporary, package-scoped exception** (`PYTHON_LICENSE_EXCEPTIONS`) — never a silent pass, and never a hard failure that would red the current tree. The exception carries a rationale referencing #355/ADR-0008 and a note to delete it when #355 lands. Any **other** LGPL dep (npm or Python) still fails.

## Acceptance criteria

- [x] **AC.1** — the gate inspects the Python dep tree (`tools/runner-ui/pyproject.toml`) and applies the allowlist; a non-permissive/unmapped Python dep is flagged, not silently passed. *Verified: `checkPythonLicenses`/`evaluatePython` tests + end-to-end `runLicenseGate` fail test.*
- [x] **AC.2** — PySide6/LGPL is **explicitly allowlisted with a documented rationale** (source-only, dynamically linked, temporary; references #355/ADR-0008), never silently passing. *Verified: tests assert the exception is recorded with license `LGPL-3.0`, `removeWhen: #355`, and a rationale matching `#355|ADR-0008`; a non-PySide6 LGPL dep still fails.*
- [x] **AC.3** — a test covers a disallowed Python license being caught (GPL-3.0 fixture → gate fails), plus unmapped-dep fails-closed. *Verified: `evaluatePython` GPL test + `runLicenseGate` end-to-end temp-repo fail test.*

## Verification

- `node plugin/scripts/gates/license.mjs` → **exit 0** (PySide6 allowlisted with rationale; everything else permissive).
- `pnpm verify` → **664/664 green** (26 in the license suite, incl. 9 new #349 tests).

Closes #349
