### PR TITLE
docs(agents): teach the denylist escalation path in role cards + delivery brief

### DIFF
--- a/plugin/agents/implementer.md
+++ b/plugin/agents/implementer.md
@@ -25,6 +25,20 @@ Make one plan task's failing tests pass — smallest correct change, repo conven
 - Never touch files outside the brief's scope without flagging it in the report (plan-drift is checked at ship).
 - No shell strings built from untrusted input; argv arrays only.
 
+## Denylist — safe alternative first, then escalate (never retry a block)
+The PreToolUse denylist blocks a few high-blast-radius commands. Don't reflexively reach for them — use the safe alternative up front:
+
+| Blocked class | Safe alternative |
+| --- | --- |
+| recursive `rm` outside build/temp (`recursive-delete`) | targeted `rm <paths>` — name the paths, don't recurse over the tree |
+| `git reset --hard` (`hard-reset`) | `git revert` / `git restore <paths>` |
+| force-push (`force-push`) | `--force-with-lease`, and only when explicitly requested |
+| `git clean -f` (`git-clean-force`) | targeted `rm <paths>` |
+
+**On a denylist block, escalate — do not retry the blocked command** (`escalate.mjs`); a genuinely-required destructive action is a human decision, not a retry.
+
+**Literal-string caveat:** the denylist matches these command strings even inside quoted/heredoc bodies, so a PR body, comment, or trail note that merely *mentions* a blocked command trips it when passed inline. Write such content to a file and pass `--body-file` (or `git commit -F <file>`), never inline on a shell command line.
+
 ## Output contract
 Body — concise, bullets over prose, no task restatement (what changed, why, verification run), then a terminal JSON block:
 

--- a/plugin/cards/implementer.md
+++ b/plugin/cards/implementer.md
@@ -17,6 +17,20 @@ Make one plan task's failing tests pass — smallest correct change, repo conven
 - Never touch files outside the brief's scope without flagging it in the report (plan-drift is checked at ship).
 - No shell strings built from untrusted input; argv arrays only.
 
+## Denylist — safe alternative first, then escalate (never retry a block)
+The PreToolUse denylist blocks a few high-blast-radius commands. Don't reflexively reach for them — use the safe alternative up front:
+
+| Blocked class | Safe alternative |
+| --- | --- |
+| recursive `rm` outside build/temp (`recursive-delete`) | targeted `rm <paths>` — name the paths, don't recurse over the tree |
+| `git reset --hard` (`hard-reset`) | `git revert` / `git restore <paths>` |
+| force-push (`force-push`) | `--force-with-lease`, and only when explicitly requested |
+| `git clean -f` (`git-clean-force`) | targeted `rm <paths>` |
+
+**On a denylist block, escalate — do not retry the blocked command** (`escalate.mjs`); a genuinely-required destructive action is a human decision, not a retry.
+
+**Literal-string caveat:** the denylist matches these command strings even inside quoted/heredoc bodies, so a PR body, comment, or trail note that merely *mentions* a blocked command trips it when passed inline. Write such content to a file and pass `--body-file` (or `git commit -F <file>`), never inline on a shell command line.
+
 ## Output contract
 Body — concise, bullets over prose, no task restatement (what changed, why, verification run), then a terminal JSON block:
 

