### PR TITLE
docs(design): cockpit UI split-cockpit visual spec (#354)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,8 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 ## Design specs
 
 - [Console — heat identity](design/2026-07-17-console.md) — visual spec for the local web console: situation-as-heat token system, states matrix, a11y contract.
+- [Cockpit browser UI](design/2026-08-03-cockpit-ui.md) — visual spec for the runner-fleet cockpit web app (#354, ADR-0008): split-cockpit layout (persistent fleet sidebar + Usage/Terminal/Logs main pane), states matrix, a11y contract, on the smithy token vocabulary (zero new tokens).
+- [Cockpit UI variants (#354)](design/variants-354/README.md) — the three token-grounded mockups behind the cockpit spec (A single-pane · B tabbed · C split-cockpit, owner pick); design-lane reference.
 
 ## Decisions (ADRs)
 

--- a/docs/design/2026-08-03-cockpit-ui.md
+++ b/docs/design/2026-08-03-cockpit-ui.md
@@ -1,0 +1,128 @@
+# Visual spec — cockpit browser UI (#354)
+
+<!-- forge visual-spec template (spec §4 item 11). Every section below is
+mandatory — speclint.mjs enforces their presence; design-reviewer validates
+the implementation against their content. -->
+
+## Summary
+The runner-fleet **cockpit browser UI** — the web front-end that renders the
+FastAPI cores landed in #351–#353 (fleet discovery/control, usage/cost, logs,
+and the PTY-over-websocket terminal). It lives in `tools/runner-ui/`, served by
+the `forge-cockpit` launcher over `127.0.0.1` (loopback-only, session-token
+gated per #352), and replaces the retired PySide6 desktop app (ADR-0008,
+supersedes ADR-0006 Decision 1). Chosen variant: **C — split cockpit** (owner
+pick, `docs/design/variants-354/variant-c.html`). Rationale: a persistent,
+always-visible fleet sidebar (mini status cards + inline start/stop/restart
+controls) sits beside a main pane that toggles between Usage / Terminal / Logs
+with **Terminal as the default view**. The "mission control" feel — fleet
+health is never out of sight (glance-away, not a navigation away), and the
+terminal is one click from anywhere (the mode bar, or a mini-card's own
+actions). The tradeoff accepted: the main content column is the narrowest of
+the three variants because the fleet sidebar is permanent chrome; at 375px the
+sidebar flattens into a horizontal-scroll strip above the main pane so the
+terminal and chart reclaim full width. Dark-only, drawing exclusively on the
+existing smithy token vocabulary (see Token delta) — zero new tokens.
+
+## States matrix
+Three representative surfaces: the **fleet mini-card**, a **control button**
+(start / stop / restart — every mutating control requires the session token),
+and the **usage panel**.
+
+| state | normal content | long content | extreme content |
+| --- | --- | --- | --- |
+| default | mini-card: `iron.bg` plate, `iron.seam` border, `heat.*`-mapped left edge (online→`success`, offline→`heat.cool`, mis-target→`heat.alarm`) + a text status label (never color-only); control button: quiet `ink.ash` on transparent, `iron.seam` border, ≥24px hit height; usage panel: token chart + per-model breakdown with real figures | long repo/platform names truncate with ellipsis; the card grows to fit its status/meta lines; breakdown figures stay `tabular-nums` right-aligned | 12+ runners: the sidebar list scrolls vertically (`overflow-y:auto`), cards keep fixed width; usage breakdown adds rows, panel scrolls |
+| hover | control button: border + label shift to `heat.ember`; mode-bar tab: label brightens to `ink.ash` | button label wraps inside its box rather than overflowing | — (non-interactive card body has no hover) |
+| focus | 2px `heat.ember` outline, 2px offset (`:focus-visible`) on every control, mode-bar tab, and the terminal surface | same | same |
+| active | control button `:active`: faint `heat.ember` wash (rgba); selected mode-bar tab carries a `claude` bottom border + `ink.ash` label | pressed label ellipsizes, `title` carries the full action | rapid toggling never loses the aria-selected single-source-of-truth |
+| disabled | control that can't apply is `disabled` + dimmed (start-when-online, stop-when-offline) with a `title` explaining why; not focusable | disabled label truncates, `title` carries full reason | all controls on a card disabled mid-transition until the next fleet poll settles |
+| loading | a card mid-restart shows a spinner glyph + "restarting…" on the control in `heat.spark`; its sibling controls disable; the fleet stamp reads "updated HH:MM:SS" via `aria-live=polite` | "re-provisioning…" long label stays on one line, ellipsizes | many concurrent transitions: each card owns its own spinner, no global blocker |
+| empty | sidebar with no runners for the repo: a labeled dashed placeholder card "no runners for this repo"; usage panel with no transcripts: "no usage recorded yet" in `ink.smoke` | — | — |
+| error | mis-target card: `heat.alarm` left edge + an inline `role=alert` line ("reports as <other-repo>") + a lock-glyph re-provision control; usage panel: `role=alert` banner ("transcripts unreadable — check `~/.claude/projects` permissions") in `error`; control failure: inline errline on the card, actionable, never an `alert()` | error text wraps inside the card/banner | repeated poll/control failures keep the last good render and never steal focus |
+
+## Breakpoints
+Rendered at three widths (CSS `@media`, no JS layout switching):
+- **375 (mobile):** `body` switches to `flex-direction:column`; the sidebar
+  becomes a full-width horizontal-scroll strip above the main pane
+  (`fleet-list` → `flex-direction:row`, `overflow-x:auto`), mini-cards get a
+  min-width and scroll sideways; the session-token footer pill is hidden to
+  save height; mode-bar tab labels shrink, terminal pane caps to ~44vh so both
+  fleet and terminal stay usable.
+- **768 (tablet):** the split persists — sidebar narrows (~200px) and mode-bar
+  tabs drop their long text labels to glyph-only to fit; main pane holds the
+  active view full-height.
+- **1280 (desktop):** the reference layout — ~270px persistent sidebar, full
+  mode bar with text labels, main pane at comfortable width; the usage chart
+  and terminal render at the intended (narrower-than-full-page) column the
+  split trades for permanent fleet visibility.
+
+## Themes
+Dark-only, deliberately — inherited from the console precedent
+(`docs/design/2026-07-17-console.md`) and the smithy **heat metaphor**: runner
+health glows (edge + wash) read only on a dark ground, and the cockpit is a
+glanceable ops surface. A light theme is **out of scope**; if a real need ever
+appears it enters as a token-delta finding (a light-mode mapping of the
+`iron.*` / `ink.*` / `heat.*` scales), not an ad-hoc restyle. Token-driven
+differences only — no theme-specific one-off values.
+
+## A11y contract
+- **Focus order:** wordmark/stamp → fleet mini-cards in list order, and within
+  a card its control buttons left-to-right (start/stop/restart/re-provision) →
+  main mode bar (Usage / Terminal / Logs tabs) → the active mode view's
+  interactive surface (the terminal, or usage/log scroll region) → session
+  pill. Reordering the fleet never traps focus.
+- **Roles / accessible names:** sidebar `aria-label="Fleet health"`; fleet list
+  `role=list`, each card `role=listitem`; the update stamp
+  `role=status aria-live=polite`; mode bar `role=tablist` with `role=tab` +
+  `aria-selected` buttons controlling `role=tabpanel` views; the mis-target
+  message and usage error banner `role=alert`; the token chart `role=img` with
+  a text `aria-label` summarizing the trend; the terminal surface labeled and
+  keyboard-reachable.
+- **Contrast pairs (token references):** `ink.ash` on `iron.plate` / `iron.bg`
+  (body + terminal text) ≥ 7:1; `ink.smoke` on `iron.plate` (secondary/meta)
+  ≥ 4.5:1; `success` / `heat.spark` / `heat.alarm` / `error` status labels on
+  `iron.bg` ≥ 4.5:1; `ink.steel` links on `iron.plate` ≥ 4.5:1.
+- **Target sizes:** every control (mini-card buttons, mode-bar tabs) ≥ 24px hit
+  height (`min-height:24px` + padding); at 375 the strip's controls keep the
+  same floor.
+- **Non-color-only status:** fleet online / offline / mis-target never rely on
+  the edge color alone — each carries a text label ("online" / "offline" /
+  "mis-target") and mis-target adds a `role=alert` glyph line; log levels carry
+  an uppercase text level beside their color.
+- **Reduced motion behavior:** under `prefers-reduced-motion:reduce` the
+  restart spinner and the terminal cursor blink both stop (static glyph /
+  steady cursor); the pane-toggle and card-hover transitions are removed.
+
+## Motion
+| element | property | duration token | easing token | reduced-motion |
+| --- | --- | --- | --- | --- |
+| mode view (Usage/Terminal/Logs toggle) | opacity/visibility swap | `motion.calm` (250ms) | default ease | instant swap (transition removed) |
+| control button (hover/active) | border-color, color, background | `motion.calm` (250ms) | default ease | none (transition removed) |
+| mini-card control spinner (loading) | rotate | 900ms linear loop | linear | animation none — static glyph |
+| terminal cursor | blink (opacity) | 1s step | step-start | animation none — steady cursor at reduced opacity |
+
+## Token delta
+- **Tokens used:** the smithy vocabulary only —
+  `iron.bg` · `iron.plate` · `iron.seam` (grounds);
+  `ink.ash` · `ink.smoke` · `ink.steel` (text/links);
+  `heat.cool` · `heat.warm` · `heat.spark` · `heat.ember` · `heat.alarm`
+  (the heat scale); the semantic `success` · `error` · `claude` overrides from
+  `plugin/themes/forge.json`; `motion.calm` (250ms); and the display
+  (Bahnschrift/DIN) + mono (Consolas/Cascadia) type roles. All defined by the
+  console spec (`docs/design/2026-07-17-console.md`) and `plugin/themes/forge.json`.
+- **New tokens proposed:** none. The designer confirmed zero new tokens — the
+  cockpit is built entirely from the existing scales.
+- **Reuse decision (recorded as a deliberate precedent, not a one-off):** fleet
+  binary health is mapped onto the heat vocabulary — online→`success`,
+  offline→`heat.cool` ("cold iron", no fire), mis-target→`heat.alarm` + `error`
+  (a real misconfiguration, styled like the console's `lockdown` severity).
+  This makes the cockpit a **second consumer** of `heat.cool`/`heat.alarm`
+  beyond the console's situation-urgency metaphor — health, not situation. It
+  is intentional reuse; if the two surfaces ever need independent scales this
+  mapping must be revisited explicitly rather than forked silently.
+- **One-off values:** none (by definition — a one-off is a finding). Edge and
+  hover washes are rgba() of the `heat.*` tokens at low alpha, not new colors.
+
+## Graph ripple
+New component, no consumers yet. (The cockpit UI is the top of its own tree —
+it consumes the #351–#353 FastAPI/websocket endpoints but nothing in the repo
+consumes the UI; features.graph is off for this non-TS surface.)

--- a/docs/design/variants-354/README.md
+++ b/docs/design/variants-354/README.md
@@ -1,0 +1,70 @@
+# Variants — cockpit browser UI (#354, epic #350, ADR-0008)
+
+Three self-contained HTML mockups for the FastAPI-backed cockpit web app: fleet
+(`/api/fleet`, `/api/control`), usage/cost (`/api/usage`), a terminal
+(`/api/terminal` websocket, mocked here as a static styled pane — production
+wires it to xterm.js), and logs (`/api/logs`). All dark-only, all on the smithy
+token vocabulary from `docs/design/2026-07-17-console.md` +
+`plugin/themes/forge.json`. Mock fleet: `dngioidev/forge` (both legs online),
+`dngioidev/iomanage` (windows leg offline, wsl2 leg mis-targeted).
+
+## Variant A — single-pane ops dashboard (`variant-a.html`)
+Everything on one scroll: fleet cards top, usage/cost band middle, a
+terminal+logs dock pinned to the bottom (tab-switched, not page-navigated).
+Glanceable — the whole cockpit's state is visible without a click.
+**Tradeoff:** the busiest of the three; the terminal dock competes for
+vertical space with the chart band on short viewports, so it's capped to a
+fixed height rather than filling the screen.
+
+## Variant B — tabbed workspace (`variant-b.html`)
+A left icon+label rail (Fleet · Usage · Terminal · Logs, collapsing to a
+bottom tab bar at 375px) shows one full-height view at a time. The calmest
+variant — no competing panels, most screen real estate per surface (a real
+xterm.js pane wants room).
+**Tradeoff:** the terminal is a full navigation away from the fleet sidebar,
+so glancing at fleet health while typing in the terminal needs a tab switch.
+
+## Variant C — split cockpit (`variant-c.html`)
+A persistent, always-visible fleet sidebar (mini status cards + inline
+controls) plus a main pane that toggles between Usage / Terminal / Logs,
+terminal set as the default main view. The "mission control" feel: fleet
+health is never out of sight, and the terminal is one click from anywhere.
+**Tradeoff:** narrowest main content column of the three (fleet sidebar is
+permanent chrome), so the usage chart and terminal both render in a
+comparatively tighter width — mitigated at 375px by flattening the sidebar to
+a horizontal scroll strip above the main pane.
+
+## Token deltas
+None. All three variants draw exclusively from the existing smithy
+vocabulary (`iron.*`, `ink.*`, `heat.*`, `motion.calm`, Bahnschrift/Consolas)
+plus the semantic `success`/`error`/`claude` tokens already declared in
+`plugin/themes/forge.json`. One reuse decision worth flagging as a
+precedent, not a delta: fleet online/offline/mis-target status is mapped onto
+`success` (online), `heat.cool` (offline — "cold iron", no fire) and
+`heat.alarm`/`error` (mis-target — a real misconfiguration, styled like the
+console's `lockdown` severity) rather than inventing a new status scale —
+this is a second consumer of `heat.cool`/`heat.alarm` beyond the console's
+situation metaphor, so if the two surfaces ever want independent scales this
+mapping should be revisited explicitly.
+
+## States matrix coverage (all three)
+- **Fleet card:** default (online/offline), hover/focus (real CSS on control
+  buttons), active (`:active` press), disabled (start-when-running,
+  stop-when-stopped), loading (a card mid-restart, spinner), error
+  (mis-target card with an inline `role="alert"` banner), empty (a labeled
+  reference card/strip).
+- **Control button:** default/hover/focus/active are live CSS — try tabbing
+  and clicking; disabled and loading are rendered in place; every mutating
+  button carries a lock glyph + title noting it needs the session token.
+- **Usage panel:** default (chart + breakdown with real numbers), loading/
+  empty/error documented inline (a labeled banner in A/B/C rather than
+  faked skeleton states, since a static mock can't show a real transient).
+
+## Responsive + a11y notes (all three)
+Rendered via CSS at 375 / 768 / 1280 (see each file's `@media` blocks — no
+JS-based layout switching). Focus rings are 2px `heat.ember`, 2px offset, on
+every interactive element (`:focus-visible`). Figures use
+`font-variant-numeric: tabular-nums`. The terminal cursor blink and the
+restart spinner both collapse under `prefers-reduced-motion: reduce`. Status
+is never color-only — every pill/card carries a text label alongside its
+color.

--- a/docs/design/variants-354/variant-a.html
+++ b/docs/design/variants-354/variant-a.html
@@ -1,0 +1,274 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>forge cockpit — variant A (single-pane ops dashboard)</title>
+<style>
+  /* ---- smithy tokens (docs/design/2026-07-17-console.md + plugin/themes/forge.json) ---- */
+  :root {
+    --iron-bg:#161310; --iron-plate:#1f1a15; --iron-seam:#3a322a;
+    --ink-ash:#d8d2c8; --ink-smoke:#a49a87; --ink-steel:#7fa8c9;
+    --heat-cool:#4d5a52; --heat-warm:#b56a3c; --heat-spark:#ffd166; --heat-ember:#ff7a45; --heat-alarm:#e2483d;
+    --claude:#f0813f; --success:#46a758; --error:#e5484d;
+    --motion-calm:250ms;
+    --font-display:Bahnschrift,'DIN Alternate','Arial Narrow',sans-serif;
+    --font-mono:Consolas,'Cascadia Mono',ui-monospace,monospace;
+  }
+  * { box-sizing:border-box; }
+  html,body { margin:0; }
+  body {
+    background:var(--iron-bg); color:var(--ink-ash); font:14px/1.55 var(--font-mono);
+    padding:20px 16px 0;
+  }
+  h1,h2,h3 { font-family:var(--font-display); font-weight:600; margin:0; text-transform:uppercase; letter-spacing:.08em; }
+  a { color:var(--ink-steel); }
+  :focus-visible { outline:2px solid var(--heat-ember); outline-offset:2px; }
+  .tabular { font-variant-numeric:tabular-nums; }
+
+  /* ---- header ---- */
+  .topbar { display:flex; flex-wrap:wrap; gap:12px; align-items:center; justify-content:space-between; border-bottom:1px solid var(--iron-seam); padding-bottom:14px; margin-bottom:20px; }
+  .wordmark { font-size:22px; letter-spacing:.14em; }
+  .wordmark em { font-style:normal; color:var(--claude); }
+  .topbar-right { display:flex; align-items:center; gap:14px; flex-wrap:wrap; }
+  .session-pill { display:inline-flex; align-items:center; gap:6px; font-size:12px; color:var(--ink-smoke); border:1px solid var(--iron-seam); border-radius:999px; padding:5px 12px; min-height:24px; }
+  .session-pill .dot { width:8px; height:8px; border-radius:50%; background:var(--success); box-shadow:0 0 6px rgba(70,167,88,.5); }
+  .stamp { font-size:12px; color:var(--ink-smoke); }
+
+  main { max-width:1280px; margin:0 auto; }
+  section { margin-bottom:28px; }
+  section > h2 { font-size:14px; color:var(--ink-smoke); margin-bottom:12px; display:flex; align-items:center; gap:10px; }
+  section > h2 .rule { flex:1; height:1px; background:var(--iron-seam); }
+
+  /* ---- fleet cards ---- */
+  .fleet-grid { display:grid; grid-template-columns:repeat(4,1fr); gap:14px; }
+  .card { position:relative; background:var(--iron-plate); border:1px solid var(--iron-seam); border-left:4px solid var(--edge,var(--heat-cool)); border-radius:3px; padding:14px 16px; overflow:hidden; }
+  .card::before { content:''; position:absolute; inset:0; pointer-events:none; background:radial-gradient(120% 90% at 0% 100%, var(--glow,transparent), transparent 60%); }
+  .card.online  { --edge:var(--success); --glow:rgba(70,167,88,.10); }
+  .card.offline { --edge:var(--heat-cool); }
+  .card.mistarget { --edge:var(--heat-alarm); --glow:rgba(226,72,61,.14); }
+  .card-head { display:flex; justify-content:space-between; align-items:flex-start; gap:8px; }
+  .repo-name { font-family:var(--font-display); font-size:15px; letter-spacing:.04em; }
+  .platform-tag { font-size:11px; color:var(--ink-smoke); }
+  .status-pill { font-size:11px; letter-spacing:.06em; text-transform:uppercase; padding:2px 8px; border-radius:999px; white-space:nowrap; }
+  .status-pill.online { color:var(--success); border:1px solid rgba(70,167,88,.4); }
+  .status-pill.offline { color:var(--ink-smoke); border:1px solid var(--iron-seam); }
+  .status-pill.mistarget { color:var(--heat-alarm); border:1px solid rgba(226,72,61,.5); }
+  .card-meta { margin-top:8px; font-size:12px; color:var(--ink-smoke); }
+  .card-meta b { color:var(--ink-ash); font-weight:normal; }
+  .card-error { margin-top:8px; font-size:12px; color:var(--error); border:1px dashed rgba(226,72,61,.5); padding:6px 8px; border-radius:2px; }
+  .card-actions { margin-top:12px; display:flex; gap:6px; flex-wrap:wrap; }
+  button.ctl {
+    font:inherit; font-size:12px; color:var(--ink-ash); background:transparent; border:1px solid var(--iron-seam);
+    padding:6px 10px; min-height:24px; border-radius:2px; cursor:pointer; display:inline-flex; align-items:center; gap:5px;
+  }
+  button.ctl:hover:not(:disabled) { border-color:var(--heat-ember); color:var(--heat-ember); }
+  button.ctl:active:not(:disabled) { background:rgba(255,122,69,.08); }
+  button.ctl:disabled { opacity:.38; cursor:not-allowed; }
+  button.ctl .lock { font-size:10px; opacity:.7; }
+  button.ctl.loading { color:var(--heat-spark); border-color:rgba(255,209,102,.5); }
+  .spin { display:inline-block; width:9px; height:9px; border:2px solid rgba(255,209,102,.35); border-top-color:var(--heat-spark); border-radius:50%; animation:spin 900ms linear infinite; }
+  @media (prefers-reduced-motion:reduce) { .spin { animation:none; border-top-color:rgba(255,209,102,.35); } }
+  @keyframes spin { to { transform:rotate(360deg); } }
+
+  details.states-ref { margin-top:14px; font-size:12px; color:var(--ink-smoke); }
+  details.states-ref summary { cursor:pointer; color:var(--ink-steel); }
+  .ref-row { display:flex; gap:10px; flex-wrap:wrap; margin-top:10px; }
+  .ref-row .card { flex:1 1 220px; padding:10px 12px; }
+
+  /* ---- usage band ---- */
+  .usage-band { display:grid; grid-template-columns:2fr 1fr; gap:16px; }
+  .panel { background:var(--iron-plate); border:1px solid var(--iron-seam); border-radius:3px; padding:16px 18px; }
+  .panel h3 { font-size:12px; color:var(--ink-smoke); margin-bottom:12px; letter-spacing:.1em; }
+  .stat-row { display:flex; gap:24px; margin-bottom:14px; flex-wrap:wrap; }
+  .stat { }
+  .stat .num { font-size:24px; color:var(--ink-ash); }
+  .stat .num.accent { color:var(--claude); }
+  .stat .lbl { font-size:11px; color:var(--ink-smoke); text-transform:uppercase; letter-spacing:.08em; }
+  svg.chart { width:100%; height:150px; display:block; overflow:visible; }
+  .chart-grid line { stroke:var(--iron-seam); stroke-width:1; }
+  .chart-area { fill:url(#tokenGrad); }
+  .chart-line { fill:none; stroke:var(--claude); stroke-width:2; }
+  .chart-end { fill:var(--claude); }
+  .chart-end-glow { fill:var(--claude); opacity:.18; }
+  .chart-end-label { fill:var(--ink-ash); font:600 11px var(--font-mono); }
+  .breakdown-row { display:flex; align-items:center; gap:8px; margin-bottom:10px; font-size:12px; }
+  .breakdown-row .model { width:88px; color:var(--ink-smoke); flex-shrink:0; }
+  .breakdown-bar { flex:1; height:8px; background:var(--iron-seam); border-radius:2px; overflow:hidden; }
+  .breakdown-bar i { display:block; height:100%; background:var(--claude); }
+  .breakdown-row .figs { width:150px; text-align:right; color:var(--ink-ash); flex-shrink:0; }
+
+  /* ---- terminal dock ---- */
+  .dock { background:#0d0b09; border:1px solid var(--iron-seam); border-radius:3px 3px 0 0; margin:0 -16px; }
+  .dock-tabs { display:flex; gap:2px; border-bottom:1px solid var(--iron-seam); padding:0 14px; }
+  .dock-tab { font:inherit; font-size:12px; color:var(--ink-smoke); background:transparent; border:none; border-bottom:2px solid transparent; padding:10px 12px; min-height:24px; cursor:pointer; }
+  .dock-tab[aria-selected="true"] { color:var(--ink-ash); border-bottom-color:var(--claude); }
+  .dock-tab:hover { color:var(--ink-ash); }
+  .dock-body { padding:12px 16px; height:200px; overflow-y:auto; }
+  .term-line { white-space:pre-wrap; font-size:13px; }
+  .term-prompt { color:var(--heat-spark); }
+  .term-path { color:var(--ink-steel); }
+  .term-out { color:var(--ink-ash); }
+  .cursor { display:inline-block; width:7px; height:14px; background:var(--ink-ash); vertical-align:text-bottom; animation:blink 1s step-start infinite; }
+  @media (prefers-reduced-motion:reduce) { .cursor { animation:none; opacity:.7; } }
+  @keyframes blink { 50% { opacity:0; } }
+  .log-line { display:flex; gap:10px; font-size:12px; padding:2px 0; border-bottom:1px solid rgba(58,50,42,.4); }
+  .log-line .lvl { width:52px; flex-shrink:0; text-transform:uppercase; font-size:10px; letter-spacing:.05em; }
+  .log-line.info .lvl { color:var(--ink-steel); }
+  .log-line.warn .lvl { color:var(--heat-spark); }
+  .log-line.error .lvl { color:var(--error); }
+  .log-line .ts { color:var(--ink-smoke); flex-shrink:0; }
+  footer.note { text-align:center; color:var(--ink-smoke); font-size:11px; padding:14px 0 22px; }
+
+  /* ---- responsive: 1280 default above, tablet/mobile below ---- */
+  @media (max-width:1024px) {
+    .fleet-grid { grid-template-columns:repeat(2,1fr); }
+    .usage-band { grid-template-columns:1fr; }
+  }
+  @media (max-width:480px) {
+    .fleet-grid { grid-template-columns:1fr; }
+    .card-actions button.ctl { flex:1; justify-content:center; }
+    .stat-row { gap:16px; }
+    .dock-body { height:160px; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<div class="topbar">
+  <h1 class="wordmark">for<em>g</em>e cockpit</h1>
+  <div class="topbar-right">
+    <span class="session-pill" title="mutating actions carry this session's capability token"><span class="dot"></span>session 3f2a&hellip;9c — connected</span>
+    <span class="stamp tabular" role="status" aria-live="polite">updated 12:41:07</span>
+  </div>
+</div>
+
+<section aria-labelledby="fleet-h">
+  <h2 id="fleet-h">Fleet<span class="rule"></span></h2>
+  <div class="fleet-grid" role="list">
+
+    <div class="card online" role="listitem">
+      <div class="card-head">
+        <div><div class="repo-name">dngioidev/forge</div><div class="platform-tag">&#8862; windows-native &middot; nssm</div></div>
+        <span class="status-pill online">online</span>
+      </div>
+      <div class="card-meta">forge-runner-dngioidev-forge &middot; up <b>4d 6h</b> &middot; last job <b>12m ago</b></div>
+      <div class="card-actions">
+        <button class="ctl" disabled title="already running">start</button>
+        <button class="ctl"><span class="lock" title="requires session token">&#128274;</span> stop</button>
+        <button class="ctl"><span class="lock">&#128274;</span> restart</button>
+      </div>
+    </div>
+
+    <div class="card online" role="listitem">
+      <div class="card-head">
+        <div><div class="repo-name">dngioidev/forge</div><div class="platform-tag">&#128039; wsl2-linux &middot; systemd</div></div>
+        <span class="status-pill online">online</span>
+      </div>
+      <div class="card-meta">forge-runner-dngioidev-forge &middot; up <b>2d 19h</b> &middot; idle</div>
+      <div class="card-actions">
+        <button class="ctl" disabled title="already running">start</button>
+        <button class="ctl loading"><span class="spin" aria-hidden="true"></span> restarting&hellip;</button>
+        <button class="ctl" disabled>restart</button>
+      </div>
+    </div>
+
+    <div class="card offline" role="listitem">
+      <div class="card-head">
+        <div><div class="repo-name">dngioidev/iomanage</div><div class="platform-tag">&#8862; windows-native &middot; nssm</div></div>
+        <span class="status-pill offline">offline</span>
+      </div>
+      <div class="card-meta">forge-runner-dngioidev-iomanage &middot; stopped <b>3h ago</b> &middot; manual</div>
+      <div class="card-actions">
+        <button class="ctl"><span class="lock" title="requires session token">&#128274;</span> start</button>
+        <button class="ctl" disabled title="already stopped">stop</button>
+        <button class="ctl" disabled title="already stopped">restart</button>
+      </div>
+    </div>
+
+    <div class="card mistarget" role="listitem">
+      <div class="card-head">
+        <div><div class="repo-name">dngioidev/iomanage</div><div class="platform-tag">&#128039; wsl2-linux &middot; systemd</div></div>
+        <span class="status-pill mistarget">mis-target</span>
+      </div>
+      <div class="card-meta">forge-runner-dngioidev-iomanage &middot; systemd unit active</div>
+      <div class="card-error" role="alert">GitHub reports this runner registered under <b class="tabular">dngioidev/forge</b>, not <b>iomanage</b> &mdash; check the service name / re-provision.</div>
+      <div class="card-actions">
+        <button class="ctl"><span class="lock">&#128274;</span> stop</button>
+        <button class="ctl"><span class="lock">&#128274;</span> re-provision</button>
+      </div>
+    </div>
+
+  </div>
+
+  <details class="states-ref">
+    <summary>states reference &mdash; empty &amp; focus (fleet + controls)</summary>
+    <div class="ref-row">
+      <div class="card offline" style="text-align:center; color:var(--ink-smoke); --edge:var(--iron-seam);">no runners registered for this repo &mdash; run <span style="color:var(--ink-steel)">forge cockpit provision</span></div>
+      <button class="ctl" style="outline:2px solid var(--heat-ember); outline-offset:2px;">restart &mdash; :focus-visible</button>
+    </div>
+  </details>
+</section>
+
+<section aria-labelledby="usage-h">
+  <h2 id="usage-h">Usage &amp; cost<span class="rule"></span></h2>
+  <div class="usage-band">
+    <div class="panel">
+      <h3>tokens &middot; last 14 days</h3>
+      <div class="stat-row">
+        <div class="stat"><div class="num accent tabular">3.24M</div><div class="lbl">tokens today</div></div>
+        <div class="stat"><div class="num tabular">$14.82</div><div class="lbl">cost today</div></div>
+        <div class="stat"><div class="num tabular">$412.65</div><div class="lbl">cost, 30d</div></div>
+      </div>
+      <svg class="chart" viewBox="0 0 560 150" preserveAspectRatio="none" role="img" aria-label="Daily token usage, last 14 days, rising to 3.24 million tokens today">
+        <defs>
+          <linearGradient id="tokenGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#f0813f" stop-opacity=".28"/>
+            <stop offset="100%" stop-color="#f0813f" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+        <g class="chart-grid">
+          <line x1="0" y1="20" x2="560" y2="20"/><line x1="0" y1="60" x2="560" y2="60"/>
+          <line x1="0" y1="100" x2="560" y2="100"/><line x1="0" y1="140" x2="560" y2="140"/>
+        </g>
+        <path class="chart-area" d="M0,90 L40,78 80,98 120,60 160,42 200,102 240,116 280,50 320,32 360,42 400,20 440,66 480,42 520,10 520,150 0,150 Z"/>
+        <path class="chart-line" d="M0,90 L40,78 80,98 120,60 160,42 200,102 240,116 280,50 320,32 360,42 400,20 440,66 480,42 520,10"/>
+        <circle class="chart-end-glow" cx="520" cy="10" r="9"/>
+        <circle class="chart-end" cx="520" cy="10" r="3.5"/>
+        <text class="chart-end-label tabular" x="486" y="2">3.24M</text>
+      </svg>
+    </div>
+    <div class="panel">
+      <h3>by model &middot; 30 days</h3>
+      <div class="breakdown-row"><span class="model">Sonnet 5</span><div class="breakdown-bar"><i style="width:75%"></i></div><span class="figs tabular">51.2M &middot; $301.40</span></div>
+      <div class="breakdown-row"><span class="model">Opus 4.6</span><div class="breakdown-bar"><i style="width:18%"></i></div><span class="figs tabular">12.1M &middot; $98.75</span></div>
+      <div class="breakdown-row"><span class="model">Haiku 4.5</span><div class="breakdown-bar"><i style="width:7%"></i></div><span class="figs tabular">5.1M &middot; $12.50</span></div>
+      <details class="states-ref"><summary>states reference &mdash; loading / empty / error</summary>
+        <p style="margin-top:8px; color:var(--ink-smoke);">loading: bars render as pulseless skeleton bars (no motion by default) &middot; empty: &ldquo;no usage recorded yet&rdquo; &middot; error: &ldquo;transcripts unreadable &mdash; check ~/.claude/projects permissions&rdquo; in <span style="color:var(--error)">error</span> ink.</p>
+      </details>
+    </div>
+  </div>
+</section>
+
+<section aria-labelledby="dock-h">
+  <h2 id="dock-h">Terminal &amp; logs<span class="rule"></span></h2>
+  <div class="dock">
+    <div class="dock-tabs" role="tablist">
+      <button class="dock-tab" role="tab" aria-selected="true">Terminal</button>
+      <button class="dock-tab" role="tab" aria-selected="false">Logs</button>
+    </div>
+    <div class="dock-body" role="tabpanel">
+      <div class="term-line"><span class="term-prompt">dngioi@forge</span> <span class="term-path">~/mywp/forge</span>$ gh run watch 18234561</div>
+      <div class="term-line term-out">&#10003; build &middot; 4m12s &middot; forge-runner-dngioidev-forge</div>
+      <div class="term-line term-out">&#10003; test (windows-native) &middot; 2m48s</div>
+      <div class="term-line term-out">&#10003; test (wsl2-linux) &middot; 3m01s</div>
+      <div class="term-line"><span class="term-prompt">dngioi@forge</span> <span class="term-path">~/mywp/forge</span>$ <span class="cursor"></span></div>
+    </div>
+  </div>
+</section>
+
+<footer class="note">terminal rendered here as a static pane for the mockup &mdash; production streams raw bytes from <code>/api/terminal</code> into <strong>xterm.js</strong> (#354/#353).</footer>
+</main>
+</body>
+</html>

--- a/docs/design/variants-354/variant-b.html
+++ b/docs/design/variants-354/variant-b.html
@@ -1,0 +1,275 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>forge cockpit — variant B (tabbed workspace)</title>
+<style>
+  :root {
+    --iron-bg:#161310; --iron-plate:#1f1a15; --iron-seam:#3a322a;
+    --ink-ash:#d8d2c8; --ink-smoke:#a49a87; --ink-steel:#7fa8c9;
+    --heat-cool:#4d5a52; --heat-warm:#b56a3c; --heat-spark:#ffd166; --heat-ember:#ff7a45; --heat-alarm:#e2483d;
+    --claude:#f0813f; --success:#46a758; --error:#e5484d;
+    --motion-calm:250ms;
+    --font-display:Bahnschrift,'DIN Alternate','Arial Narrow',sans-serif;
+    --font-mono:Consolas,'Cascadia Mono',ui-monospace,monospace;
+  }
+  * { box-sizing:border-box; }
+  html,body { margin:0; height:100%; }
+  body { background:var(--iron-bg); color:var(--ink-ash); font:14px/1.55 var(--font-mono); display:flex; min-height:100vh; }
+  h1,h2,h3 { font-family:var(--font-display); font-weight:600; margin:0; text-transform:uppercase; letter-spacing:.08em; }
+  a { color:var(--ink-steel); }
+  :focus-visible { outline:2px solid var(--heat-ember); outline-offset:2px; }
+  .tabular { font-variant-numeric:tabular-nums; }
+
+  /* ---- rail ---- */
+  .rail { width:220px; flex-shrink:0; background:var(--iron-plate); border-right:1px solid var(--iron-seam); display:flex; flex-direction:column; }
+  .rail .wordmark { font-size:16px; letter-spacing:.14em; padding:18px 16px; border-bottom:1px solid var(--iron-seam); }
+  .rail .wordmark em { font-style:normal; color:var(--claude); }
+  .rail nav { display:flex; flex-direction:column; padding:10px; gap:2px; flex:1; }
+  .rail-btn { display:flex; align-items:center; gap:10px; font:inherit; font-size:13px; color:var(--ink-smoke); background:transparent; border:none; border-left:3px solid transparent; padding:11px 12px; min-height:24px; text-align:left; cursor:pointer; border-radius:2px; }
+  .rail-btn .ic { width:16px; text-align:center; }
+  .rail-btn:hover { color:var(--ink-ash); background:rgba(255,255,255,.02); }
+  .rail-btn[aria-selected="true"] { color:var(--ink-ash); border-left-color:var(--claude); background:rgba(240,129,63,.06); }
+  .rail-foot { padding:14px 16px; border-top:1px solid var(--iron-seam); font-size:11px; color:var(--ink-smoke); }
+  .session-pill { display:inline-flex; align-items:center; gap:6px; }
+  .session-pill .dot { width:7px; height:7px; border-radius:50%; background:var(--success); box-shadow:0 0 6px rgba(70,167,88,.5); }
+
+  /* ---- main ---- */
+  .view-wrap { flex:1; min-width:0; display:flex; flex-direction:column; }
+  .view-head { display:flex; justify-content:space-between; align-items:baseline; padding:18px 24px; border-bottom:1px solid var(--iron-seam); }
+  .view-head .stamp { font-size:12px; color:var(--ink-smoke); }
+  .view { padding:22px 24px; overflow-y:auto; flex:1; }
+  .view[hidden] { display:none; }
+
+  /* ---- fleet ---- */
+  .fleet-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:14px; }
+  .card { position:relative; background:var(--iron-plate); border:1px solid var(--iron-seam); border-left:4px solid var(--edge,var(--heat-cool)); border-radius:3px; padding:14px 16px; overflow:hidden; }
+  .card::before { content:''; position:absolute; inset:0; pointer-events:none; background:radial-gradient(120% 90% at 0% 100%, var(--glow,transparent), transparent 60%); }
+  .card.online  { --edge:var(--success); --glow:rgba(70,167,88,.10); }
+  .card.offline { --edge:var(--heat-cool); }
+  .card.mistarget { --edge:var(--heat-alarm); --glow:rgba(226,72,61,.14); }
+  .card-head { display:flex; justify-content:space-between; align-items:flex-start; gap:8px; }
+  .repo-name { font-family:var(--font-display); font-size:15px; letter-spacing:.04em; }
+  .platform-tag { font-size:11px; color:var(--ink-smoke); }
+  .status-pill { font-size:11px; letter-spacing:.06em; text-transform:uppercase; padding:2px 8px; border-radius:999px; white-space:nowrap; }
+  .status-pill.online { color:var(--success); border:1px solid rgba(70,167,88,.4); }
+  .status-pill.offline { color:var(--ink-smoke); border:1px solid var(--iron-seam); }
+  .status-pill.mistarget { color:var(--heat-alarm); border:1px solid rgba(226,72,61,.5); }
+  .card-meta { margin-top:8px; font-size:12px; color:var(--ink-smoke); }
+  .card-meta b { color:var(--ink-ash); font-weight:normal; }
+  .card-error { margin-top:8px; font-size:12px; color:var(--error); border:1px dashed rgba(226,72,61,.5); padding:6px 8px; border-radius:2px; }
+  .card-actions { margin-top:12px; display:flex; gap:6px; flex-wrap:wrap; }
+  button.ctl { font:inherit; font-size:12px; color:var(--ink-ash); background:transparent; border:1px solid var(--iron-seam); padding:6px 10px; min-height:24px; border-radius:2px; cursor:pointer; display:inline-flex; align-items:center; gap:5px; }
+  button.ctl:hover:not(:disabled) { border-color:var(--heat-ember); color:var(--heat-ember); }
+  button.ctl:active:not(:disabled) { background:rgba(255,122,69,.08); }
+  button.ctl:disabled { opacity:.38; cursor:not-allowed; }
+  button.ctl.loading { color:var(--heat-spark); border-color:rgba(255,209,102,.5); }
+  .spin { display:inline-block; width:9px; height:9px; border:2px solid rgba(255,209,102,.35); border-top-color:var(--heat-spark); border-radius:50%; animation:spin 900ms linear infinite; }
+  @media (prefers-reduced-motion:reduce) { .spin { animation:none; border-top-color:rgba(255,209,102,.35); } }
+  @keyframes spin { to { transform:rotate(360deg); } }
+  .empty-card { text-align:center; color:var(--ink-smoke); padding:30px 16px; border:1px dashed var(--iron-seam); border-radius:3px; }
+
+  /* ---- usage ---- */
+  .panel { background:var(--iron-plate); border:1px solid var(--iron-seam); border-radius:3px; padding:16px 18px; margin-bottom:16px; }
+  .panel h3 { font-size:12px; color:var(--ink-smoke); margin-bottom:12px; letter-spacing:.1em; }
+  .stat-row { display:flex; gap:24px; margin-bottom:14px; flex-wrap:wrap; }
+  .stat .num { font-size:24px; color:var(--ink-ash); }
+  .stat .num.accent { color:var(--claude); }
+  .stat .lbl { font-size:11px; color:var(--ink-smoke); text-transform:uppercase; letter-spacing:.08em; }
+  svg.chart { width:100%; height:170px; display:block; overflow:visible; }
+  .chart-grid line { stroke:var(--iron-seam); stroke-width:1; }
+  .chart-area { fill:url(#tokenGrad); }
+  .chart-line { fill:none; stroke:var(--claude); stroke-width:2; }
+  .chart-end { fill:var(--claude); }
+  .chart-end-glow { fill:var(--claude); opacity:.18; }
+  .chart-end-label { fill:var(--ink-ash); font:600 11px var(--font-mono); }
+  .breakdown-row { display:flex; align-items:center; gap:8px; margin-bottom:10px; font-size:12px; }
+  .breakdown-row .model { width:88px; color:var(--ink-smoke); flex-shrink:0; }
+  .breakdown-bar { flex:1; height:8px; background:var(--iron-seam); border-radius:2px; overflow:hidden; }
+  .breakdown-bar i { display:block; height:100%; background:var(--claude); }
+  .breakdown-row .figs { width:150px; text-align:right; color:var(--ink-ash); flex-shrink:0; }
+  .err-banner { color:var(--error); border:1px dashed rgba(226,72,61,.5); padding:8px 10px; border-radius:2px; font-size:12px; margin-top:10px; }
+
+  /* ---- terminal / logs ---- */
+  .term-pane { background:#0d0b09; border:1px solid var(--iron-seam); border-radius:3px; padding:14px 16px; height:calc(100vh - 220px); min-height:260px; overflow-y:auto; }
+  .term-line { white-space:pre-wrap; font-size:13px; }
+  .term-prompt { color:var(--heat-spark); }
+  .term-path { color:var(--ink-steel); }
+  .term-out { color:var(--ink-ash); }
+  .cursor { display:inline-block; width:7px; height:14px; background:var(--ink-ash); vertical-align:text-bottom; animation:blink 1s step-start infinite; }
+  @media (prefers-reduced-motion:reduce) { .cursor { animation:none; opacity:.7; } }
+  @keyframes blink { 50% { opacity:0; } }
+  .log-line { display:flex; gap:10px; font-size:12px; padding:3px 0; border-bottom:1px solid rgba(58,50,42,.4); }
+  .log-line .lvl { width:52px; flex-shrink:0; text-transform:uppercase; font-size:10px; letter-spacing:.05em; }
+  .log-line.info .lvl { color:var(--ink-steel); }
+  .log-line.warn .lvl { color:var(--heat-spark); }
+  .log-line.error .lvl { color:var(--error); }
+  .log-line .ts { color:var(--ink-smoke); flex-shrink:0; }
+
+  /* ---- responsive ---- */
+  @media (max-width:1024px) {
+    .fleet-grid { grid-template-columns:1fr; }
+  }
+  @media (max-width:768px) {
+    .rail { width:170px; }
+  }
+  @media (max-width:480px) {
+    body { flex-direction:column; }
+    .rail { width:100%; flex-direction:row; align-items:stretch; border-right:none; border-bottom:1px solid var(--iron-seam); order:2; position:sticky; bottom:0; }
+    .rail .wordmark, .rail-foot { display:none; }
+    .rail nav { flex-direction:row; flex:1; padding:6px; }
+    .rail-btn { flex:1; flex-direction:column; gap:2px; border-left:none; border-top:3px solid transparent; font-size:10px; text-align:center; padding:8px 4px; }
+    .rail-btn[aria-selected="true"] { border-top-color:var(--claude); border-left-color:transparent; }
+    .view-wrap { order:1; }
+    .term-pane { height:44vh; }
+  }
+</style>
+</head>
+<body>
+
+<aside class="rail">
+  <div class="wordmark">for<em>g</em>e</div>
+  <nav role="tablist" aria-label="Cockpit sections">
+    <button class="rail-btn" role="tab" aria-selected="true" aria-controls="v-fleet" data-tab="fleet"><span class="ic">&#9880;</span> Fleet</button>
+    <button class="rail-btn" role="tab" aria-selected="false" aria-controls="v-usage" data-tab="usage"><span class="ic">&#9202;</span> Usage</button>
+    <button class="rail-btn" role="tab" aria-selected="false" aria-controls="v-term" data-tab="term"><span class="ic">&gt;_</span> Terminal</button>
+    <button class="rail-btn" role="tab" aria-selected="false" aria-controls="v-logs" data-tab="logs"><span class="ic">&#8801;</span> Logs</button>
+  </nav>
+  <div class="rail-foot"><span class="session-pill"><span class="dot"></span> session 3f2a&hellip;9c</span></div>
+</aside>
+
+<div class="view-wrap">
+  <div class="view-head">
+    <h2 id="view-title">Fleet</h2>
+    <span class="stamp tabular" role="status" aria-live="polite">updated 12:41:07</span>
+  </div>
+
+  <section class="view" id="v-fleet" role="tabpanel">
+    <div class="fleet-grid">
+      <div class="card online">
+        <div class="card-head">
+          <div><div class="repo-name">dngioidev/forge</div><div class="platform-tag">&#8862; windows-native &middot; nssm</div></div>
+          <span class="status-pill online">online</span>
+        </div>
+        <div class="card-meta">forge-runner-dngioidev-forge &middot; up <b>4d 6h</b> &middot; last job <b>12m ago</b></div>
+        <div class="card-actions">
+          <button class="ctl" disabled title="already running">start</button>
+          <button class="ctl"><span title="requires session token">&#128274;</span> stop</button>
+          <button class="ctl"><span>&#128274;</span> restart</button>
+        </div>
+      </div>
+      <div class="card online">
+        <div class="card-head">
+          <div><div class="repo-name">dngioidev/forge</div><div class="platform-tag">&#128039; wsl2-linux &middot; systemd</div></div>
+          <span class="status-pill online">online</span>
+        </div>
+        <div class="card-meta">forge-runner-dngioidev-forge &middot; up <b>2d 19h</b> &middot; idle</div>
+        <div class="card-actions">
+          <button class="ctl" disabled title="already running">start</button>
+          <button class="ctl loading"><span class="spin" aria-hidden="true"></span> restarting&hellip;</button>
+          <button class="ctl" disabled>restart</button>
+        </div>
+      </div>
+      <div class="card offline">
+        <div class="card-head">
+          <div><div class="repo-name">dngioidev/iomanage</div><div class="platform-tag">&#8862; windows-native &middot; nssm</div></div>
+          <span class="status-pill offline">offline</span>
+        </div>
+        <div class="card-meta">forge-runner-dngioidev-iomanage &middot; stopped <b>3h ago</b> &middot; manual</div>
+        <div class="card-actions">
+          <button class="ctl"><span title="requires session token">&#128274;</span> start</button>
+          <button class="ctl" disabled title="already stopped">stop</button>
+          <button class="ctl" disabled title="already stopped">restart</button>
+        </div>
+      </div>
+      <div class="card mistarget">
+        <div class="card-head">
+          <div><div class="repo-name">dngioidev/iomanage</div><div class="platform-tag">&#128039; wsl2-linux &middot; systemd</div></div>
+          <span class="status-pill mistarget">mis-target</span>
+        </div>
+        <div class="card-meta">forge-runner-dngioidev-iomanage &middot; systemd unit active</div>
+        <div class="card-error" role="alert">GitHub reports this runner registered under <b class="tabular">dngioidev/forge</b>, not <b>iomanage</b>.</div>
+        <div class="card-actions">
+          <button class="ctl"><span>&#128274;</span> stop</button>
+          <button class="ctl"><span>&#128274;</span> re-provision</button>
+        </div>
+      </div>
+    </div>
+    <p style="margin-top:16px; font-size:12px; color:var(--ink-smoke);">states reference &mdash; empty: <span class="empty-card" style="display:inline-block; padding:4px 10px; border-radius:2px;">no runners registered for this repo</span></p>
+  </section>
+
+  <section class="view" id="v-usage" role="tabpanel" hidden>
+    <div class="panel">
+      <h3>tokens &middot; last 14 days</h3>
+      <div class="stat-row">
+        <div class="stat"><div class="num accent tabular">3.24M</div><div class="lbl">tokens today</div></div>
+        <div class="stat"><div class="num tabular">$14.82</div><div class="lbl">cost today</div></div>
+        <div class="stat"><div class="num tabular">$412.65</div><div class="lbl">cost, 30d</div></div>
+      </div>
+      <svg class="chart" viewBox="0 0 700 170" preserveAspectRatio="none" role="img" aria-label="Daily token usage, last 14 days, rising to 3.24 million tokens today">
+        <defs>
+          <linearGradient id="tokenGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#f0813f" stop-opacity=".28"/>
+            <stop offset="100%" stop-color="#f0813f" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+        <g class="chart-grid">
+          <line x1="0" y1="24" x2="700" y2="24"/><line x1="0" y1="70" x2="700" y2="70"/>
+          <line x1="0" y1="116" x2="700" y2="116"/><line x1="0" y1="162" x2="700" y2="162"/>
+        </g>
+        <path class="chart-area" d="M0,104 L50,90 100,112 150,68 200,48 250,116 300,132 350,58 400,36 450,48 500,22 550,76 600,48 650,10 650,170 0,170 Z"/>
+        <path class="chart-line" d="M0,104 L50,90 100,112 150,68 200,48 250,116 300,132 350,58 400,36 450,48 500,22 550,76 600,48 650,10"/>
+        <circle class="chart-end-glow" cx="650" cy="10" r="9"/>
+        <circle class="chart-end" cx="650" cy="10" r="3.5"/>
+        <text class="chart-end-label tabular" x="614" y="2">3.24M</text>
+      </svg>
+    </div>
+    <div class="panel">
+      <h3>by model &middot; 30 days</h3>
+      <div class="breakdown-row"><span class="model">Sonnet 5</span><div class="breakdown-bar"><i style="width:75%"></i></div><span class="figs tabular">51.2M &middot; $301.40</span></div>
+      <div class="breakdown-row"><span class="model">Opus 4.6</span><div class="breakdown-bar"><i style="width:18%"></i></div><span class="figs tabular">12.1M &middot; $98.75</span></div>
+      <div class="breakdown-row"><span class="model">Haiku 4.5</span><div class="breakdown-bar"><i style="width:7%"></i></div><span class="figs tabular">5.1M &middot; $12.50</span></div>
+      <div class="err-banner" role="alert">example error state: transcripts unreadable &mdash; check <code>~/.claude/projects</code> permissions</div>
+    </div>
+  </section>
+
+  <section class="view" id="v-term" role="tabpanel" hidden>
+    <div class="term-pane">
+      <div class="term-line"><span class="term-prompt">dngioi@forge</span> <span class="term-path">~/mywp/forge</span>$ gh run watch 18234561</div>
+      <div class="term-line term-out">&#10003; build &middot; 4m12s &middot; forge-runner-dngioidev-forge</div>
+      <div class="term-line term-out">&#10003; test (windows-native) &middot; 2m48s</div>
+      <div class="term-line term-out">&#10003; test (wsl2-linux) &middot; 3m01s</div>
+      <div class="term-line"><span class="term-prompt">dngioi@forge</span> <span class="term-path">~/mywp/forge</span>$ <span class="cursor"></span></div>
+    </div>
+    <p style="margin-top:10px; font-size:11px; color:var(--ink-smoke);">static mockup pane &mdash; production streams <code>/api/terminal</code> into <strong>xterm.js</strong> (#354/#353).</p>
+  </section>
+
+  <section class="view" id="v-logs" role="tabpanel" hidden>
+    <div class="panel" style="max-height:calc(100vh - 220px); overflow-y:auto;">
+      <div class="log-line info"><span class="ts tabular">12:41:02</span><span class="lvl">info</span><span>fleet scan complete &middot; 4 runners &middot; 1 mis-target</span></div>
+      <div class="log-line warn"><span class="ts tabular">12:38:47</span><span class="lvl">warn</span><span>gh api rate limit at 62% &middot; resets 13:00</span></div>
+      <div class="log-line info"><span class="ts tabular">12:22:10</span><span class="lvl">info</span><span>control: restart forge-runner-dngioidev-forge (wsl2) requested</span></div>
+      <div class="log-line error"><span class="ts tabular">09:58:33</span><span class="lvl">error</span><span>provision: iomanage (wsl2) target mismatch &mdash; see Fleet</span></div>
+      <div class="log-line info"><span class="ts tabular">09:12:00</span><span class="lvl">info</span><span>usage collector: 41 transcripts scanned, 0 skipped</span></div>
+    </div>
+  </section>
+</div>
+
+<script>
+  var tabs = document.querySelectorAll('.rail-btn');
+  var views = { fleet:'v-fleet', usage:'v-usage', term:'v-term', logs:'v-logs' };
+  var titles = { fleet:'Fleet', usage:'Usage', term:'Terminal', logs:'Logs' };
+  tabs.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      tabs.forEach(function (b) { b.setAttribute('aria-selected', 'false'); });
+      btn.setAttribute('aria-selected', 'true');
+      Object.values(views).forEach(function (id) { document.getElementById(id).hidden = true; });
+      var key = btn.getAttribute('data-tab');
+      document.getElementById(views[key]).hidden = false;
+      document.getElementById('view-title').textContent = titles[key];
+    });
+  });
+</script>
+</body>
+</html>

--- a/docs/design/variants-354/variant-c.html
+++ b/docs/design/variants-354/variant-c.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>forge cockpit — variant C (split cockpit)</title>
+<style>
+  :root {
+    --iron-bg:#161310; --iron-plate:#1f1a15; --iron-seam:#3a322a;
+    --ink-ash:#d8d2c8; --ink-smoke:#a49a87; --ink-steel:#7fa8c9;
+    --heat-cool:#4d5a52; --heat-warm:#b56a3c; --heat-spark:#ffd166; --heat-ember:#ff7a45; --heat-alarm:#e2483d;
+    --claude:#f0813f; --success:#46a758; --error:#e5484d;
+    --motion-calm:250ms;
+    --font-display:Bahnschrift,'DIN Alternate','Arial Narrow',sans-serif;
+    --font-mono:Consolas,'Cascadia Mono',ui-monospace,monospace;
+  }
+  * { box-sizing:border-box; }
+  html,body { margin:0; height:100%; }
+  body { background:var(--iron-bg); color:var(--ink-ash); font:14px/1.55 var(--font-mono); display:flex; min-height:100vh; }
+  h1,h2,h3 { font-family:var(--font-display); font-weight:600; margin:0; text-transform:uppercase; letter-spacing:.08em; }
+  a { color:var(--ink-steel); }
+  :focus-visible { outline:2px solid var(--heat-ember); outline-offset:2px; }
+  .tabular { font-variant-numeric:tabular-nums; }
+
+  /* ---- persistent fleet sidebar ---- */
+  .sidebar { width:270px; flex-shrink:0; background:var(--iron-plate); border-right:1px solid var(--iron-seam); display:flex; flex-direction:column; }
+  .sidebar-head { padding:16px 16px 10px; border-bottom:1px solid var(--iron-seam); }
+  .wordmark { font-size:16px; letter-spacing:.14em; }
+  .wordmark em { font-style:normal; color:var(--claude); }
+  .sidebar-head .stamp { font-size:11px; color:var(--ink-smoke); margin-top:6px; display:block; }
+  .fleet-list { flex:1; overflow-y:auto; padding:10px; display:flex; flex-direction:column; gap:8px; }
+  .mini-card { position:relative; background:var(--iron-bg); border:1px solid var(--iron-seam); border-left:3px solid var(--edge,var(--heat-cool)); border-radius:2px; padding:8px 10px; overflow:hidden; }
+  .mini-card.online  { --edge:var(--success); }
+  .mini-card.offline { --edge:var(--heat-cool); }
+  .mini-card.mistarget { --edge:var(--heat-alarm); }
+  .mini-head { display:flex; justify-content:space-between; align-items:baseline; gap:6px; }
+  .mini-name { font-size:12.5px; }
+  .mini-plat { font-size:10px; color:var(--ink-smoke); }
+  .mini-status { font-size:10px; text-transform:uppercase; letter-spacing:.05em; }
+  .mini-status.online { color:var(--success); }
+  .mini-status.offline { color:var(--ink-smoke); }
+  .mini-status.mistarget { color:var(--heat-alarm); }
+  .mini-meta { font-size:11px; color:var(--ink-smoke); margin-top:3px; }
+  .mini-error { font-size:11px; color:var(--error); margin-top:4px; }
+  .mini-actions { display:flex; gap:4px; margin-top:6px; }
+  button.mini-ctl { font:inherit; font-size:11px; color:var(--ink-ash); background:transparent; border:1px solid var(--iron-seam); padding:4px 7px; min-height:24px; border-radius:2px; cursor:pointer; }
+  button.mini-ctl:hover:not(:disabled) { border-color:var(--heat-ember); color:var(--heat-ember); }
+  button.mini-ctl:active:not(:disabled) { background:rgba(255,122,69,.08); }
+  button.mini-ctl:disabled { opacity:.38; cursor:not-allowed; }
+  button.mini-ctl.loading { color:var(--heat-spark); border-color:rgba(255,209,102,.5); }
+  .spin { display:inline-block; width:8px; height:8px; border:2px solid rgba(255,209,102,.35); border-top-color:var(--heat-spark); border-radius:50%; animation:spin 900ms linear infinite; margin-right:3px; }
+  @media (prefers-reduced-motion:reduce) { .spin { animation:none; border-top-color:rgba(255,209,102,.35); } }
+  @keyframes spin { to { transform:rotate(360deg); } }
+  .empty-mini { text-align:center; color:var(--ink-smoke); font-size:11px; padding:14px 8px; border:1px dashed var(--iron-seam); border-radius:2px; }
+  .sidebar-foot { padding:12px 16px; border-top:1px solid var(--iron-seam); }
+  .session-pill { display:inline-flex; align-items:center; gap:6px; font-size:11px; color:var(--ink-smoke); }
+  .session-pill .dot { width:7px; height:7px; border-radius:50%; background:var(--success); box-shadow:0 0 6px rgba(70,167,88,.5); }
+
+  /* ---- main pane ---- */
+  .main { flex:1; min-width:0; display:flex; flex-direction:column; }
+  .mode-bar { display:flex; gap:2px; padding:10px 20px 0; border-bottom:1px solid var(--iron-seam); }
+  .mode-btn { display:flex; align-items:center; gap:6px; font:inherit; font-size:12px; color:var(--ink-smoke); background:transparent; border:none; border-bottom:2px solid transparent; padding:10px 14px; min-height:24px; cursor:pointer; }
+  .mode-btn:hover { color:var(--ink-ash); }
+  .mode-btn[aria-selected="true"] { color:var(--ink-ash); border-bottom-color:var(--claude); }
+  .mode-btn .kbd { font-size:10px; color:var(--ink-smoke); border:1px solid var(--iron-seam); border-radius:2px; padding:0 4px; }
+  .mode-view { padding:20px 24px; flex:1; overflow-y:auto; }
+  .mode-view[hidden] { display:none; }
+
+  .panel { background:var(--iron-plate); border:1px solid var(--iron-seam); border-radius:3px; padding:16px 18px; margin-bottom:16px; }
+  .panel h3 { font-size:12px; color:var(--ink-smoke); margin-bottom:12px; letter-spacing:.1em; }
+  .stat-row { display:flex; gap:24px; margin-bottom:14px; flex-wrap:wrap; }
+  .stat .num { font-size:24px; color:var(--ink-ash); }
+  .stat .num.accent { color:var(--claude); }
+  .stat .lbl { font-size:11px; color:var(--ink-smoke); text-transform:uppercase; letter-spacing:.08em; }
+  svg.chart { width:100%; height:170px; display:block; overflow:visible; }
+  .chart-grid line { stroke:var(--iron-seam); stroke-width:1; }
+  .chart-area { fill:url(#tokenGrad); }
+  .chart-line { fill:none; stroke:var(--claude); stroke-width:2; }
+  .chart-end { fill:var(--claude); }
+  .chart-end-glow { fill:var(--claude); opacity:.18; }
+  .chart-end-label { fill:var(--ink-ash); font:600 11px var(--font-mono); }
+  .breakdown-row { display:flex; align-items:center; gap:8px; margin-bottom:10px; font-size:12px; }
+  .breakdown-row .model { width:88px; color:var(--ink-smoke); flex-shrink:0; }
+  .breakdown-bar { flex:1; height:8px; background:var(--iron-seam); border-radius:2px; overflow:hidden; }
+  .breakdown-bar i { display:block; height:100%; background:var(--claude); }
+  .breakdown-row .figs { width:150px; text-align:right; color:var(--ink-ash); flex-shrink:0; }
+  .err-banner { color:var(--error); border:1px dashed rgba(226,72,61,.5); padding:8px 10px; border-radius:2px; font-size:12px; margin-top:10px; }
+
+  .term-pane { background:#0d0b09; border:1px solid var(--iron-seam); border-radius:3px; padding:14px 16px; height:calc(100vh - 190px); min-height:260px; overflow-y:auto; }
+  .term-line { white-space:pre-wrap; font-size:13px; }
+  .term-prompt { color:var(--heat-spark); }
+  .term-path { color:var(--ink-steel); }
+  .term-out { color:var(--ink-ash); }
+  .cursor { display:inline-block; width:7px; height:14px; background:var(--ink-ash); vertical-align:text-bottom; animation:blink 1s step-start infinite; }
+  @media (prefers-reduced-motion:reduce) { .cursor { animation:none; opacity:.7; } }
+  @keyframes blink { 50% { opacity:0; } }
+  .log-line { display:flex; gap:10px; font-size:12px; padding:3px 0; border-bottom:1px solid rgba(58,50,42,.4); }
+  .log-line .lvl { width:52px; flex-shrink:0; text-transform:uppercase; font-size:10px; letter-spacing:.05em; }
+  .log-line.info .lvl { color:var(--ink-steel); }
+  .log-line.warn .lvl { color:var(--heat-spark); }
+  .log-line.error .lvl { color:var(--error); }
+  .log-line .ts { color:var(--ink-smoke); flex-shrink:0; }
+
+  /* ---- responsive ---- */
+  @media (max-width:1024px) {
+    .sidebar { width:220px; }
+  }
+  @media (max-width:768px) {
+    .sidebar { width:200px; }
+    .mode-btn span.lbl-full { display:none; }
+  }
+  @media (max-width:480px) {
+    body { flex-direction:column; }
+    .sidebar { width:100%; border-right:none; border-bottom:1px solid var(--iron-seam); max-height:none; }
+    .fleet-list { flex-direction:row; overflow-x:auto; overflow-y:visible; }
+    .mini-card { min-width:180px; flex-shrink:0; }
+    .sidebar-foot { display:none; }
+    .term-pane { height:44vh; }
+    .mode-bar { padding:8px 12px 0; }
+    .mode-btn { padding:8px 10px; font-size:11px; }
+  }
+</style>
+</head>
+<body>
+
+<aside class="sidebar" aria-label="Fleet health (always visible)">
+  <div class="sidebar-head">
+    <div class="wordmark">for<em>g</em>e cockpit</div>
+    <span class="stamp tabular" role="status" aria-live="polite">updated 12:41:07</span>
+  </div>
+  <div class="fleet-list" role="list">
+    <div class="mini-card online" role="listitem">
+      <div class="mini-head"><span class="mini-name">dngioidev/forge</span><span class="mini-status online">online</span></div>
+      <div class="mini-plat">&#8862; windows-native &middot; nssm</div>
+      <div class="mini-meta">up <b>4d 6h</b> &middot; job 12m ago</div>
+      <div class="mini-actions">
+        <button class="mini-ctl" disabled title="already running">start</button>
+        <button class="mini-ctl" title="requires session token">&#128274; stop</button>
+      </div>
+    </div>
+    <div class="mini-card online" role="listitem">
+      <div class="mini-head"><span class="mini-name">dngioidev/forge</span><span class="mini-status online">online</span></div>
+      <div class="mini-plat">&#128039; wsl2-linux &middot; systemd</div>
+      <div class="mini-meta">up <b>2d 19h</b> &middot; idle</div>
+      <div class="mini-actions">
+        <button class="mini-ctl loading"><span class="spin" aria-hidden="true"></span>restarting&hellip;</button>
+        <button class="mini-ctl" disabled>restart</button>
+      </div>
+    </div>
+    <div class="mini-card offline" role="listitem">
+      <div class="mini-head"><span class="mini-name">dngioidev/iomanage</span><span class="mini-status offline">offline</span></div>
+      <div class="mini-plat">&#8862; windows-native &middot; nssm</div>
+      <div class="mini-meta">stopped <b>3h ago</b> &middot; manual</div>
+      <div class="mini-actions">
+        <button class="mini-ctl" title="requires session token">&#128274; start</button>
+        <button class="mini-ctl" disabled title="already stopped">stop</button>
+      </div>
+    </div>
+    <div class="mini-card mistarget" role="listitem">
+      <div class="mini-head"><span class="mini-name">dngioidev/iomanage</span><span class="mini-status mistarget">mis-target</span></div>
+      <div class="mini-plat">&#128039; wsl2-linux &middot; systemd</div>
+      <div class="mini-error" role="alert">reports as dngioidev/forge</div>
+      <div class="mini-actions">
+        <button class="mini-ctl">&#128274; stop</button>
+        <button class="mini-ctl">&#128274; re-provision</button>
+      </div>
+    </div>
+    <div class="empty-mini">states reference &mdash; empty:<br>&ldquo;no runners for this repo&rdquo;</div>
+  </div>
+  <div class="sidebar-foot"><span class="session-pill"><span class="dot"></span>session 3f2a&hellip;9c &middot; connected</span></div>
+</aside>
+
+<div class="main">
+  <div class="mode-bar" role="tablist" aria-label="Main view">
+    <button class="mode-btn" role="tab" aria-selected="false" aria-controls="m-usage" data-mode="usage">&#9202; <span class="lbl-full">Usage</span></button>
+    <button class="mode-btn" role="tab" aria-selected="true" aria-controls="m-term" data-mode="term">&gt;_ <span class="lbl-full">Terminal</span> <span class="kbd">1 click</span></button>
+    <button class="mode-btn" role="tab" aria-selected="false" aria-controls="m-logs" data-mode="logs">&#8801; <span class="lbl-full">Logs</span></button>
+  </div>
+
+  <section class="mode-view" id="m-usage" role="tabpanel" hidden>
+    <div class="panel">
+      <h3>tokens &middot; last 14 days</h3>
+      <div class="stat-row">
+        <div class="stat"><div class="num accent tabular">3.24M</div><div class="lbl">tokens today</div></div>
+        <div class="stat"><div class="num tabular">$14.82</div><div class="lbl">cost today</div></div>
+        <div class="stat"><div class="num tabular">$412.65</div><div class="lbl">cost, 30d</div></div>
+      </div>
+      <svg class="chart" viewBox="0 0 700 170" preserveAspectRatio="none" role="img" aria-label="Daily token usage, last 14 days, rising to 3.24 million tokens today">
+        <defs>
+          <linearGradient id="tokenGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#f0813f" stop-opacity=".28"/>
+            <stop offset="100%" stop-color="#f0813f" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+        <g class="chart-grid">
+          <line x1="0" y1="24" x2="700" y2="24"/><line x1="0" y1="70" x2="700" y2="70"/>
+          <line x1="0" y1="116" x2="700" y2="116"/><line x1="0" y1="162" x2="700" y2="162"/>
+        </g>
+        <path class="chart-area" d="M0,104 L50,90 100,112 150,68 200,48 250,116 300,132 350,58 400,36 450,48 500,22 550,76 600,48 650,10 650,170 0,170 Z"/>
+        <path class="chart-line" d="M0,104 L50,90 100,112 150,68 200,48 250,116 300,132 350,58 400,36 450,48 500,22 550,76 600,48 650,10"/>
+        <circle class="chart-end-glow" cx="650" cy="10" r="9"/>
+        <circle class="chart-end" cx="650" cy="10" r="3.5"/>
+        <text class="chart-end-label tabular" x="614" y="2">3.24M</text>
+      </svg>
+    </div>
+    <div class="panel">
+      <h3>by model &middot; 30 days</h3>
+      <div class="breakdown-row"><span class="model">Sonnet 5</span><div class="breakdown-bar"><i style="width:75%"></i></div><span class="figs tabular">51.2M &middot; $301.40</span></div>
+      <div class="breakdown-row"><span class="model">Opus 4.6</span><div class="breakdown-bar"><i style="width:18%"></i></div><span class="figs tabular">12.1M &middot; $98.75</span></div>
+      <div class="breakdown-row"><span class="model">Haiku 4.5</span><div class="breakdown-bar"><i style="width:7%"></i></div><span class="figs tabular">5.1M &middot; $12.50</span></div>
+      <div class="err-banner" role="alert">example error state: transcripts unreadable &mdash; check <code>~/.claude/projects</code> permissions</div>
+    </div>
+  </section>
+
+  <section class="mode-view" id="m-term" role="tabpanel">
+    <div class="term-pane">
+      <div class="term-line"><span class="term-prompt">dngioi@forge</span> <span class="term-path">~/mywp/forge</span>$ gh run watch 18234561</div>
+      <div class="term-line term-out">&#10003; build &middot; 4m12s &middot; forge-runner-dngioidev-forge</div>
+      <div class="term-line term-out">&#10003; test (windows-native) &middot; 2m48s</div>
+      <div class="term-line term-out">&#10003; test (wsl2-linux) &middot; 3m01s</div>
+      <div class="term-line"><span class="term-prompt">dngioi@forge</span> <span class="term-path">~/mywp/forge</span>$ <span class="cursor"></span></div>
+    </div>
+    <p style="margin-top:10px; font-size:11px; color:var(--ink-smoke);">static mockup pane &mdash; production streams <code>/api/terminal</code> into <strong>xterm.js</strong> (#354/#353). Terminal is the default main view here &mdash; one click from anywhere via the mode bar or a mini-card's own actions.</p>
+  </section>
+
+  <section class="mode-view" id="m-logs" role="tabpanel" hidden>
+    <div class="panel" style="max-height:calc(100vh - 190px); overflow-y:auto;">
+      <div class="log-line info"><span class="ts tabular">12:41:02</span><span class="lvl">info</span><span>fleet scan complete &middot; 4 runners &middot; 1 mis-target</span></div>
+      <div class="log-line warn"><span class="ts tabular">12:38:47</span><span class="lvl">warn</span><span>gh api rate limit at 62% &middot; resets 13:00</span></div>
+      <div class="log-line info"><span class="ts tabular">12:22:10</span><span class="lvl">info</span><span>control: restart forge-runner-dngioidev-forge (wsl2) requested</span></div>
+      <div class="log-line error"><span class="ts tabular">09:58:33</span><span class="lvl">error</span><span>provision: iomanage (wsl2) target mismatch &mdash; see sidebar</span></div>
+      <div class="log-line info"><span class="ts tabular">09:12:00</span><span class="lvl">info</span><span>usage collector: 41 transcripts scanned, 0 skipped</span></div>
+    </div>
+  </section>
+</div>
+
+<script>
+  var tabs = document.querySelectorAll('.mode-btn');
+  var views = { usage:'m-usage', term:'m-term', logs:'m-logs' };
+  tabs.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      tabs.forEach(function (b) { b.setAttribute('aria-selected', 'false'); });
+      btn.setAttribute('aria-selected', 'true');
+      Object.values(views).forEach(function (id) { document.getElementById(id).hidden = true; });
+      document.getElementById(views[btn.getAttribute('data-mode')]).hidden = false;
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Graduates **Variant C — split cockpit** (owner pick) into the committed visual spec for the runner-fleet **cockpit browser UI** that renders the #351–#353 FastAPI/websocket cores (fleet · usage/cost · logs · PTY terminal), served by `forge-cockpit` over `127.0.0.1` (ADR-0008, supersedes ADR-0006 Decision 1).

`docs/design/2026-08-03-cockpit-ui.md` — persistent fleet sidebar (mini status cards + inline start/stop/restart) beside a Usage/Terminal/Logs main pane with **Terminal as default**. Fleet is always glance-away; the terminal is one click from anywhere.

## Scope

**Refs #354 — part of #354, does NOT close it.** This delivers the visual **spec** (a design phase). The UI implementation (a later forge:plan → execute) is what closes #354.

## Notes / AC

- Spec produced from `plugin/templates/visual-spec.md`; **every mandatory section filled** — speclint: **pass** (all sections present, no one-off hex values).
- **Zero new tokens** — reuses the smithy `iron.*`/`ink.*`/`heat.*` + `success`/`error`/`claude` vocabulary. Recorded the one deliberate reuse: fleet binary-health (online/offline/mis-target) mapped onto `success`/`heat.cool`/`heat.alarm`+`error` — a second consumer of the heat vocabulary, flagged as a precedent to revisit explicitly if the surfaces ever need independent scales.
- Dark-only (heat metaphor + console precedent); light theme out of scope as a future token-delta finding.
- Route-indexed the spec + the `variants-354/` mockups (kept as design-lane reference) in `docs/README.md`.

## Verification (honest)

- speclint `2026-08-03-cockpit-ui.md`: **pass**
- `docsync.mjs`: **clean (56 docs indexed)**
- `pnpm verify`: **green — 692/692 tests, 58 files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SATRHKa6mDHDuirhP6QuwL