### PR TITLE
fix(lib): back off + retry on GitHub GraphQL rate limits (#360)

### DIFF
--- a/plugin/scripts/lib/boardctx.mjs
+++ b/plugin/scripts/lib/boardctx.mjs
@@ -6,12 +6,23 @@ import { getRepoInfo, optionKey } from './board.mjs';
  * per script run. Every ID comes from config — no hand-built GraphQL ids
  * (spec §6). All gh calls flow through the injected wrapper.
  */
-export async function makeBoardCtx({ gh, cwd }) {
+export async function makeBoardCtx({ gh, cwd, now = Date.now, itemsTtlMs = 15000 }) {
   const cfg = await loadConfig(cwd);
   if (!cfg.ok) return { ok: false, error: `${CONFIG_RELPATH} invalid or missing: ${cfg.errors[0]}` };
   const repo = await getRepoInfo(gh);
   if (!repo.ok) return { ok: false, error: repo.error };
   const board = cfg.config.board;
+
+  // #360 AC.3 — field/option IDs already come from forge.json (resolved once by
+  // loadConfig, never re-fetched per board op — see resolveOption below). The
+  // remaining per-run GraphQL hot path is `project item-list`, which every
+  // read-path re-fetches (500 items). A short-TTL memo dedupes repeated reads
+  // within a resolved ctx — notably the long-lived MCP session, where one
+  // memoized ctx serves board_status / autopilot_select across many calls. Every
+  // mutation through this ctx busts the memo, so a re-read after a move sees the
+  // new state (preserves the #178 verify-after-move contract).
+  let itemsCache = null; // { at, value }
+  const invalidateItems = () => { itemsCache = null; };
 
   const ctx = {
     ok: true,
@@ -34,14 +45,21 @@ export async function makeBoardCtx({ gh, cwd }) {
       return { ok: true, fieldId: field.id, optionId: id };
     },
 
-    async listItems() {
+    /** #360: memoized per ctx (TTL + invalidate-on-mutation). `refresh` forces a re-fetch. */
+    async listItems({ refresh = false } = {}) {
+      if (!refresh && itemsCache && (now() - itemsCache.at) < itemsTtlMs) return itemsCache.value;
       const res = await gh(
         ['project', 'item-list', String(board.projectNumber), '--owner', repo.owner, '--format', 'json', '--limit', '500'],
         { parseJson: true },
       );
-      if (!res.ok) return { ok: false, error: res.stderr || 'item-list failed' };
-      return { ok: true, items: res.json.items ?? [] };
+      if (!res.ok) return { ok: false, error: res.stderr || 'item-list failed' }; // never cache a failure
+      const value = { ok: true, items: res.json.items ?? [] };
+      itemsCache = { at: now(), value };
+      return value;
     },
+
+    /** Force the next listItems() to re-fetch (e.g. after an out-of-band board change). */
+    invalidateItems,
 
     async findItemByIssue(issueNumber) {
       const list = await this.listItems();
@@ -76,6 +94,7 @@ export async function makeBoardCtx({ gh, cwd }) {
         { parseJson: true },
       );
       if (!res.ok) return { ok: false, error: res.stderr || 'item-add failed' };
+      invalidateItems(); // a new item invalidates the cached list (#360)
       return { ok: true, itemId: res.json.id };
     },
 
@@ -87,6 +106,7 @@ export async function makeBoardCtx({ gh, cwd }) {
         '--field-id', opt.fieldId, '--single-select-option-id', opt.optionId,
       ]);
       if (!res.ok) return { ok: false, error: res.stderr || `set ${fieldKey}=${key} failed` };
+      invalidateItems(); // the field changed — a re-read must be fresh (#178 verify-after-move)
       return { ok: true };
     },
 

--- a/plugin/scripts/lib/exec.mjs
+++ b/plugin/scripts/lib/exec.mjs
@@ -44,12 +44,81 @@ function spawnOnce(command, args = [], options = {}, viaComSpec = false) {
 }
 
 /**
+ * #360 — GitHub rate-limit backoff.
+ *
+ * The GraphQL bucket is 5,000 points/hour *shared account-wide* across every
+ * repo and tool. A multi-repo forge user (or forge running alongside other
+ * tooling) exhausts it fast; Projects v2 board ops and the merge bar's
+ * statusCheckRollup are all GraphQL. Without backoff the run hard-fails on a raw
+ * 403 and stalls. These helpers are pure so the retry decision is unit-tested
+ * with a mocked rate-limited response — no real API and no real sleep.
+ */
+
+/** Does a gh result carry GitHub's rate-limit signature? (pure — AC.1) */
+export function isRateLimited(res) {
+  if (!res || res.ok) return false;
+  const text = `${res.stderr || ''}\n${res.stdout || ''}`;
+  // `x-ratelimit-remaining: 0` (headers on a -i/verbose error), the REST/GraphQL
+  // "API rate limit exceeded" body, the GraphQL RATE_LIMITED type, or a secondary
+  // (abuse) limit. A bare 403 alone is NOT enough — it must mention a rate limit.
+  if (/x-ratelimit-remaining:\s*0/i.test(text)) return true;
+  if (/API rate limit exceeded/i.test(text)) return true;
+  if (/secondary rate limit/i.test(text)) return true;
+  if (/\bRATE_LIMITED\b/.test(text)) return true;
+  if (/\b403\b/.test(text) && /rate limit/i.test(text)) return true;
+  return false;
+}
+
+/**
+ * How long to wait before the next retry, in ms (pure — AC.1). Honors the reset
+ * window when the response exposes it (`x-ratelimit-reset` epoch seconds, or a
+ * `retry-after` seconds hint for secondary limits); otherwise exponential
+ * backoff by attempt. Bounded: reset waits cap at `resetCapMs`, the exponential
+ * fallback at `capMs`. `now`/`attempt` are injected so a test drives it without
+ * a real clock.
+ */
+export function retryDelayFrom(res, { now = Date.now(), attempt = 0, baseMs = 1000, capMs = 60000, resetCapMs = 15 * 60 * 1000 } = {}) {
+  const text = `${(res && res.stderr) || ''}\n${(res && res.stdout) || ''}`;
+  const reset = /x-ratelimit-reset:\s*(\d+)/i.exec(text);
+  if (reset) {
+    const wait = Number(reset[1]) * 1000 - now;
+    if (wait > 0) return Math.min(wait + 1000, resetCapMs); // +1s cushion past the reset
+  }
+  const retryAfter = /retry-after:\s*(\d+)/i.exec(text);
+  if (retryAfter) return Math.min(Number(retryAfter[1]) * 1000 + 1000, resetCapMs);
+  return Math.min(baseMs * 2 ** attempt, capMs); // 1s, 2s, 4s, 8s … capped
+}
+
+/** The clear, actionable line forge surfaces instead of a raw 403 (AC.2). */
+export function rateLimitNotice(res, delayMs, attempt, max) {
+  const text = `${(res && res.stderr) || ''}\n${(res && res.stdout) || ''}`;
+  const rem = /x-ratelimit-remaining:\s*(\d+)/i.exec(text);
+  const remaining = rem ? rem[1] : '0';
+  const secs = Math.ceil(delayMs / 1000);
+  return `forge: GitHub API rate limit hit (remaining ${remaining}, reset in ~${secs}s) — backing off, retrying (attempt ${attempt}/${max})`;
+}
+
+const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
  * gh CLI wrapper factory. The exec function is injectable so every consumer
  * (init, doctor) is testable with scripted responses instead of a live gh.
+ *
+ * #360: a rate-limited response is not hard-failed — the wrapper backs off and
+ * retries (bounded by `maxRetries`), honoring the reset window, and surfaces an
+ * actionable line each wait (AC.1 + AC.2). `sleep`/`now`/`log` are injected so a
+ * test drives the retry→succeed path with no real API and no real delay.
  */
-export function makeGh(execFn = run) {
+export function makeGh(execFn = run, { maxRetries = 5, sleep = defaultSleep, now = Date.now, log = console.error } = {}) {
   return async function gh(args, { parseJson = false } = {}) {
-    const res = await execFn('gh', args);
+    let res;
+    for (let attempt = 0; ; attempt++) {
+      res = await execFn('gh', args);
+      if (res.ok || attempt >= maxRetries || !isRateLimited(res)) break;
+      const delay = retryDelayFrom(res, { now: now(), attempt });
+      log(rateLimitNotice(res, delay, attempt + 1, maxRetries));
+      await sleep(delay);
+    }
     if (parseJson && res.ok) {
       try {
         return { ...res, json: JSON.parse(res.stdout) };
@@ -59,4 +128,20 @@ export function makeGh(execFn = run) {
     }
     return res;
   };
+}
+
+/**
+ * AC.4 — GraphQL budget preflight. Reads `gh api rate_limit` (a REST call that
+ * itself does NOT count against any bucket) so a batch (e.g. an autopilot
+ * iteration) can check the shared GraphQL budget and degrade gracefully — pause
+ * and surface the reset window — rather than firing calls that will 403.
+ * Returns `{ ok, remaining, limit, resetInSec, low }`; `low` trips at `lowWater`.
+ */
+export async function rateBudget(gh, { lowWater = 200, now = () => Math.floor(Date.now() / 1000) } = {}) {
+  const res = await gh(['api', 'rate_limit'], { parseJson: true });
+  if (!res.ok || !res.json) return { ok: false, error: res.stderr || 'rate_limit query failed' };
+  const g = res.json.resources?.graphql ?? {};
+  const remaining = g.remaining ?? 0;
+  const resetInSec = Math.max(0, (g.reset ?? 0) - now());
+  return { ok: true, remaining, limit: g.limit ?? 0, resetInSec, low: remaining <= lowWater };
 }

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -98,6 +98,37 @@ describe('boardctx', () => {
     ]);
     expect((await ctx2.findItemByIssue(9)).item).toBe(null);
   });
+
+  it('AC-360.3: listItems is memoized per ctx — repeated reads hit gh once', async () => {
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_1', content: { number: 7 }, status: 'Ready' }])],
+    ]);
+    await ctx.listItems();
+    await ctx.listItems();
+    await ctx.findItemByIssue(7); // also reads the list
+    expect(calls.filter((c) => c.startsWith('project item-list')).length).toBe(1);
+  });
+
+  it('AC-360.3: a mutation invalidates the memo so a re-read is fresh (preserves #178)', async () => {
+    let status = 'Ready';
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), () => itemList([{ id: 'ITEM_1', content: { number: 7 }, status }])],
+      [(j) => j.startsWith('project item-edit'), () => { status = 'Done'; return { stdout: '' }; }],
+    ]);
+    expect(ctx.itemFieldKey((await ctx.listItems()).items[0], 'status')).toBe('ready');
+    await ctx.setSelect('ITEM_1', 'status', 'done'); // busts the memo
+    expect(ctx.itemFieldKey((await ctx.listItems()).items[0], 'status')).toBe('done'); // fresh, not stale
+    expect(calls.filter((c) => c.startsWith('project item-list')).length).toBe(2);
+  });
+
+  it('AC-360.3: refresh:true forces a re-fetch', async () => {
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([{ id: 'ITEM_1', content: { number: 7 }, status: 'Ready' }])],
+    ]);
+    await ctx.listItems();
+    await ctx.listItems({ refresh: true });
+    expect(calls.filter((c) => c.startsWith('project item-list')).length).toBe(2);
+  });
 });
 
 describe('create (AC-2.1)', () => {

--- a/tests/lib/exec.test.mjs
+++ b/tests/lib/exec.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { run, makeGh } from '../../plugin/scripts/lib/exec.mjs';
+import { run, makeGh, isRateLimited, retryDelayFrom, rateLimitNotice, rateBudget } from '../../plugin/scripts/lib/exec.mjs';
 
 describe('run', () => {
   it('runs a real process and captures stdout', async () => {
@@ -57,5 +57,110 @@ describe('makeGh', () => {
     const res = await gh(['x'], { parseJson: true });
     expect(res.ok).toBe(false);
     expect(res.json).toBe(null);
+  });
+});
+
+// #360 — GraphQL rate-limit backoff.
+const RL_403 = { ok: false, code: 1, stdout: '', stderr: 'HTTP 403: API rate limit exceeded for user ID 123 (https://docs.github.com/…)' };
+
+describe('isRateLimited (AC-360.1)', () => {
+  it('detects the REST/GraphQL "API rate limit exceeded" body', () => {
+    expect(isRateLimited(RL_403)).toBe(true);
+  });
+  it('detects x-ratelimit-remaining: 0 headers', () => {
+    expect(isRateLimited({ ok: false, code: 1, stdout: '', stderr: 'HTTP 403\nx-ratelimit-remaining: 0\nx-ratelimit-reset: 1785764483' })).toBe(true);
+  });
+  it('detects the GraphQL RATE_LIMITED type and secondary limits', () => {
+    expect(isRateLimited({ ok: false, stderr: '{"errors":[{"type":"RATE_LIMITED"}]}' })).toBe(true);
+    expect(isRateLimited({ ok: false, stderr: 'You have exceeded a secondary rate limit' })).toBe(true);
+  });
+  it('does NOT flag a plain success or an unrelated 403', () => {
+    expect(isRateLimited({ ok: true, stdout: '{}', stderr: '' })).toBe(false);
+    expect(isRateLimited({ ok: false, stderr: 'HTTP 403: Resource not accessible by integration' })).toBe(false);
+    expect(isRateLimited(null)).toBe(false);
+  });
+});
+
+describe('retryDelayFrom (AC-360.1)', () => {
+  it('honors the reset window when x-ratelimit-reset is present', () => {
+    const now = 1_000_000_000_000; // ms
+    const res = { ok: false, stderr: `x-ratelimit-reset: ${now / 1000 + 30}` }; // reset 30s out
+    const delay = retryDelayFrom(res, { now, attempt: 0 });
+    expect(delay).toBe(30_000 + 1000); // wait to reset + 1s cushion
+  });
+  it('caps a far-future reset at resetCapMs', () => {
+    const now = 1_000_000_000_000;
+    const res = { ok: false, stderr: `x-ratelimit-reset: ${now / 1000 + 99999}` };
+    expect(retryDelayFrom(res, { now, attempt: 0 })).toBe(15 * 60 * 1000);
+  });
+  it('falls back to exponential backoff (capped) with no reset header', () => {
+    const r = RL_403;
+    expect(retryDelayFrom(r, { attempt: 0 })).toBe(1000);
+    expect(retryDelayFrom(r, { attempt: 3 })).toBe(8000);
+    expect(retryDelayFrom(r, { attempt: 20 })).toBe(60_000); // capMs
+  });
+});
+
+describe('makeGh rate-limit backoff (AC-360.1 / AC-360.2)', () => {
+  it('a mocked rate-limited response is handled gracefully: retry → succeed', async () => {
+    let calls = 0;
+    const slept = [];
+    const logs = [];
+    const gh = makeGh(
+      async () => (++calls === 1 ? RL_403 : { ok: true, code: 0, stdout: '{"ok":true}', stderr: '' }),
+      { sleep: async (ms) => { slept.push(ms); }, now: () => 0, log: (m) => logs.push(m) },
+    );
+    const res = await gh(['project', 'item-list'], { parseJson: true });
+    expect(res.ok).toBe(true);          // recovered rather than hard-failing
+    expect(res.json.ok).toBe(true);
+    expect(calls).toBe(2);              // one rate-limited attempt, then success
+    expect(slept).toEqual([1000]);      // backed off once (injected sleep, no real delay)
+    // AC.2: an actionable line, not a raw 403
+    expect(logs[0]).toMatch(/rate limit hit .*reset in ~1s.*retrying \(attempt 1\/5\)/);
+  });
+
+  it('gives up after maxRetries and returns the last rate-limited result (bounded)', async () => {
+    let calls = 0;
+    const gh = makeGh(async () => { calls++; return RL_403; }, { maxRetries: 3, sleep: async () => {}, now: () => 0, log: () => {} });
+    const res = await gh(['x']);
+    expect(res.ok).toBe(false);
+    expect(calls).toBe(4); // initial + 3 retries, then stop
+  });
+
+  it('does not retry a non-rate-limit failure', async () => {
+    let calls = 0;
+    const gh = makeGh(async () => { calls++; return { ok: false, code: 1, stdout: '', stderr: 'HTTP 404: Not Found' }; }, { sleep: async () => {}, log: () => {} });
+    const res = await gh(['x']);
+    expect(res.ok).toBe(false);
+    expect(calls).toBe(1);
+  });
+});
+
+describe('rateLimitNotice (AC-360.2)', () => {
+  it('surfaces remaining + reset-in-Ns + retrying', () => {
+    const line = rateLimitNotice({ stderr: 'x-ratelimit-remaining: 0' }, 42_000, 2, 5);
+    expect(line).toContain('remaining 0');
+    expect(line).toContain('reset in ~42s');
+    expect(line).toContain('attempt 2/5');
+  });
+});
+
+describe('rateBudget (AC-360.4)', () => {
+  const RATE = { resources: { graphql: { limit: 5000, remaining: 120, reset: 100 } } };
+  it('reports the shared GraphQL budget and flags low', async () => {
+    const gh = makeGh(async (cmd, args) => {
+      expect(args).toEqual(['api', 'rate_limit']);
+      return { ok: true, code: 0, stdout: JSON.stringify(RATE), stderr: '' };
+    });
+    const b = await rateBudget(gh, { lowWater: 200, now: () => 40 });
+    expect(b).toMatchObject({ ok: true, remaining: 120, limit: 5000, resetInSec: 60, low: true });
+  });
+  it('not low when remaining is comfortable', async () => {
+    const gh = makeGh(async () => ({ ok: true, code: 0, stdout: JSON.stringify({ resources: { graphql: { limit: 5000, remaining: 4000, reset: 0 } } }), stderr: '' }));
+    expect((await rateBudget(gh, { lowWater: 200 })).low).toBe(false);
+  });
+  it('surfaces an error when the query fails', async () => {
+    const gh = makeGh(async () => ({ ok: false, code: 1, stdout: '', stderr: 'boom' }));
+    expect(await rateBudget(gh)).toMatchObject({ ok: false });
   });
 });


### PR DESCRIPTION
Closes #360.

## Why
The GitHub GraphQL bucket is **5,000 points/hour shared account-wide** across every repo and tool. A multi-repo forge user (or forge running alongside other tooling) exhausts it fast — Projects v2 board ops and the merge bar's `statusCheckRollup` are all GraphQL. Today the shared gh layer surfaces a rate-limit 403 as a hard failure and the run stalls with a raw error and no wait-for-reset (observed firsthand twice during autopilot runs, each recovering only after a ~7-min reset).

## What

**AC.1 + AC.2 — backoff/retry (primary, `lib/exec.mjs`)**
- `makeGh` now detects a rate-limit response — `403` + a rate-limit body, `x-ratelimit-remaining: 0`, the GraphQL `RATE_LIMITED` type, or a secondary/abuse limit — and **backs off + retries** instead of hard-failing. A bare 403 without a rate-limit mention is not retried.
- Retries honor the **reset window** (`x-ratelimit-reset` epoch, or a `retry-after` seconds hint), falling back to exponential backoff. Bounded: `maxRetries` (default 5), reset waits capped at 15 min, exponential fallback at 60 s.
- Instead of a raw 403, forge surfaces a clear line: `GitHub API rate limit hit (remaining N, reset in ~Ns) — backing off, retrying (attempt k/max)`.
- The decision is factored into pure `isRateLimited(res)` / `retryDelayFrom(res, {now, attempt})` / `rateLimitNotice(...)`, so a **mocked rate-limited response is driven retry→succeed** with **no real API and no real sleep** (injected `sleep` + `now`).

**AC.3 — reduce GraphQL call volume (`lib/boardctx.mjs`)**
- Field/option IDs already come from `forge.json` (resolved once by `loadConfig`, never re-fetched per board op — `getProjectFields` runs only in init/doctor bootstrap). So the literal "cache field/option IDs" ask is already satisfied architecturally.
- The remaining per-run GraphQL hot path is `project item-list` (500 items), which every read-path re-fetches. It's now **memoized per ctx** (short TTL) and **busted on every mutation** (`setSelect` / `addItemByUrl`). This dedupes repeated reads within a resolved ctx — notably the **long-lived MCP session**, where one memoized ctx serves `board_status` / `autopilot_select` across many calls and today re-fetches all items each time. Because every mutation invalidates the memo, a re-read after a move sees the new state — the **#178 verify-after-move contract is preserved** (test added). A `listItems({ refresh: true })` escape hatch forces a re-fetch.

**AC.4 — budget preflight (`lib/exec.mjs`)**
- `rateBudget(gh)` reads `gh api rate_limit` (a REST call that doesn't count against any bucket) and returns `{ remaining, limit, resetInSec, low }`, so a batch can degrade gracefully rather than fire calls that will 403.

## Verification
- `pnpm verify` green — **692 tests pass** (58 files), including the new AC-360 tests.
- New tests in `tests/lib/exec.test.mjs`: `isRateLimited` detection matrix, `retryDelayFrom` reset-window + cap + exponential fallback, `makeGh` retry→succeed (mocked rate-limit, injected sleep/clock), bounded give-up after `maxRetries`, no-retry for non-rate-limit failures, `rateLimitNotice` shape, `rateBudget` low/comfortable/error.
- New tests in `tests/board.test.mjs`: `AC-360.3` memo dedupe, mutation-invalidation freshness (preserves #178), `refresh:true`.
- Honest scope note: the retry/backoff (AC.1/AC.2) is the high-value fix and is exercised end-to-end via injected sleep/clock — a live rate limit can't be forced in a unit test. The autopilot merge-bar / CI-watch `statusCheckRollup` dedup mentioned in AC.3 is **not** attempted here (it needs the `forge-ci` monitor transition reuse — a larger, more invasive change); the item-list memo + budget preflight already cut the largest board-op volume. If the maintainer wants the `ciGreen` dedup pursued, it's a clean follow-up parented to #182.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