--- a/plugin/skills/autopilot/SKILL.md
+++ b/plugin/skills/autopilot/SKILL.md
@@ -57,6 +57,19 @@ Per ticket, the main loop does exactly three things: **spawn**, **record**, **co
 1. **Spawn a delivery subagent** with the Task tool — `subagent_type: general-purpose` (or a dedicated delivery agent if the roster has one). The brief is self-contained so the subagent needs no main-loop context: the ticket ref + body, the route (deliver, or shape-first under `--shape`), the merge bar (§ auto-merge), the escalation triggers (§ human gates), and this instruction — *do the whole ticket in your own context (branch, plan, implement, test, gates, ship, open the PR, **watch CI to green in this same run with `gh pr checks <pr> --watch`**, auto-merge on green, post-merge ritual); file follow-ups directly with `board/create.mjs`; escalate with `escalate.mjs`; then return a compact terminal report and nothing else.*
 
    **Forbidden — the return-then-resume stall:** the brief must NOT tell the subagent to open the PR and then return awaiting an external/background completion notification (e.g. "await the CI watcher's notification"). The subagent's context is discarded on return and **nothing re-invokes it when CI goes green** — that stalls the ticket until a manual resume. The background CI monitor notifies the **main loop**, not a returned subagent. The subagent must therefore watch CI to conclusion **in-run itself** (`gh pr checks <pr> --watch`) and merge within the **same invocation** — never return on the assumption it will be re-spawned on green.
+
+   **Denylist safe-alternatives — carried in every delivery brief.** The brief teaches each spawned delivery subagent the safe alternative up front so it doesn't reflexively reach for a denylisted destructive command, hit the block, and burn a turn retrying:
+
+   | Blocked class | Safe alternative |
+   | --- | --- |
+   | recursive `rm` outside build/temp (`recursive-delete`) | targeted `rm <paths>` — name the paths, don't recurse over the tree |
+   | `git reset --hard` (`hard-reset`) | `git revert` / `git restore <paths>` |
+   | force-push (`force-push`) | `--force-with-lease`, and only when explicitly requested |
+   | `git clean -f` (`git-clean-force`) | targeted `rm <paths>` |
+
+   **On a denylist block, escalate — do not retry the blocked command** (`escalate.mjs`); a genuinely-required destructive action is a human decision, not a retry.
+
+   **Literal-string caveat:** the denylist matches these command strings even inside quoted/heredoc bodies, so a PR body, comment, or trail note that merely *mentions* a blocked command trips it when passed inline. Write such content to a file and pass `--body-file` (or `git commit -F <file>`), never inline on a shell command line.
 2. **Read only the terminal report** — `{issue, outcome: merged|escalated|awaiting-human|skipped, pr, notes}` — and **run it through the watchdog** (`watchdog.mjs` `resolveReturnedTicket`, § Return-then-resume watchdog) before recording. A subagent that returns `awaiting-merge` (opened a green PR, then returned awaiting a re-invocation) must NOT be recorded as a silent terminal state — the watchdog turns that into a `merge` (funnel to the bar) or an `escalate` (surface awaiting-human / escalate). Every already-resolved outcome passes through as `continue`. The main loop then writes the resolved outcome to `run.json`, trails the ticket, and never re-reads the subagent's work.
 3. **Continue** to the next ticket. Because the delivery context is discarded, the main window is unchanged between tickets — a 5-ticket and a 50-ticket run cost the same orchestration overhead, and the run never compacts mid-loop.
 

--- a/plugin/skills/deliver/SKILL.md
+++ b/plugin/skills/deliver/SKILL.md
@@ -18,6 +18,21 @@ The trail, ledger, and journal are the record — don't re-narrate them in chat.
 - **Preconditions:** the ticket is triaged (clear ask + acceptance). Otherwise the planner returns `verdict: fail` — escalate, don't guess. `deliver` doesn't do discovery/spec work.
 - **Orchestrator owns state, subagents own work:** branch, ledger, `scope.json`, gates, trail, escalations stay with the main loop; subagents return their terminal JSON report only.
 
