### PR TITLE
feat(cockpit): serve the Python cores over a 127.0.0.1 FastAPI backend (#351)

### DIFF
--- a/plugin/scripts/gates/license.mjs
+++ b/plugin/scripts/gates/license.mjs
@@ -55,10 +55,20 @@ export const EXPECTED_LICENSE = 'MIT';
  * with the desktop UI (ADR-0008), so they leave this map: the cockpit is now
  * cores-only and fully permissive. The map is kept fail-closed for whatever Python
  * deps remain or are added next.
+ *
+ * #351 — the Cockpit v2 localhost backend (ADR-0008) adds the FastAPI web
+ * framework served by uvicorn (both permissive) plus httpx (dev-only, powering
+ * FastAPI's TestClient). fastapi + pydantic are MIT; starlette, uvicorn, and
+ * httpx are BSD-3-Clause. Only the DECLARED names in pyproject.toml are resolved
+ * here (transitive deps are not gate-inspected), so fastapi/uvicorn/httpx are the
+ * three that need a classification.
  */
 export const PYTHON_LICENSES = Object.freeze({
   psutil: 'BSD-3-Clause',
   pytest: 'MIT',
+  fastapi: 'MIT',
+  uvicorn: 'BSD-3-Clause',
+  httpx: 'BSD-3-Clause',
 });
 
 /**

--- a/tests/gates/license.test.mjs
+++ b/tests/gates/license.test.mjs
@@ -239,9 +239,11 @@ testpaths = ["tests"]
   it('AC-355.3: the whole real Python tree is inspected + allowlist applied (gate is not blind to it)', async () => {
     const res = await checkPythonLicenses(REPO_ROOT);
     expect(res.skipped).toBeFalsy();
-    // #355 — cores-only: PySide6/pywinpty/pytest-qt are gone; only psutil + pytest remain.
-    // every declared dep is actually evaluated, not silently skipped.
-    expect(res.names).toEqual(['psutil', 'pytest']);
+    // #355 retired PySide6/pywinpty/pytest-qt; #351 (Cockpit v2 backend, ADR-0008)
+    // added the FastAPI web stack — fastapi + uvicorn (runtime) and httpx (dev,
+    // powering the TestClient), all permissive. Every declared dep is actually
+    // evaluated, not silently skipped.
+    expect(res.names).toEqual(['psutil', 'fastapi', 'uvicorn', 'pytest', 'httpx']);
     expect(res.ok).toBe(true);
   });
 

--- a/tools/runner-ui/forge_cockpit/server.py
+++ b/tools/runner-ui/forge_cockpit/server.py
@@ -1,0 +1,304 @@
+"""Cockpit v2 localhost backend (ticket #351, ADR-0008) — the Python cores over HTTP.
+
+ADR-0008 re-architected the cockpit from a native PySide6 window into a local
+**web app**: the existing framework-agnostic Python cores served over
+``127.0.0.1``, a browser UI, and an xterm.js terminal over a websocket. This
+module is the **HTTP backend + endpoint surface** half of that: a FastAPI (ASGI)
+app, served by uvicorn, that exposes each core as a loopback JSON endpoint —
+
+* ``GET  /api/health``    — liveness probe.
+* ``GET  /api/fleet``     — :func:`forge_cockpit.discovery.discover_fleet`.
+* ``POST /api/control``   — :func:`forge_cockpit.control.control` (start/stop/restart).
+* ``GET  /api/logs``      — :func:`forge_cockpit.logs.read_logs`.
+* ``POST /api/provision`` — :func:`forge_cockpit.provision.provision` (install/uninstall).
+* ``GET  /api/usage``     — :func:`forge_cockpit.usage.collect_usage` (+ aggregates).
+
+It is a **thin route layer**: it decodes the request, calls the matching core
+UNCHANGED, and serializes the core's typed result to JSON. No business logic
+lives here — the cores remain framework-agnostic (they know nothing of HTTP).
+
+Security (ADR-0005 + ADR-0006, inherited unchanged — AC.2):
+
+* The server binds **127.0.0.1 only** (:data:`HOST`) — never ``0.0.0.0`` — so the
+  surface is reachable from this machine alone.
+* The invariants carried by the cores hold end to end: **PAT-free**,
+  ``~/.forge/runner.env`` is **never read** (``shellout`` refuses any argv that
+  references it), and usage is **metadata only** (no prompt/response content).
+  No endpoint here adds a field that could carry a secret or the PAT.
+
+Scope boundary (ADR-0008 children): this ticket (#351) is the HTTP surface only.
+Loopback **hardening** — ``Host``-header/DNS-rebinding validation, a launch-minted
+capability token, ``Origin``/CSRF checks — is deliberately deferred to **#352**;
+the PTY-over-websocket terminal is **#353**; the browser UI is **#354**. This
+module does the minimal correct ``127.0.0.1`` bind and nothing more.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from forge_cockpit import discovery, usage
+from forge_cockpit.control import ACTIONS as CONTROL_ACTIONS
+from forge_cockpit.control import control
+from forge_cockpit.discovery import (
+    UNKNOWN_TARGET,
+    Fleet,
+    OnlineStatus,
+    RunnerEntry,
+)
+from forge_cockpit.logs import DEFAULT_TAIL_LINES, read_logs
+from forge_cockpit.provision import ACTIONS as PROVISION_ACTIONS
+from forge_cockpit.provision import PLATFORMS, provision
+from forge_cockpit.usage import (
+    UsageAggregate,
+    UsageRecord,
+    aggregate_by_day,
+    aggregate_by_model,
+    aggregate_by_session,
+    collect_usage,
+)
+
+#: Loopback-only bind address (ADR-0008 — AC.1). NEVER ``0.0.0.0``: the cockpit
+#: backend is reachable from this machine alone. Loopback hardening beyond the
+#: bind (Host header / Origin / capability token) is #352.
+HOST = "127.0.0.1"
+
+#: Default port for the local cockpit backend.
+DEFAULT_PORT = 8765
+
+
+# --------------------------------------------------------------------------- #
+# Request models (pydantic) — validated bodies for the mutating endpoints.
+# --------------------------------------------------------------------------- #
+class ControlRequest(BaseModel):
+    """Body for ``POST /api/control`` — which service and which verb."""
+
+    name: str = Field(..., min_length=1, description="The service/unit NAME (name-derived, #264).")
+    mechanism: str = Field(..., description="nssm | systemd | docker.")
+    action: str = Field(..., description="start | stop | restart.")
+
+
+class ProvisionRequest(BaseModel):
+    """Body for ``POST /api/provision`` — install/uninstall a repo-scoped service."""
+
+    action: str = Field(..., description="install | uninstall.")
+    owner: str = Field(..., min_length=1)
+    repo: str = Field(..., min_length=1)
+    platform: str | None = Field(default=None, description="windows | linux (defaults to host).")
+    force: bool = Field(default=False, description="Bypass the clobber/mis-target guard.")
+
+
+# --------------------------------------------------------------------------- #
+# Serializers — typed core dataclasses -> plain JSON-able dicts.
+#
+# Explicit (not blanket ``asdict``) so derived fields the UI needs (target slug,
+# online_count, total_tokens) travel too, and so nothing outside the cores' typed
+# fields is ever leaked (a secret has nowhere to hide — AC.2).
+# --------------------------------------------------------------------------- #
+def _serialize_target(target: discovery.Target) -> dict:
+    return {
+        "owner": target.owner,
+        "repo": target.repo,
+        "known": target.known,
+        "slug": target.slug,
+    }
+
+
+def _serialize_online(online: OnlineStatus) -> dict:
+    return {
+        "online": online.online,
+        "offline": online.offline,
+        "total": online.total,
+        "known": online.known,
+    }
+
+
+def _serialize_entry(entry: RunnerEntry) -> dict:
+    return {
+        "name": entry.name,
+        "mechanism": entry.mechanism,
+        "service_state": entry.service_state,
+        "target": _serialize_target(entry.target),
+        "online": _serialize_online(entry.online),
+        "repo": entry.repo,
+        "online_count": entry.online_count,
+    }
+
+
+def _serialize_fleet(fleet: Fleet) -> dict:
+    return {"runners": [_serialize_entry(e) for e in fleet.runners]}
+
+
+def _serialize_usage_record(record: UsageRecord) -> dict:
+    return {
+        "session_id": record.session_id,
+        "model": record.model,
+        "timestamp": record.timestamp.isoformat() if record.timestamp is not None else None,
+        "input_tokens": record.input_tokens,
+        "output_tokens": record.output_tokens,
+        "cache_read_tokens": record.cache_read_tokens,
+        "cache_creation_tokens": record.cache_creation_tokens,
+        "total_tokens": record.total_tokens,
+    }
+
+
+def _serialize_aggregate(agg: UsageAggregate) -> dict:
+    return {
+        "key": agg.key,
+        "turns": agg.turns,
+        "input_tokens": agg.input_tokens,
+        "output_tokens": agg.output_tokens,
+        "cache_read_tokens": agg.cache_read_tokens,
+        "cache_creation_tokens": agg.cache_creation_tokens,
+        "total_tokens": agg.total_tokens,
+        "cost_input": agg.cost_input,
+        "cost_output": agg.cost_output,
+        "cost_cache_read": agg.cost_cache_read,
+        "cost_cache_creation": agg.cost_cache_creation,
+        "total_cost": agg.total_cost,
+        "unpriced_turns": agg.unpriced_turns,
+        "unpriced_models": sorted(agg.unpriced_models),
+    }
+
+
+def _serialize_aggregates(aggs: dict[str, UsageAggregate]) -> dict:
+    return {key: _serialize_aggregate(agg) for key, agg in aggs.items()}
+
+
+# --------------------------------------------------------------------------- #
+# App factory + routes (thin — decode, call the core, serialize).
+# --------------------------------------------------------------------------- #
+def create_app() -> FastAPI:
+    """Build the FastAPI app wiring each core to a loopback JSON endpoint (AC.1).
+
+    A factory (not a module-global app) so tests can build a fresh instance and
+    the console entry point can serve one, without import-time side effects.
+    """
+    app = FastAPI(
+        title="Forge cockpit backend",
+        summary="Local (127.0.0.1) HTTP surface over the framework-agnostic runner cores.",
+        version="2.0.0",
+    )
+
+    @app.get("/api/health")
+    def health() -> dict:
+        """Liveness probe — the UI polls this to know the backend is up."""
+        return {"status": "ok", "service": "forge-cockpit"}
+
+    @app.get("/api/fleet")
+    def get_fleet() -> dict:
+        """Discover the runner fleet (:func:`discover_fleet`) — AC.1."""
+        return _serialize_fleet(discovery.discover_fleet())
+
+    @app.post("/api/control")
+    def post_control(req: ControlRequest) -> dict:
+        """Start / stop / restart a service (:func:`control`) — AC.1.
+
+        The core reads only the entry's NAME and mechanism (never its env), so a
+        minimal :class:`RunnerEntry` reconstructed from the request is sufficient
+        and keeps this a thin wrapper.
+        """
+        if req.action not in CONTROL_ACTIONS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"unknown action {req.action!r}; expected one of {list(CONTROL_ACTIONS)}",
+            )
+        entry = RunnerEntry(
+            name=req.name,
+            mechanism=req.mechanism,
+            service_state="unknown",
+            target=UNKNOWN_TARGET,
+            online=OnlineStatus.unknown(),
+        )
+        return dataclasses.asdict(control(entry, req.action))
+
+    @app.get("/api/logs")
+    def get_logs(
+        name: str = Query(..., min_length=1, description="The service/unit NAME."),
+        mechanism: str = Query(..., description="nssm | systemd | docker."),
+        lines: int = Query(default=DEFAULT_TAIL_LINES, ge=1, le=10000),
+    ) -> dict:
+        """Read the tail of a service's own logs (:func:`read_logs`) — AC.1."""
+        entry = RunnerEntry(
+            name=name,
+            mechanism=mechanism,
+            service_state="unknown",
+            target=UNKNOWN_TARGET,
+            online=OnlineStatus.unknown(),
+        )
+        return dataclasses.asdict(read_logs(entry, lines=lines))
+
+    @app.post("/api/provision")
+    def post_provision(req: ProvisionRequest) -> dict:
+        """Install / uninstall a repo-scoped runner service (:func:`provision`) — AC.1.
+
+        Never handles the PAT (AC.2/AC.3 of the core): the token is out of band.
+        The clobber/mis-target guard cross-references the live fleet in the UI
+        layer (#354) — the HTTP surface passes ``force`` straight through.
+        """
+        if req.action not in PROVISION_ACTIONS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"unknown action {req.action!r}; expected one of {list(PROVISION_ACTIONS)}",
+            )
+        if req.platform is not None and req.platform not in PLATFORMS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"unknown platform {req.platform!r}; expected one of {list(PLATFORMS)}",
+            )
+        result = provision(
+            req.action,
+            req.owner,
+            req.repo,
+            platform=req.platform,
+            force=req.force,
+        )
+        return dataclasses.asdict(result)
+
+    @app.get("/api/usage")
+    def get_usage() -> dict:
+        """Claude usage/cost from local transcripts (:func:`collect_usage`) — AC.1.
+
+        Metadata only — token counts, model ids, timestamps, and derived cost.
+        No prompt/response content is read or returned (ADR-0006 — AC.2).
+        """
+        records = collect_usage()
+        return {
+            "records": [_serialize_usage_record(r) for r in records],
+            "by_session": _serialize_aggregates(aggregate_by_session(records)),
+            "by_day": _serialize_aggregates(aggregate_by_day(records)),
+            "by_model": _serialize_aggregates(aggregate_by_model(records)),
+        }
+
+    return app
+
+
+#: Module-level ASGI app (``uvicorn forge_cockpit.server:app``) — built once.
+app = create_app()
+
+
+def build_config(*, host: str = HOST, port: int = DEFAULT_PORT) -> uvicorn.Config:
+    """The uvicorn config for serving the app — bound to loopback by default (AC.1/AC.4).
+
+    Factored out so a test can assert the bind host is ``127.0.0.1`` and never
+    ``0.0.0.0`` without standing a real socket up.
+    """
+    return uvicorn.Config(app, host=host, port=port, log_level="info")
+
+
+def main() -> None:
+    """Console entry point (``forge-cockpit``): serve the backend on 127.0.0.1.
+
+    Restores the ``forge-cockpit`` launch command #355 removed with the desktop
+    UI — now serving the FastAPI backend instead of opening a Qt window. Binds
+    loopback only; the browser UI (#354) will connect to it.
+    """
+    uvicorn.Server(build_config()).run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch path
+    main()

--- a/tools/runner-ui/pyproject.toml
+++ b/tools/runner-ui/pyproject.toml
@@ -7,11 +7,19 @@ requires-python = ">=3.12"
 license = { text = "MIT" }
 dependencies = [
     "psutil>=5.9",
+    "fastapi>=0.110",
+    "uvicorn>=0.29",
 ]
+
+[project.scripts]
+# Restores the `forge-cockpit` launch command #355 retired with the desktop UI —
+# now serves the FastAPI backend on 127.0.0.1 (ADR-0008 / #351) instead of a Qt window.
+forge-cockpit = "forge_cockpit.server:main"
 
 [dependency-groups]
 dev = [
     "pytest>=8.0",
+    "httpx>=0.27",
 ]
 
 [build-system]

--- a/tools/runner-ui/tests/test_server.py
+++ b/tools/runner-ui/tests/test_server.py
@@ -1,0 +1,355 @@
+"""Tests for the Cockpit v2 localhost backend (ticket #351, ADR-0008).
+
+These lock the HTTP surface to its contract (AC.4): each endpoint calls its core
+UNCHANGED and returns that core's data, the server binds **127.0.0.1 only** (never
+``0.0.0.0``), and the ADR-0006 security invariants survive the HTTP layer
+(PAT-free, ``runner.env`` never read, usage metadata-only — AC.2).
+
+Hermetic + headless: the cores are monkeypatched at the server module boundary to
+return canned typed results, so no test shells out (``sc``/``gh``/``wsl``) or
+reads the real ``~/.claude`` transcripts. The one seam left real is the usage
+aggregation, exercised on canned records to prove the endpoint wires it up.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from forge_cockpit import server
+from forge_cockpit.control import ActionResult
+from forge_cockpit.discovery import (
+    DOCKER,
+    NSSM,
+    SYSTEMD,
+    Fleet,
+    OnlineStatus,
+    RunnerEntry,
+    Target,
+)
+from forge_cockpit.logs import LogRead
+from forge_cockpit.provision import ProvisionResult
+from forge_cockpit.usage import UsageRecord
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(server.app)
+
+
+# --------------------------------------------------------------------------- #
+# AC.4 / AC.1 — the loopback bind (never 0.0.0.0).
+# --------------------------------------------------------------------------- #
+def test_host_constant_is_loopback_only():
+    assert server.HOST == "127.0.0.1"
+    assert server.HOST != "0.0.0.0"
+
+
+def test_build_config_binds_loopback_not_all_interfaces():
+    config = server.build_config()
+    assert config.host == "127.0.0.1"
+    # The whole point of AC.1: NEVER bound to every interface.
+    assert config.host != "0.0.0.0"
+
+
+def test_build_config_host_is_not_overridable_to_all_interfaces_by_default():
+    # Default call never yields a world-reachable bind; an explicit override is a
+    # caller's choice, but the default that main() uses is loopback.
+    assert server.build_config(port=9999).host == "127.0.0.1"
+
+
+# --------------------------------------------------------------------------- #
+# AC.1 — /api/health liveness.
+# --------------------------------------------------------------------------- #
+def test_health_ok(client):
+    res = client.get("/api/health")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok", "service": "forge-cockpit"}
+
+
+# --------------------------------------------------------------------------- #
+# AC.1 — /api/fleet returns discover_fleet()'s data.
+# --------------------------------------------------------------------------- #
+def test_fleet_endpoint_returns_discovery_data(client, monkeypatch):
+    fleet = Fleet(
+        runners=(
+            RunnerEntry(
+                name="forge-runner-dngioidev-forge",
+                mechanism=NSSM,
+                service_state="running",
+                target=Target(owner="dngioidev", repo="forge"),
+                online=OnlineStatus(online=2, offline=0, total=2, known=True),
+            ),
+            RunnerEntry(
+                name="runner-run-abc",
+                mechanism=DOCKER,
+                service_state="exited",
+                target=Target(owner=None, repo=None),
+                online=OnlineStatus.unknown(),
+            ),
+        )
+    )
+    monkeypatch.setattr(server.discovery, "discover_fleet", lambda: fleet)
+
+    body = client.get("/api/fleet").json()
+    assert [r["name"] for r in body["runners"]] == [
+        "forge-runner-dngioidev-forge",
+        "runner-run-abc",
+    ]
+    first = body["runners"][0]
+    assert first["mechanism"] == "nssm"
+    assert first["service_state"] == "running"
+    assert first["target"] == {
+        "owner": "dngioidev",
+        "repo": "forge",
+        "known": True,
+        "slug": "dngioidev/forge",
+    }
+    assert first["online"] == {"online": 2, "offline": 0, "total": 2, "known": True}
+    assert first["online_count"] == 2
+    assert first["repo"] == "dngioidev/forge"
+    # The docker job entry keeps the unknown target/online sentinels.
+    assert body["runners"][1]["repo"] == "unknown/legacy"
+    assert body["runners"][1]["online"]["known"] is False
+
+
+# --------------------------------------------------------------------------- #
+# AC.1 — /api/control drives control() (start/stop/restart).
+# --------------------------------------------------------------------------- #
+def test_control_endpoint_returns_action_result(client, monkeypatch):
+    captured: dict = {}
+
+    def fake_control(entry: RunnerEntry, action: str):
+        captured["name"] = entry.name
+        captured["mechanism"] = entry.mechanism
+        captured["action"] = action
+        return ActionResult(
+            action=action,
+            name=entry.name,
+            mechanism=entry.mechanism,
+            ok=True,
+            elevated=False,
+            message="Restart succeeded for systemd --user unit.",
+        )
+
+    monkeypatch.setattr(server, "control", fake_control)
+
+    res = client.post(
+        "/api/control",
+        json={"name": "forge-runner-a-b", "mechanism": SYSTEMD, "action": "restart"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["action"] == "restart"
+    assert body["message"].startswith("Restart succeeded")
+    # The core was called with the request's name/mechanism/action.
+    assert captured == {"name": "forge-runner-a-b", "mechanism": "systemd", "action": "restart"}
+
+
+def test_control_rejects_unknown_action(client):
+    res = client.post(
+        "/api/control",
+        json={"name": "forge-runner-a-b", "mechanism": NSSM, "action": "obliterate"},
+    )
+    assert res.status_code == 422
+
+
+# --------------------------------------------------------------------------- #
+# AC.1 — /api/logs drives read_logs().
+# --------------------------------------------------------------------------- #
+def test_logs_endpoint_returns_logread(client, monkeypatch):
+    captured: dict = {}
+
+    def fake_read_logs(entry: RunnerEntry, *, lines: int):
+        captured["name"] = entry.name
+        captured["mechanism"] = entry.mechanism
+        captured["lines"] = lines
+        return LogRead(ok=True, text="line1\nline2", source="journalctl --user -u forge-runner-a-b")
+
+    monkeypatch.setattr(server, "read_logs", fake_read_logs)
+
+    res = client.get(
+        "/api/logs",
+        params={"name": "forge-runner-a-b", "mechanism": SYSTEMD, "lines": 50},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body == {
+        "ok": True,
+        "text": "line1\nline2",
+        "source": "journalctl --user -u forge-runner-a-b",
+    }
+    assert captured == {"name": "forge-runner-a-b", "mechanism": "systemd", "lines": 50}
+
+
+def test_logs_default_lines(client, monkeypatch):
+    seen: dict = {}
+    monkeypatch.setattr(
+        server,
+        "read_logs",
+        lambda entry, *, lines: seen.update(lines=lines)
+        or LogRead(ok=True, text="", source="s"),
+    )
+    client.get("/api/logs", params={"name": "n", "mechanism": NSSM})
+    assert seen["lines"] == server.DEFAULT_TAIL_LINES
+
+
+# --------------------------------------------------------------------------- #
+# AC.1 — /api/provision drives provision(); AC.2/AC.3 — never handles the PAT.
+# --------------------------------------------------------------------------- #
+def test_provision_endpoint_returns_result(client, monkeypatch):
+    captured: dict = {}
+
+    def fake_provision(action, owner, repo, *, platform=None, force=False, **kwargs):
+        captured.update(action=action, owner=owner, repo=repo, platform=platform, force=force)
+        return ProvisionResult(
+            action=action,
+            platform=platform or "linux",
+            name=f"forge-runner-{owner}-{repo}",
+            owner=owner,
+            repo=repo,
+            ok=True,
+            elevated=False,
+            message="Install succeeded.",
+        )
+
+    monkeypatch.setattr(server, "provision", fake_provision)
+
+    res = client.post(
+        "/api/provision",
+        json={"action": "install", "owner": "dngioidev", "repo": "forge", "platform": "linux"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert body["name"] == "forge-runner-dngioidev-forge"
+    assert captured == {
+        "action": "install",
+        "owner": "dngioidev",
+        "repo": "forge",
+        "platform": "linux",
+        "force": False,
+    }
+
+
+def test_provision_rejects_unknown_action(client):
+    res = client.post(
+        "/api/provision",
+        json={"action": "nuke", "owner": "o", "repo": "r"},
+    )
+    assert res.status_code == 422
+
+
+def test_provision_rejects_unknown_platform(client):
+    res = client.post(
+        "/api/provision",
+        json={"action": "install", "owner": "o", "repo": "r", "platform": "solaris"},
+    )
+    assert res.status_code == 422
+
+
+def test_provision_request_never_accepts_a_token_field(client, monkeypatch):
+    """AC.2/AC.3: the PAT is out of band. Even if a client tries to smuggle a
+    token in the body, it is ignored — it never reaches the core."""
+    captured: dict = {}
+    monkeypatch.setattr(
+        server,
+        "provision",
+        lambda action, owner, repo, **kw: captured.update(kw=kw)
+        or ProvisionResult(action, "linux", "n", owner, repo, True, False, "ok"),
+    )
+    client.post(
+        "/api/provision",
+        json={
+            "action": "install",
+            "owner": "o",
+            "repo": "r",
+            "token": "ghp_SHOULD_BE_IGNORED",  # not a model field
+        },
+    )
+    # The unknown 'token' field never becomes a provision() kwarg.
+    assert "token" not in captured["kw"]
+
+
+# --------------------------------------------------------------------------- #
+# AC.1 — /api/usage drives collect_usage(); AC.2 — metadata only, no content.
+# --------------------------------------------------------------------------- #
+def test_usage_endpoint_returns_records_and_aggregates(client, monkeypatch):
+    records = [
+        UsageRecord(
+            session_id="s1",
+            model="claude-opus-4-8",
+            timestamp=datetime(2026, 8, 3, 12, 0, tzinfo=timezone.utc),
+            input_tokens=1_000_000,
+            output_tokens=500_000,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        ),
+    ]
+    monkeypatch.setattr(server, "collect_usage", lambda: records)
+
+    body = client.get("/api/usage").json()
+
+    assert len(body["records"]) == 1
+    rec = body["records"][0]
+    assert rec["session_id"] == "s1"
+    assert rec["model"] == "claude-opus-4-8"
+    assert rec["input_tokens"] == 1_000_000
+    assert rec["total_tokens"] == 1_500_000
+    assert rec["timestamp"] == "2026-08-03T12:00:00+00:00"
+
+    # Aggregations are wired up and priced (opus: $5 in / $25 out per 1M).
+    by_model = body["by_model"]["claude-opus-4-8"]
+    assert by_model["turns"] == 1
+    assert by_model["total_cost"] == pytest.approx(5.0 + 12.5)  # 1M*$5 + 0.5M*$25
+    assert body["by_session"]["s1"]["turns"] == 1
+    assert body["by_day"]["2026-08-03"]["turns"] == 1
+
+
+def test_usage_response_is_metadata_only_no_content_fields(client, monkeypatch):
+    """AC.2: the usage surface exposes token/cost metadata only — there is nowhere
+    for prompt/response CONTENT to appear (ADR-0006 privacy invariant)."""
+    records = [
+        UsageRecord(
+            session_id="s1",
+            model="claude-opus-4-8",
+            timestamp=None,
+            input_tokens=10,
+            output_tokens=20,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        ),
+    ]
+    monkeypatch.setattr(server, "collect_usage", lambda: records)
+
+    rec = client.get("/api/usage").json()["records"][0]
+    allowed = {
+        "session_id",
+        "model",
+        "timestamp",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+        "total_tokens",
+    }
+    assert set(rec) == allowed
+    # No content-bearing keys leaked into the surface.
+    for banned in ("content", "message", "text", "prompt", "response"):
+        assert banned not in rec
+
+
+# --------------------------------------------------------------------------- #
+# AC.2 — no endpoint carries a PAT / secret field anywhere in its response.
+# --------------------------------------------------------------------------- #
+def test_no_endpoint_response_mentions_a_pat_or_secret(client, monkeypatch):
+    monkeypatch.setattr(server.discovery, "discover_fleet", lambda: Fleet(runners=()))
+    monkeypatch.setattr(server, "collect_usage", lambda: [])
+
+    for path in ("/api/health", "/api/fleet", "/api/usage"):
+        text = client.get(path).text.lower()
+        for banned in ("runner.env", "ghp_", "github_pat", "forge_runner_pat"):
+            assert banned not in text

--- a/tools/runner-ui/uv.lock
+++ b/tools/runner-ui/uv.lock
@@ -3,6 +3,58 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -12,23 +64,95 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
 name = "forge-cockpit"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "psutil" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pytest" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "psutil", specifier = ">=5.9" }]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.110" },
+    { name = "psutil", specifier = ">=5.9" },
+    { name = "uvicorn", specifier = ">=0.29" },
+]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0" }]
+dev = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8.0" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -86,6 +210,96 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -108,4 +322,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/18/ccce41535dee1be77735592bd19965f3972c82e07ee703d324709496b716/uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd", size = 100571, upload-time = "2026-08-01T18:19:30.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d5/68e6e9bca63c0badf67002890a46d3784c958de45b65e1275ec583ca1f06/uvicorn-0.52.1-py3-none-any.whl", hash = "sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a", size = 79859, upload-time = "2026-08-01T18:19:29.294Z" },
 ]


### PR DESCRIPTION
Closes #351

## What

Cockpit v2 (ADR-0008, epic #350) — the **localhost HTTP backend**. A FastAPI
(ASGI) app served by uvicorn binds **127.0.0.1 only** and exposes each existing
framework-agnostic Python core UNCHANGED as a loopback JSON endpoint. New module
`tools/runner-ui/forge_cockpit/server.py` is a thin route layer (decode → call
the core → serialize the typed result); the cores stay framework-agnostic. A
`forge-cockpit` console entry point runs uvicorn on 127.0.0.1 — restoring the
launch command #355 retired with the desktop UI, now serving the backend.

| Endpoint | Core |
|---|---|
| `GET /api/health` | liveness |
| `GET /api/fleet` | `discovery.discover_fleet` |
| `POST /api/control` | `control.control` (start/stop/restart) |
| `GET /api/logs` | `logs.read_logs` |
| `POST /api/provision` | `provision.provision` (install/uninstall) |
| `GET /api/usage` | `usage.collect_usage` + by session/day/model aggregates |

**Scope boundary:** loopback hardening (Host/Origin/DNS-rebinding/CSRF/capability
token) is #352; PTY-over-websocket terminal is #353; browser UI is #354. This PR
is the HTTP surface only, with the minimal correct 127.0.0.1 bind.

## Acceptance criteria

- [x] **AC.1** — FastAPI/uvicorn app binds 127.0.0.1 only and exposes discovery,
  control, logs, provision, usage, reusing the `forge_cockpit/*.py` cores
  unchanged. *Verified:* `test_server.py` monkeypatches each core at the server
  boundary and asserts the endpoint returns its data; `build_config().host ==
  "127.0.0.1"`.
- [x] **AC.2** — ADR-0006 invariants hold end to end: PAT-free, `runner.env`
  never read (shellout's hard backstop unchanged), usage metadata-only; no
  endpoint exposes a secret/PAT. *Verified:* tests assert the usage surface is
  metadata-only (no content/message/prompt keys), provision ignores a smuggled
  `token` field, and no response mentions `runner.env`/`ghp_`/`*_pat`.
- [x] **AC.3** — `fastapi` + `uvicorn` added to `pyproject.toml` (MIT /
  BSD-3-Clause), `httpx` dev-only for TestClient; `uv lock` regenerated; license
  gate reports **zero exceptions**. *Verified:* `node plugin/scripts/gates/license.mjs`
  → `license: clean — ... 5 Python dep(s), 0 documented exception(s)`.
- [x] **AC.4** — pytest (headless, TestClient) covers each endpoint returning its
  core's data and asserts loopback-only bind (not 0.0.0.0). *Verified:* 20 new
  tests, all green.

## Verification (this run)

```
uv run pytest -q         → 122 passed  (20 new server tests + existing cores)
node .../gates/license.mjs → license: clean — 5 Python dep(s), 0 documented exception(s)
pnpm verify              → 58 files, 675 tests passed
```

## Notes

- The clobber/mis-target guard in `provision` cross-references the live fleet;
  the HTTP surface passes `force` straight through and leaves that cross-ref to
  the UI flow (#354) — the core guard is unchanged for direct callers.
- Runtime transitive deps (starlette, pydantic, pydantic-core, anyio, sniffio,
  idna, click, h11, typing-extensions) are all MIT/BSD/PSF. `certifi` (MPL-2.0)
  appears **only** on the dev/test path via `httpx` (TestClient), not at runtime,
  and the license gate inspects declared deps (not transitive), so it is not a
  gate finding — flagged here for honesty, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
