### PR TITLE
fix(cockpit): alias raw-hex UI values to smithy tokens (#368)

### DIFF
--- a/docs/design/2026-08-03-cockpit-ui.md
+++ b/docs/design/2026-08-03-cockpit-ui.md
@@ -102,15 +102,26 @@ differences only — no theme-specific one-off values.
 
 ## Token delta
 - **Tokens used:** the smithy vocabulary only —
-  `iron.bg` · `iron.plate` · `iron.seam` (grounds);
+  `iron.bg` · `iron.plate` · `iron.seam` · `iron.pit` (grounds);
   `ink.ash` · `ink.smoke` · `ink.steel` (text/links);
   `heat.cool` · `heat.warm` · `heat.spark` · `heat.ember` · `heat.alarm`
   (the heat scale); the semantic `success` · `error` · `claude` overrides from
   `plugin/themes/forge.json`; `motion.calm` (250ms); and the display
   (Bahnschrift/DIN) + mono (Consolas/Cascadia) type roles. All defined by the
   console spec (`docs/design/2026-07-17-console.md`) and `plugin/themes/forge.json`.
-- **New tokens proposed:** none. The designer confirmed zero new tokens — the
-  cockpit is built entirely from the existing scales.
+- **New tokens proposed (#368):** one — `iron.pit` (`#0d0b09`), the terminal
+  ground: a near-black well deeper than `iron.bg` (`#161310`) so the live-shell
+  pane reads as a recessed pit set into the plate. Carried from the variant-c
+  mockup as a raw hex, it is now a first-class `iron.*` ground token, defined once
+  in the cockpit `:root` (`--iron-pit`) and consumed by `.term-pane` and the
+  xterm theme (read from the same custom property, since xterm takes concrete
+  colour strings not `var()`). It extends the `iron.*` ground scale rather than
+  restyling; no other surface consumes it yet.
+- **Documented exception — SVG presentation attributes (#368):** the usage-chart
+  gradient stops (`app.mjs`) reference `--claude` via an inline
+  `style="stop-color:var(--claude)"` rather than the `stop-color` presentation
+  attribute, because SVG presentation attributes cannot consume `var()`. This is
+  the sanctioned single-sourcing path for SVG fills, not a one-off value.
 - **Reuse decision (recorded as a deliberate precedent, not a one-off):** fleet
   binary health is mapped onto the heat vocabulary — online→`success`,
   offline→`heat.cool` ("cold iron", no fire), mis-target→`heat.alarm` + `error`

--- a/tools/runner-ui/forge_cockpit/web/app.css
+++ b/tools/runner-ui/forge_cockpit/web/app.css
@@ -4,7 +4,7 @@
    tokens at low alpha, not new colours. */
 :root {
   /* grounds */
-  --iron-bg:#161310; --iron-plate:#1f1a15; --iron-seam:#3a322a;
+  --iron-bg:#161310; --iron-plate:#1f1a15; --iron-seam:#3a322a; --iron-pit:#0d0b09;
   /* text / links */
   --ink-ash:#d8d2c8; --ink-smoke:#a49a87; --ink-steel:#7fa8c9;
   /* heat scale */
@@ -102,7 +102,7 @@ svg.chart { width:100%; height:170px; display:block; overflow:visible; }
 .breakdown-row .figs { width:170px; text-align:right; color:var(--ink-ash); flex-shrink:0; }
 .err-banner { color:var(--error); border:1px dashed rgba(226,72,61,.5); padding:8px 10px; border-radius:2px; font-size:12px; margin-top:10px; }
 
-.term-pane { background:#0d0b09; border:1px solid var(--iron-seam); border-radius:3px; padding:8px 10px; height:calc(100vh - 190px); min-height:260px; overflow:hidden; }
+.term-pane { background:var(--iron-pit); border:1px solid var(--iron-seam); border-radius:3px; padding:8px 10px; height:calc(100vh - 190px); min-height:260px; overflow:hidden; }
 .term-pane .xterm { height:100%; }
 .term-note { margin-top:10px; font-size:11px; color:var(--ink-smoke); }
 .term-note.error { color:var(--error); }

--- a/tools/runner-ui/forge_cockpit/web/app.mjs
+++ b/tools/runner-ui/forge_cockpit/web/app.mjs
@@ -252,8 +252,8 @@ function renderChart(series, empty) {
   svg.setAttribute('aria-label', `Daily token usage, last ${series.length} days, latest ${formatTokens(series[series.length - 1])} tokens (peak ${peak})`);
   svg.innerHTML = `
     <defs><linearGradient id="tokenGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#f0813f" stop-opacity=".28"/>
-      <stop offset="100%" stop-color="#f0813f" stop-opacity="0"/>
+      <stop offset="0%" style="stop-color:var(--claude)" stop-opacity=".28"/>
+      <stop offset="100%" style="stop-color:var(--claude)" stop-opacity="0"/>
     </linearGradient></defs>
     <g class="chart-grid">
       <line x1="0" y1="24" x2="${W}" y2="24"/><line x1="0" y1="70" x2="${W}" y2="70"/>
@@ -318,11 +318,20 @@ function startTerminal() {
     note.classList.add('error');
     return;
   }
+  // xterm's theme takes concrete colour strings, not CSS var() — so single-source
+  // it from the :root smithy tokens (app.css) at construction rather than re-typing
+  // the hex here (#368: no one-off values; iron.pit is the terminal ground).
+  const token = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
   const term = new window.Terminal({
     cursorBlink: !REDUCED_MOTION,
     fontFamily: "Consolas, 'Cascadia Mono', ui-monospace, monospace",
     fontSize: 13,
-    theme: { background: '#0d0b09', foreground: '#d8d2c8', cursor: '#d8d2c8', selectionBackground: '#3a322a' },
+    theme: {
+      background: token('--iron-pit'),
+      foreground: token('--ink-ash'),
+      cursor: token('--ink-ash'),
+      selectionBackground: token('--iron-seam'),
+    },
   });
   const fit = window.FitAddon ? new window.FitAddon.FitAddon() : null;
   if (fit) term.loadAddon(fit);


### PR DESCRIPTION
Closes #368 — parent epic #350. Follow-up hygiene from #354: the two raw hex values carried from the variant-c mockup into the shipped cockpit UI are now single-sourced to smithy tokens.

## Acceptance criteria
- [x] **AC.1** — terminal-ground `#0d0b09` in `tools/runner-ui/forge_cockpit/web` CSS replaced with a smithy token. Added a new ground token `iron.pit` (`--iron-pit:#0d0b09`) to the cockpit `:root`; `.term-pane` now uses `var(--iron-pit)`. Documented in the spec Token delta (a near-black well deeper than `iron.bg`). The xterm theme in `app.mjs` reads the same `--iron-pit` custom property at construction (xterm takes concrete colour strings, not `var()`), so there is one source of truth.
- [x] **AC.2** — chart gradient stops `#f0813f` now use `--claude` via inline `style="stop-color:var(--claude)"` (SVG presentation attributes can't consume `var()`). Recorded as a documented exception in the spec Token delta.
- [x] **AC.3** — no undocumented raw hex remains in the cockpit web CSS/HTML outside the `:root` token definitions (verified: all remaining 6-digit hex in `app.css`/`index.html` sits inside the `:root` block; both target values gone from `app.mjs`). `pnpm verify` + the license gate stay green.

## Verification (this run)
- `pnpm verify` (vitest): **710 passed / 59 files**.
- `speclint docs/design/2026-08-03-cockpit-ui.md`: all mandatory sections present.
- `docsync.mjs`: clean (56 docs indexed).
- `license.mjs`: clean — MIT, 0 documented exceptions.
- `grep 0d0b09|f0813f` in `web/`: only the `:root` token definitions remain.

No visual change — the tokens resolve to the same colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)