+## Denylist — safe alternative first, then escalate (never retry a block)
+
+The PreToolUse denylist blocks a few high-blast-radius commands. Don't reflexively reach for them — use the safe alternative up front:
+
+| Blocked class | Safe alternative |
+| --- | --- |
+| recursive `rm` outside build/temp (`recursive-delete`) | targeted `rm <paths>` — name the paths, don't recurse over the tree |
+| `git reset --hard` (`hard-reset`) | `git revert` / `git restore <paths>` |
+| force-push (`force-push`) | `--force-with-lease`, and only when explicitly requested |
+| `git clean -f` (`git-clean-force`) | targeted `rm <paths>` |
+
+**On a denylist block, escalate — do not retry the blocked command** (`escalate.mjs`); a genuinely-required destructive action is a human decision, not a retry.
+
+**Literal-string caveat:** the denylist matches these command strings even inside quoted/heredoc bodies, so a PR body, comment, or trail note that merely *mentions* a blocked command trips it when passed inline. Write such content to a file and pass `--body-file` (or `git commit -F <file>`), never inline on a shell command line.
+
 ## Phase 0 — Classify
 
 Spawn `planner` (`subagent_type: planner`) with the ticket ref + body + any linked spec/design/ADR. It returns the **ticket kind** (`spike | bug | ui | feature | test | chore`) and a **typed task plan** (each task tagged `code | test | ui | infra`, with Files + AC-IDs + test plan). `verdict: fail` → escalate, stop. The orchestrator picks the route from the kind:

--- a/tests/skills/denylist-guidance.test.mjs
+++ b/tests/skills/denylist-guidance.test.mjs
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => readFile(join(root, rel), 'utf8');
+
+// The three artifacts that must carry the denylist safe-alternatives + escalate
+// guidance (#346). The implementer *card* is the source of truth for the compiled
+// implementer agent (freshness gate lives in tests/backends/cards.test.mjs), so the
+// card is what we assert against here.
+const ARTIFACTS = {
+  'implementer role card': 'plugin/cards/implementer.md',
+  'deliver skill': 'plugin/skills/deliver/SKILL.md',
+  'autopilot delivery brief': 'plugin/skills/autopilot/SKILL.md',
+};
+
+describe('denylist escalation guidance (#346)', () => {
+  // AC-346.1 (role cards) + AC-346.2 (autopilot brief): the safe alternative for
+  // every denylisted destructive class is taught up front, in all three artifacts.
+  for (const [label, path] of Object.entries(ARTIFACTS)) {
+    it(`AC-346.1/AC-346.2: ${label} teaches the safe alternative for each denylisted destructive class`, async () => {
+      const s = await read(path);
+      // recursive rm (outside build/temp) -> targeted rm <paths>
+      expect(s, `${label}: recursive-delete class`).toContain('recursive-delete');
+      expect(s, `${label}: recursive rm safe alt`).toContain('targeted `rm <paths>`');
+      // git reset --hard -> git revert / git restore <paths>
+      expect(s, `${label}: hard-reset class`).toContain('hard-reset');
+      expect(s, `${label}: hard-reset safe alt (revert)`).toContain('git revert');
+      expect(s, `${label}: hard-reset safe alt (restore)`).toContain('git restore <paths>');
+      // force-push -> --force-with-lease, only when explicitly requested
+      expect(s, `${label}: force-push class`).toContain('force-push');
+      expect(s, `${label}: force-push safe alt`).toContain('--force-with-lease');
+      expect(s, `${label}: force-push only-when-requested`).toMatch(/only when explicitly requested/i);
+      // git clean -f -> targeted rm
+      expect(s, `${label}: git-clean-force class`).toContain('git-clean-force');
+    });
+  }
+
+  // AC-346.2: the escalate-don't-retry rule is present everywhere (the ticket calls
+  // it out specifically for the autopilot delivery brief, but all three carry it).
+  for (const [label, path] of Object.entries(ARTIFACTS)) {
+    it(`AC-346.2: ${label} states the escalate-don't-retry rule on a denylist block`, async () => {
+      const s = await read(path);
+      expect(s, `${label}: escalate-don't-retry`).toMatch(/do not retry the blocked command/i);
+      expect(s, `${label}: names escalate tool`).toContain('escalate.mjs');
+    });
+  }
+
+  // AC-346.3: the literal-string / --body-file caveat is present everywhere.
+  for (const [label, path] of Object.entries(ARTIFACTS)) {
+    it(`AC-346.3: ${label} includes the literal-string caveat (write via --body-file, never inline)`, async () => {
+      const s = await read(path);
+      expect(s, `${label}: literal-string caveat`).toMatch(/literal-string caveat/i);
+      expect(s, `${label}: quoted/heredoc bodies`).toMatch(/quoted\/heredoc bodies/i);
+      expect(s, `${label}: --body-file`).toContain('--body-file');
+      expect(s, `${label}: never inline on a shell command line`).toMatch(/never inline on a shell command line/i);
+    });
+  }
+
+  // AC-346.4: the guidance is the SAME canonical block across all three (so the
+  // copies can't silently drift). Assert the table header row is byte-identical.
+  it('AC-346.4: the safe-alternatives table is identical across the role cards and the delivery brief', async () => {
+    const header = '| Blocked class | Safe alternative |';
+    for (const [label, path] of Object.entries(ARTIFACTS)) {
+      const s = await read(path);
+      expect(s, `${label}: missing canonical table header`).toContain(header);
+    }
+  });
+
+  // AC-346.4: the compiled implementer AGENT (not just the card) carries the
+  // guidance — the freshness gate guarantees it, but assert it directly so a
+  // stale-agent regression is caught by this file too.
+  it('AC-346.4: the compiled implementer agent carries the denylist guidance', async () => {
+    const agent = await read('plugin/agents/implementer.md');
+    expect(agent).toContain('recursive-delete');
+    expect(agent).toContain('--force-with-lease');
+    expect(agent).toMatch(/do not retry the blocked command/i);
+    expect(agent).toContain('--body-file');
+  });
+});


