### PR TITLE
ci(pages): self-enable Pages in the deploy workflow (#373)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+        with:
+          # Self-enable Pages + set the GitHub-Actions build type if it isn't
+          # already, so the deploy can't 404 on a legacy/branch build type (the
+          # first public deploy failed exactly this way) and forks work first-try.
+          enablement: true
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site


### PR DESCRIPTION
Closes #373. Follow-up hardening to the OSS flip (#209) / landing page (#371).

The first public Pages deploy failed with `configure-pages` "Get Pages site failed — Not Found": Pages was enabled but on the **legacy** (deploy-from-branch) build type, not **workflow**. Fixed live via the API (site is up at https://dngioidev.github.io/forge/); this makes the fix durable in-workflow.

## Change
- `actions/configure-pages` now runs with `enablement: true` — it enables Pages and sets the GitHub-Actions build type if it isn't already, so the deploy can't regress on build type and **forks deploy first-try**. Action SHA pin unchanged; still self-hosted, still path-filtered to `site/`.

## AC
- [x] AC.1 `enablement: true` on configure-pages
- [x] AC.2 actionlint clean, pin unchanged, runner/path-filter unchanged
- [ ] AC.3 confirm a green deploy + HTTP 200 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)