### PR DESCRIPTION
## What

Delivery agents (orchestrator + spawned subagents) repeatedly reached for denylist-blocked destructive commands, hit the block, and burned a turn retrying. This teaches the safe alternative + escalate-don't-retry path up front, in the three artifacts a delivery agent actually reads.

One **canonical block** (identical wording, so the copies can't drift) added to:

- `plugin/cards/implementer.md` — the implementer role card (recompiled to `plugin/agents/implementer.md`)
- `plugin/skills/deliver/SKILL.md` — the deliver skill
- `plugin/skills/autopilot/SKILL.md` — the § Orchestration spawn brief the loop hands each delivery subagent

The block maps each denylisted destructive class (verified against `plugin/hooks/denylist.mjs`) to its safe alternative, states the escalate-don't-retry rule, and carries the literal-string / `--body-file` caveat.

## Acceptance criteria

- [x] **AC.1** — the implementer and deliver role cards teach the safe alternative for each denylisted destructive class up front: recursive removal outside build/temp -> targeted removal by path; hard-reset -> `git revert` / `git restore <paths>`; force-push -> `--force-with-lease` (only when explicitly requested); clean-force -> targeted removal.
- [x] **AC.2** — the autopilot delivery brief carries the same safe-alternatives list plus the rule: on a denylist block, escalate — do not retry the blocked command.
- [x] **AC.3** — the guidance includes the literal-string caveat: the denylist matches blocked-command strings inside quoted/heredoc bodies, so content that must mention a blocked command is written via a file + `--body-file`, never inline on a shell command line.
- [x] **AC.4** — `tests/skills/denylist-guidance.test.mjs` asserts the safe-alternative / escalate-don't-retry / caveat guidance is present in the role cards, the deliver skill, the autopilot brief, and the compiled implementer agent, so it cannot silently regress (mirrors the existing skill-text assertions).

## Verification

- `pnpm verify` — **675 passing / 58 files**, all green (includes the new `denylist-guidance` suite, the card freshness gate, and the deliver/autopilot skill-text suites).
- `node plugin/scripts/backends/compile.mjs` re-run so the compiled implementer agent matches its card (freshness gate green).
- Dogfooded the fix being shipped: every trail comment, the commit body, and this PR body that mention the blocked command strings were staged to a file and passed via `--body-file` / `-F`, never inline on a shell command line.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
