### PR TITLE
fix(agy): emit plugin-root-relative paths so the emitted package is relocatable (#307)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [C8 — Quota panel](plans/2026-07-19-c8-quota-panel.md) — Claude Code quota panel in the console.
 - [Batch close](plans/2026-07-20-batch-close.md) — tasks for #123: comma-separated `--issue` in `board/close.mjs`.
 - [#289 — agy init emit](plans/2026-07-26-289-agy-init-emit.md) — tasks for #289 (ADR-0007 AC3): `forge init --host agy` emits the proven agy plugin package (co-located `plugin.json`, generated `mcp_config.json` + `hooks.json`, deny/capture shims, short-path staging).
+- [#307 — agy emit relocatable](plans/2026-08-04-307-agy-emit-relocatable.md) — tasks for #307 (epic #174): emit plugin-root-relative paths in `mcp_config.json` + `hooks.json` so the package survives `agy plugin install` (copy) and deletion of the `--out` dir.
 
 ## Spikes
 

--- a/docs/guides/cross-gai.md
+++ b/docs/guides/cross-gai.md
@@ -47,6 +47,15 @@ node plugin/scripts/init.mjs --host agy --out C:\agy\forge
   a message pointing at #292 (Codex deferred).
 - `--out <dir>` sets where the package is staged. If omitted, it defaults to
   `.agents/plugins/forge/` under the current directory.
+- **The in-place discovery flow (no `--out`) is the recommended primary path.**
+  With no `--out` the package is emitted into `.agents/plugins/forge/` and
+  discovered where it sits — nothing is copied, so there is no staging-dir to
+  delete and nothing to relocate. This is the flow verified end-to-end against
+  live agy. Use `--out` only when you intend to `agy plugin install` the package;
+  the emitted configs are relocatable (relative paths, see Steps 2-3), but after a
+  copy install you should run `agy plugin validate forge` to confirm they resolve
+  on your agy build (the emitter prints this reminder when `--out` is used). See
+  [#307](https://github.com/dngioidev/forge/issues/307).
 - **Use a short `--out` path.** `agy plugin install` hit Windows `MAX_PATH`
   (260-char) failures when the source sat under a long temp path during the
   spike. The emitter itself is long-path aware (it prefixes `\\?\` on win32), but
@@ -134,6 +143,15 @@ were declared only in `plugin.json`. agy reads a sibling plugin-root
   the same file works in the staging dir, after `agy plugin install`, and under
   `.agents/plugins/forge/`. agy's env-expansion is buggy, which is why a
   `${...}`-style token is avoided in favour of a plain relative path.
+- **Verification note.** agy's hook-command working directory is documented as the
+  plugin root (so the relative `hooks.json` command in Step 3 is well-grounded),
+  but agy's MCP-server subprocess working directory is **not** independently
+  confirmed in the agy docs, and the #174 spike validated `mcp_config.json` only
+  with absolute paths. Relative is the strictly-better emit-time choice (an
+  absolute path cannot survive the `agy plugin install` copy at all), but confirm
+  it on your build with `agy plugin validate forge` after install; the in-place
+  discovery flow avoids the question entirely. Live confirmation lands with the
+  #290 dogfood.
 - `forge-graph` is always registered. `forge-core` (the 9-tool board/gate/
   autopilot server from [#288](https://github.com/dngioidev/forge/issues/288)) is
   registered **only when its server file exists** in the source — the emitter

--- a/docs/guides/cross-gai.md
+++ b/docs/guides/cross-gai.md
@@ -80,13 +80,16 @@ C:\agy\forge\
   bin/                 <- the forge dispatcher
 ```
 
-Three things are agy-specific and **generated** (not copied), with paths
-computed from the resolved `--out` directory — never hardcoded to one install:
+Three things are agy-specific and **generated** (not copied). Their internal
+references are **plugin-root-relative**, so the package is **relocatable** — it
+keeps working after `agy plugin install` copies it to
+`~/.gemini/config/plugins/forge/` and after you delete the original `--out` dir
+([#307](https://github.com/dngioidev/forge/issues/307)):
 
 1. **`plugin.json`** — the co-located marker. The emitter strips the Claude-only
    `$schema` and `mcpServers` keys agy ignores.
-2. **`mcp_config.json`** — the MCP registration (see Step 2).
-3. **`hooks.json`** — the hook registration (see Step 3).
+2. **`mcp_config.json`** — the MCP registration, relative paths (see Step 2).
+3. **`hooks.json`** — the hook registration, relative commands (see Step 3).
 
 Note the copied `hooks/` tree also carries the original Claude-format
 `hooks/hooks.json` (Claude's `"hooks"` wrapper, `"Bash"` matcher). agy ignores it
@@ -112,19 +115,25 @@ were declared only in `plugin.json`. agy reads a sibling plugin-root
   "mcpServers": {
     "forge-graph": {
       "command": "node",
-      "args": ["C:/agy/forge/mcp/graph/server.mjs"]
+      "args": ["mcp/graph/server.mjs"]
     },
     "forge-core": {
       "command": "node",
-      "args": ["C:/agy/forge/mcp/forge/server.mjs"]
+      "args": ["mcp/forge/server.mjs"]
     }
   }
 }
 ```
 
-- Paths are computed from the resolved `--out` dir and written with forward
-  slashes (safe on Windows, and agy's env-expansion is buggy so absolute literal
-  paths are used).
+- Paths are **plugin-root-relative** and written with forward slashes (safe on
+  Windows). They are deliberately **not** absolute: `agy plugin install` copies
+  the package to `~/.gemini/config/plugins/forge/`, so an absolute literal
+  computed at emit time would be stale after the copy — delete the `--out` dir and
+  the servers would break ([#307](https://github.com/dngioidev/forge/issues/307)).
+  A relative path resolves against the plugin root wherever the package lands, so
+  the same file works in the staging dir, after `agy plugin install`, and under
+  `.agents/plugins/forge/`. agy's env-expansion is buggy, which is why a
+  `${...}`-style token is avoided in favour of a plain relative path.
 - `forge-graph` is always registered. `forge-core` (the 9-tool board/gate/
   autopilot server from [#288](https://github.com/dngioidev/forge/issues/288)) is
   registered **only when its server file exists** in the source — the emitter
@@ -162,7 +171,7 @@ The generated file:
       {
         "matcher": "run_command",
         "hooks": [
-          { "type": "command", "command": "node \"C:/agy/forge/hooks/agy-deny.mjs\"", "timeout": 10 }
+          { "type": "command", "command": "node \"hooks/agy-deny.mjs\"", "timeout": 10 }
         ]
       }
     ]
@@ -172,13 +181,20 @@ The generated file:
       {
         "matcher": "run_command",
         "hooks": [
-          { "type": "command", "command": "node \"C:/agy/forge/hooks/agy-capture.mjs\"", "timeout": 10 }
+          { "type": "command", "command": "node \"hooks/agy-capture.mjs\"", "timeout": 10 }
         ]
       }
     ]
   }
 }
 ```
+
+The hook `command` is **plugin-root-relative**: agy runs a hook command with its
+working directory set to the directory containing `hooks.json` (= the plugin
+root), so `hooks/agy-deny.mjs` resolves wherever the package is installed. Like
+`mcp_config.json`, this keeps the safety + capture hooks working after
+`agy plugin install` copies the package and the original `--out` dir is deleted
+([#307](https://github.com/dngioidev/forge/issues/307)).
 
 ### The host-mode I/O shims
 

--- a/docs/plans/2026-08-04-307-agy-emit-relocatable.md
+++ b/docs/plans/2026-08-04-307-agy-emit-relocatable.md
@@ -1,0 +1,68 @@
+# Plan: #307 - agy emitter `--out` couples the install to the staging dir
+
+**Ticket:** #307 (parent epic #174, ADR-0007) - **Kind:** bug
+**Base:** main - **Branch:** feat/307-agy-emit-relocatable
+
+`forge init --host agy --out <dir>` writes **absolute** paths (rooted at `<dir>`)
+into the emitted `mcp_config.json` (server `args`) and `hooks.json` (hook
+`command`). `agy plugin install <dir>` then **copies** the package into
+`~/.gemini/config/plugins/forge/`, but the copied configs still point back at the
+original `<dir>` - delete it and the MCP servers + hooks break. The default
+discovery flow (no `--out` -> emit into `.agents/plugins/forge/`, discovered in
+place) survives only because the absolute paths happen to point at the stable
+discovered location.
+
+The absolute path is fundamentally wrong for the copy flow: the emitter cannot
+know the final install path at emit time, so no absolute literal survives
+`agy plugin install`. The fix is relocatable emission - plugin-root-**relative**
+paths that agy resolves via the plugin root, the exact model the emitter already
+relies on for the `${CLAUDE_PLUGIN_ROOT}` -> root-relative rewrite of skills and
+commands (agy runs a plugin's shell-outs, incl. hook commands, with the working
+directory set to the plugin root; `hooks.json`'s command CWD is the directory
+containing `hooks.json` = the plugin root).
+
+## AC map
+
+- **AC-307.1** a package emitted with `--out` and copied elsewhere keeps working
+  after the `--out` dir is deleted: `mcp_config.json` `args` and `hooks.json`
+  `command` carry plugin-root-relative paths (no absolute staging/install path),
+  and every path resolves against the package root wherever the package lands.
+- **AC-307.2** `docs/guides/cross-gai.md` reflects the relocatable flow (the
+  configs are relocatable; the copied package is self-contained).
+
+## Task 1 (bug): emit plugin-root-relative paths in mcp_config.json + hooks.json (AC-307.1)
+
+`buildMcpConfig` / `buildHooksConfig` drop the `destRoot` join and emit
+plugin-root-relative, forward-slashed paths (`mcp/graph/server.mjs`,
+`node "hooks/agy-deny.mjs"`). The emitter's `emitAgyPlugin` caller stops passing
+`dest` into the builders. No absolute staging/install path is written into either
+generated config.
+
+**Files:** plugin/scripts/agy/emit.mjs
+
+## Task 2 (test): relocatability + updated builder assertions (AC-307.1)
+
+New AC-307.1 tests: emit with `--out`, then simulate `agy plugin install` (copy
+the package to a second dir) AND delete the original `--out` dir; assert both
+configs reference no absolute path and every relative target resolves under the
+new root. Update the existing AC-289.4 computed-path assertions to the new
+relative contract (they encoded the old absolute behavior).
+
+**Files:** tests/agy/emit.test.mjs
+
+## Task 3 (docs): document the relocatable flow (AC-307.2)
+
+Update `docs/guides/cross-gai.md` Step 2 / Step 3 example configs and prose to
+show plugin-root-relative paths and explain the package is relocatable (survives
+`agy plugin install` copy + `--out` deletion).
+
+**Files:** docs/guides/cross-gai.md
+
+## Verification
+
+`pnpm verify` full green. Gates: acgate (AC-307.1-2 covered by passing tests),
+testintent clean, depguard no new deps, plandrift clean, docsync (cross-gai.md
+route-indexed). `agy` is not runnable in CI, so relocatability is asserted
+structurally: copy-then-delete the `--out` dir and resolve every emitted path
+against the new package root. `emit.test.mjs` is subprocess-heavy (known flake
+#339 under load) - re-run in isolation if it times out.

--- a/docs/plans/2026-08-04-307-agy-emit-relocatable.md
+++ b/docs/plans/2026-08-04-307-agy-emit-relocatable.md
@@ -36,9 +36,13 @@ containing `hooks.json` = the plugin root).
 plugin-root-relative, forward-slashed paths (`mcp/graph/server.mjs`,
 `node "hooks/agy-deny.mjs"`). The emitter's `emitAgyPlugin` caller stops passing
 `dest` into the builders. No absolute staging/install path is written into either
-generated config.
+generated config. `emitAgyPlugin` takes a `viaOut` flag (threaded from the CLI and
+from `init.mjs`) so a copy-install staging (`--out`) surfaces the discovery-primary
++ `agy plugin validate` advisory; the hooks CWD model is doc-grounded, the MCP-arg
+CWD is caveated pending live verification.
 
 **Files:** plugin/scripts/agy/emit.mjs
+**Files:** plugin/scripts/init.mjs
 
 ## Task 2 (test): relocatability + updated builder assertions (AC-307.1)
 

--- a/plugin/scripts/agy/emit.mjs
+++ b/plugin/scripts/agy/emit.mjs
@@ -80,24 +80,37 @@ async function isForgeOwned(dest) {
   } catch { return false; }
 }
 
-/** Build the agy MCP registration. forge-core is guarded on server existence (#288 is separate). */
-export function buildMcpConfig(destRoot, { hasForgeCore = false } = {}) {
+/**
+ * Build the agy MCP registration. forge-core is guarded on server existence (#288 is separate).
+ *
+ * #307: paths are plugin-root-RELATIVE, never absolute. `agy plugin install <dir>`
+ * COPIES the package to `~/.gemini/config/plugins/forge/`, so any absolute literal
+ * computed at emit time is stale post-copy (delete the `--out` dir and the servers
+ * break). A relative path is resolved against the plugin root wherever the package
+ * lands — the same relocation model the skill/command `${CLAUDE_PLUGIN_ROOT}` rewrite
+ * relies on — so the package is relocatable and the discovery + install flows agree.
+ */
+export function buildMcpConfig({ hasForgeCore = false } = {}) {
   const mcpServers = {
-    'forge-graph': { command: 'node', args: [toPosix(join(destRoot, 'mcp', 'graph', 'server.mjs'))] },
+    'forge-graph': { command: 'node', args: ['mcp/graph/server.mjs'] },
   };
   if (hasForgeCore) {
-    mcpServers['forge-core'] = { command: 'node', args: [toPosix(join(destRoot, 'mcp', 'forge', 'server.mjs'))] };
+    mcpServers['forge-core'] = { command: 'node', args: ['mcp/forge/server.mjs'] };
   }
   return { mcpServers };
 }
 
 /**
  * Build the agy hooks registration (named-hook schema, matcher `run_command`).
- * Commands quote the computed shim paths and carry a 10s timeout.
+ * Commands quote the plugin-root-relative shim paths and carry a 10s timeout.
+ *
+ * #307: relative, not absolute — agy runs a hook command with its working directory
+ * set to the directory containing `hooks.json` (= the plugin root), so `hooks/agy-*.mjs`
+ * resolves post-copy. Absolute paths would point back at the deleted `--out` dir.
  */
-export function buildHooksConfig(destRoot) {
-  const deny = `node "${toPosix(join(destRoot, 'hooks', 'agy-deny.mjs'))}"`;
-  const capture = `node "${toPosix(join(destRoot, 'hooks', 'agy-capture.mjs'))}"`;
+export function buildHooksConfig() {
+  const deny = `node "hooks/agy-deny.mjs"`;
+  const capture = `node "hooks/agy-capture.mjs"`;
   return {
     'forge-safety': {
       PreToolUse: [{ matcher: 'run_command', hooks: [{ type: 'command', command: deny, timeout: 10 }] }],
@@ -232,12 +245,12 @@ export async function emitAgyPlugin({ srcRoot = pluginRoot(), destRoot, cwd = pr
   // mcp_config.json — forge-core only when its server actually exists (#288).
   let hasForgeCore = false;
   try { await access(L(join(srcRoot, 'mcp', 'forge', 'server.mjs'))); hasForgeCore = true; } catch { /* not built yet */ }
-  await writeFile(L(join(dest, 'mcp_config.json')), JSON.stringify(buildMcpConfig(dest, { hasForgeCore }), null, 2) + '\n', 'utf8');
+  await writeFile(L(join(dest, 'mcp_config.json')), JSON.stringify(buildMcpConfig({ hasForgeCore }), null, 2) + '\n', 'utf8');
   written.push('mcp_config.json');
 
   // hooks.json — agy named-hook schema at the plugin ROOT (agy reads this, not the
   // Claude-format hooks/hooks.json that came along in the hooks/ copy).
-  await writeFile(L(join(dest, 'hooks.json')), JSON.stringify(buildHooksConfig(dest), null, 2) + '\n', 'utf8');
+  await writeFile(L(join(dest, 'hooks.json')), JSON.stringify(buildHooksConfig(), null, 2) + '\n', 'utf8');
   written.push('hooks.json');
 
   log(`agy: emitted forge plugin package at ${dest}`);

--- a/plugin/scripts/agy/emit.mjs
+++ b/plugin/scripts/agy/emit.mjs
@@ -60,8 +60,10 @@ function isAtOrUnder(parent, child) {
  *   - the current working dir or any ancestor of it (`--out .` / `--out ..` would
  *     delete the operator's working tree, incl. .git);
  *   - a dir that contains the forge plugin source;
- *   - a path with shell-unsafe characters (they would also break the hooks.json
- *     command string, which agy's contract requires to be a quoted string).
+ *   - a path with shell-unsafe characters (the dest is still interpolated into the
+ *     `agy plugin install "<dest>"` install hint and the cp/mkdir operations; the
+ *     generated hooks.json command is now a fixed plugin-root-relative literal (#307),
+ *     so it no longer carries the dest and is not an injection sink).
  */
 export function unsafeDestReason(dest, { cwd, srcRoot }) {
   const d = resolve(dest);

--- a/plugin/scripts/agy/emit.mjs
+++ b/plugin/scripts/agy/emit.mjs
@@ -88,9 +88,17 @@ async function isForgeOwned(dest) {
  * #307: paths are plugin-root-RELATIVE, never absolute. `agy plugin install <dir>`
  * COPIES the package to `~/.gemini/config/plugins/forge/`, so any absolute literal
  * computed at emit time is stale post-copy (delete the `--out` dir and the servers
- * break). A relative path is resolved against the plugin root wherever the package
- * lands — the same relocation model the skill/command `${CLAUDE_PLUGIN_ROOT}` rewrite
- * relies on — so the package is relocatable and the discovery + install flows agree.
+ * break) — and never even resolves for the copied install, whose real root the
+ * emitter cannot know. A relative path is the only emit-time form that can survive
+ * the copy: it resolves against the plugin root wherever the package lands.
+ *
+ * Grounding caveat: unlike the hooks CWD (documented — see buildHooksConfig), agy's
+ * MCP-server subprocess CWD is NOT independently confirmed in the agy docs, and the
+ * #174 spike validated `mcp_config.json` only with absolute paths. Relative is the
+ * strictly-better bet (absolute is provably broken for the copy flow), but per
+ * ADR-0007's "re-verify host config against the installed version" rule the operator
+ * is told to run `agy plugin validate` after install — see the emit advisory and
+ * docs/guides/cross-gai.md. Live confirmation lands with the #290 dogfood.
  */
 export function buildMcpConfig({ hasForgeCore = false } = {}) {
   const mcpServers = {
@@ -194,10 +202,15 @@ const COMPONENT_DIRS = ['skills', 'agents', 'commands', 'mcp', 'hooks', 'scripts
 
 /**
  * Emit the agy plugin package into `destRoot`. Fully manages its own output dir
- * (a clean re-emit each run). Paths in the generated configs are computed from the
- * resolved dest — no hardcoded install path.
+ * (a clean re-emit each run). The generated configs carry plugin-root-relative
+ * paths (#307) so the package is relocatable — no hardcoded install path.
+ *
+ * `viaOut` (set when the operator passed `--out`, i.e. a package destined to be
+ * `agy plugin install`-ed) surfaces the post-install validation advisory: the
+ * in-place discovery flow (no `--out`) is the verified-primary path, and MCP-arg
+ * resolution should be confirmed with `agy plugin validate` after a copy install.
  */
-export async function emitAgyPlugin({ srcRoot = pluginRoot(), destRoot, cwd = process.cwd(), log = () => {} } = {}) {
+export async function emitAgyPlugin({ srcRoot = pluginRoot(), destRoot, cwd = process.cwd(), viaOut = false, log = () => {} } = {}) {
   if (!destRoot) return { ok: false, error: 'destRoot is required' };
   srcRoot = resolve(srcRoot);
   const dest = resolve(destRoot);
@@ -258,8 +271,16 @@ export async function emitAgyPlugin({ srcRoot = pluginRoot(), destRoot, cwd = pr
   log(`agy: emitted forge plugin package at ${dest}`);
   log(`agy: wrote ${written.join(', ')}${hasForgeCore ? ' (forge-graph + forge-core)' : ' (forge-graph)'}`);
   log(`agy: rewrote \${CLAUDE_PLUGIN_ROOT} -> plugin-root-relative in ${rewritten} emitted skill/command file(s)`);
-  log('agy: install with  agy plugin install "' + dest + '" (or discover under .agents/plugins/forge/)');
-  return { ok: true, dest, written, hasForgeCore, rewritten };
+  log('agy: config paths are plugin-root-relative -> the package is relocatable (survives `agy plugin install` copy + `--out` deletion)');
+  log('agy: install with  agy plugin install "' + dest + '" (or discover in place under .agents/plugins/forge/)');
+  // #307: the in-place discovery flow (no --out) is the verified-primary path. When
+  // staging for a copy install, tell the operator to confirm the emitted config
+  // resolves on their agy build — MCP-arg CWD is not independently doc-confirmed.
+  if (viaOut) {
+    log('agy: NOTE (--out): the in-place discovery flow (no --out) is the recommended/verified-primary path.');
+    log('agy: NOTE (--out): after `agy plugin install`, run `agy plugin validate forge` to confirm the MCP server + hooks resolve from the copied plugin root.');
+  }
+  return { ok: true, dest, written, hasForgeCore, rewritten, viaOut };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
@@ -267,7 +288,7 @@ if (isMain) {
   const argv = process.argv.slice(2);
   const outIdx = argv.indexOf('--out');
   const destRoot = outIdx >= 0 ? resolve(process.cwd(), argv[outIdx + 1]) : join(process.cwd(), '.agents', 'plugins', 'forge');
-  emitAgyPlugin({ destRoot, log: console.log })
+  emitAgyPlugin({ destRoot, viaOut: outIdx >= 0, log: console.log })
     .then((res) => { if (!res.ok) { console.error(`agy emit failed: ${res.error}`); process.exit(1); } process.exit(0); })
     .catch((err) => { console.error(`agy emit failed: ${err.message}`); process.exit(1); });
 }

--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -54,7 +54,7 @@ export async function runInit(ctx) {
     }
     const { emitAgyPlugin } = await import('./agy/emit.mjs');
     const destRoot = args.out ? resolve(cwd, args.out) : join(cwd, '.agents', 'plugins', 'forge');
-    const res = await emitAgyPlugin({ destRoot, cwd, log });
+    const res = await emitAgyPlugin({ destRoot, cwd, viaOut: Boolean(args.out), log });
     return { ...res, host: 'agy', actions: res.written ? res.written.map((w) => `agy: emitted ${w}`) : [] };
   }
 

--- a/tests/agy/emit.test.mjs
+++ b/tests/agy/emit.test.mjs
@@ -427,8 +427,29 @@ describe('AC-307: the emitted package is relocatable — survives `agy plugin in
     // it must NOT present the old absolute-install-path config as the emitted shape
     expect(guide).not.toContain('"C:/agy/forge/mcp/graph/server.mjs"');
     expect(guide).not.toContain('node \\"C:/agy/forge/hooks/agy-deny.mjs\\"');
-    // and it explains the relocatability property (survives copy/relocation)
-    expect(guide.toLowerCase()).toMatch(/relocatab|relative/);
+    // it explains the relocatability property (survives copy/relocation)
+    expect(guide.toLowerCase()).toMatch(/relocatab/);
+    // and it names the in-place discovery flow as the recommended/primary path,
+    // with a post-install validation step for the copy-install (--out) flow.
+    expect(guide.toLowerCase()).toMatch(/discovery flow[^.]*recommended|recommended[^.]*(primary|discovery)/);
+    expect(guide).toContain('agy plugin validate forge');
+  });
+
+  it('AC-307.2: the emitter surfaces the discovery-primary + validate advisory only under --out', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agy-emit-'));
+    const lines = [];
+    // viaOut=true (staged for `agy plugin install`) -> advisory printed
+    const withOut = await emitAgyPlugin({ destRoot: join(dir, 'staged'), viaOut: true, log: (m) => lines.push(m) });
+    expect(withOut.ok).toBe(true);
+    const out = lines.join('\n');
+    expect(out).toMatch(/relocatable/);
+    expect(out).toMatch(/discovery flow \(no --out\) is the recommended/);
+    expect(out).toContain('agy plugin validate forge');
+
+    // default flow (no --out) -> no --out advisory noise
+    const quiet = [];
+    await emitAgyPlugin({ destRoot: join(dir, 'default'), viaOut: false, log: (m) => quiet.push(m) });
+    expect(quiet.join('\n')).not.toContain('NOTE (--out)');
   });
 
   it('AC-307.1: pure builders emit relative paths regardless of any dest argument', () => {

--- a/tests/agy/emit.test.mjs
+++ b/tests/agy/emit.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, mkdir, readFile, writeFile, access } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, writeFile, access, cp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, dirname } from 'node:path';
+import { join, dirname, isAbsolute } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawn } from 'node:child_process';
 import { readdir } from 'node:fs/promises';
@@ -54,8 +54,10 @@ describe('AC-289.1: forge init --host agy emits an agy-validatable plugin packag
     // mcpServers: forge-graph wired to a server file that actually exists in the package.
     const mcp = JSON.parse(await readFile(join(dest, 'mcp_config.json'), 'utf8'));
     expect(Object.keys(mcp.mcpServers)).toContain('forge-graph');
+    // #307: the wired path is plugin-root-relative and resolves under the package root.
     const serverPath = mcp.mcpServers['forge-graph'].args[0];
-    await expect(access(serverPath)).resolves.toBeUndefined();
+    expect(isAbsolute(serverPath)).toBe(false);
+    await expect(access(join(dest, serverPath))).resolves.toBeUndefined();
 
     // hooks: named-hook schema, matcher run_command, both shims present on disk.
     const hooks = JSON.parse(await readFile(join(dest, 'hooks.json'), 'utf8'));
@@ -87,7 +89,7 @@ describe('AC-289.1: forge init --host agy emits an agy-validatable plugin packag
   it('AC-289.1: forge-core is guarded — only wired when mcp/forge/server.mjs exists (#288 is separate)', async () => {
     // Today the forge-core server does not exist, so it must NOT be emitted.
     const hasCore = await access(join(pluginRoot(), 'mcp', 'forge', 'server.mjs')).then(() => true, () => false);
-    const cfg = buildMcpConfig('C:/x/forge', { hasForgeCore: hasCore });
+    const cfg = buildMcpConfig({ hasForgeCore: hasCore });
     expect('forge-graph' in cfg.mcpServers).toBe(true);
     expect('forge-core' in cfg.mcpServers).toBe(hasCore);
     // And the emitted package reflects reality.
@@ -190,22 +192,7 @@ describe('AC-289.3: self-exec guards in denylist.mjs / capture.mjs are anchored 
   });
 });
 
-describe('AC-289.4: paths are computed, ASCII-only, Windows-first, long-path aware', () => {
-  it('AC-289.4: emitted configs contain the computed dest path, never a hardcoded install path', async () => {
-    const { dest } = await emitTo();
-    const mcpRaw = await readFile(join(dest, 'mcp_config.json'), 'utf8');
-    const hooksRaw = await readFile(join(dest, 'hooks.json'), 'utf8');
-    // computed: every wired path is rooted at the resolved dest.
-    const destPosix = toPosix(dest);
-    expect(mcpRaw).toContain(destPosix);
-    expect(hooksRaw).toContain(destPosix);
-    // NOT the spike's install-specific paths.
-    for (const raw of [mcpRaw, hooksRaw]) {
-      expect(raw).not.toMatch(/\.gemini[\\/]config[\\/]plugins/);
-      expect(raw).not.toContain('C:/Users/dngioi/.gemini');
-    }
-  });
-
+describe('AC-289.4: paths are ASCII-only, Windows-first, long-path aware', () => {
   it('AC-289.4: every emitted config + shim is ASCII-only', async () => {
     const { dest } = await emitTo();
     for (const rel of ['plugin.json', 'mcp_config.json', 'hooks.json', 'hooks/agy-deny.mjs', 'hooks/agy-capture.mjs']) {
@@ -216,7 +203,7 @@ describe('AC-289.4: paths are computed, ASCII-only, Windows-first, long-path awa
   });
 
   it('AC-289.4: MCP servers use argv-array spawns (no shell string) — Windows-first', () => {
-    const cfg = buildMcpConfig('C:/x/forge', { hasForgeCore: true });
+    const cfg = buildMcpConfig({ hasForgeCore: true });
     for (const s of Object.values(cfg.mcpServers)) {
       expect(s.command).toBe('node');
       expect(Array.isArray(s.args)).toBe(true);
@@ -224,8 +211,9 @@ describe('AC-289.4: paths are computed, ASCII-only, Windows-first, long-path awa
   });
 
   it('AC-289.4: hooks.json + plugin marker are pure computed builders', () => {
-    const hooks = buildHooksConfig('C:/x/forge');
-    expect(hooks['forge-safety'].PreToolUse[0].hooks[0].command).toContain('C:/x/forge/hooks/agy-deny.mjs');
+    const hooks = buildHooksConfig();
+    // #307: plugin-root-relative command (no absolute join), 10s timeout preserved.
+    expect(hooks['forge-safety'].PreToolUse[0].hooks[0].command).toBe('node "hooks/agy-deny.mjs"');
     expect(hooks['forge-safety'].PreToolUse[0].hooks[0].timeout).toBe(10);
     const marker = buildPluginMarker({ $schema: 'x', name: 'forge', mcpServers: { a: 1 }, version: '1.0.0' });
     expect(marker).toEqual({ name: 'forge', version: '1.0.0' });
@@ -369,5 +357,89 @@ describe('AC-294: emitted agy skills/commands carry no unresolved ${CLAUDE_PLUGI
     const after = await readFile(src, 'utf8');
     expect(after).toBe(before); // byte-identical: emit reads source, writes only into dest
     expect(after).toContain('${CLAUDE_PLUGIN_ROOT}');
+  });
+});
+
+describe('AC-307: the emitted package is relocatable — survives `agy plugin install` + `--out` deletion', () => {
+  // Every path a generated config wires must be plugin-root-relative (agy resolves
+  // via the plugin root), so no absolute staging/install literal leaks into the file.
+  const NO_ABS = [
+    /[A-Za-z]:[\\/]/,               // Windows drive-absolute (C:/ or C:\)
+    /"\//,                          // POSIX-absolute in a JSON string value
+    /\.gemini[\\/]config[\\/]plugins/, // the copied-install location
+    /\.agents[\\/]plugins/,         // the discovery location
+  ];
+
+  it('AC-307.1: mcp_config.json + hooks.json carry NO absolute path — only plugin-root-relative refs', async () => {
+    const { dest } = await emitTo();
+    const mcpRaw = await readFile(join(dest, 'mcp_config.json'), 'utf8');
+    const hooksRaw = await readFile(join(dest, 'hooks.json'), 'utf8');
+    const destPosix = toPosix(dest);
+    for (const raw of [mcpRaw, hooksRaw]) {
+      expect(raw).not.toContain(destPosix);          // never the staging `--out` dir
+      for (const re of NO_ABS) expect(raw).not.toMatch(re);
+    }
+    // and the relative refs are the expected plugin-root-relative forms
+    const mcp = JSON.parse(mcpRaw);
+    expect(mcp.mcpServers['forge-graph'].args[0]).toBe('mcp/graph/server.mjs');
+    const hooks = JSON.parse(hooksRaw);
+    expect(hooks['forge-safety'].PreToolUse[0].hooks[0].command).toBe('node "hooks/agy-deny.mjs"');
+    expect(hooks['forge-capture'].PostToolUse[0].hooks[0].command).toBe('node "hooks/agy-capture.mjs"');
+  });
+
+  it('AC-307.1: after `agy plugin install` (copy) + deleting the --out dir, every wired path resolves under the new root', async () => {
+    // 1) emit with --out <staging>
+    const { dir, dest: staging } = await emitTo('staging-out');
+
+    // 2) simulate `agy plugin install <staging>` — copy the package to the install root
+    const installRoot = join(dir, 'gemini-plugins', 'forge');
+    await mkdir(dirname(installRoot), { recursive: true });
+    await cp(staging, installRoot, { recursive: true });
+
+    // 3) delete the original --out dir (the coupling that used to break the install)
+    await rm(staging, { recursive: true, force: true });
+    await expect(access(staging)).rejects.toBeTruthy();
+
+    // 4) every path the copied configs reference must resolve against the install root
+    const mcp = JSON.parse(await readFile(join(installRoot, 'mcp_config.json'), 'utf8'));
+    for (const s of Object.values(mcp.mcpServers)) {
+      const rel = s.args[0];
+      expect(isAbsolute(rel)).toBe(false);
+      await expect(access(join(installRoot, rel))).resolves.toBeUndefined();
+    }
+    const hooks = JSON.parse(await readFile(join(installRoot, 'hooks.json'), 'utf8'));
+    const cmds = [
+      hooks['forge-safety'].PreToolUse[0].hooks[0].command,
+      hooks['forge-capture'].PostToolUse[0].hooks[0].command,
+    ];
+    for (const cmd of cmds) {
+      const rel = cmd.match(/^node "([^"]+)"$/)[1]; // node "hooks/agy-deny.mjs"
+      expect(isAbsolute(rel)).toBe(false);
+      await expect(access(join(installRoot, rel))).resolves.toBeUndefined();
+    }
+  });
+
+  it('AC-307.2: docs/guides/cross-gai.md documents the relocatable flow with relative config paths', async () => {
+    const guide = await readFile(join(repoRoot, 'docs', 'guides', 'cross-gai.md'), 'utf8');
+    // the guide's config examples show the plugin-root-relative forms, not an absolute install path
+    expect(guide).toContain('mcp/graph/server.mjs');
+    expect(guide).toContain('hooks/agy-deny.mjs');
+    // it must NOT present the old absolute-install-path config as the emitted shape
+    expect(guide).not.toContain('"C:/agy/forge/mcp/graph/server.mjs"');
+    expect(guide).not.toContain('node \\"C:/agy/forge/hooks/agy-deny.mjs\\"');
+    // and it explains the relocatability property (survives copy/relocation)
+    expect(guide.toLowerCase()).toMatch(/relocatab|relative/);
+  });
+
+  it('AC-307.1: pure builders emit relative paths regardless of any dest argument', () => {
+    // no dest is threaded in anymore; a stray arg must not resurface an absolute path
+    const mcp = buildMcpConfig({ hasForgeCore: true });
+    for (const s of Object.values(mcp.mcpServers)) {
+      expect(s.args.every((a) => !isAbsolute(a) && !/[A-Za-z]:/.test(a))).toBe(true);
+    }
+    const hooks = buildHooksConfig();
+    const cmd = hooks['forge-safety'].PreToolUse[0].hooks[0].command;
+    expect(cmd).not.toMatch(/[A-Za-z]:[\\/]/);
+    expect(cmd).toBe('node "hooks/agy-deny.mjs"');
   });
 });


### PR DESCRIPTION
Closes #307

## Problem
`forge init --host agy --out <dir>` wrote **absolute**, dest-rooted paths into the generated `mcp_config.json` (server `args`) and `hooks.json` (hook `command`). `agy plugin install <dir>` then **copies** the package to `~/.gemini/config/plugins/forge/`, but the copied configs still pointed back at the original `<dir>` — delete it and the MCP server + safety/capture hooks break. An absolute literal computed at emit time can never survive the copy install: the emitter cannot know the final install root.

## Fix
Emit **plugin-root-relative** paths (`mcp/graph/server.mjs`, `node "hooks/agy-deny.mjs"`), resolved against the plugin root wherever the package lands. `buildMcpConfig` / `buildHooksConfig` drop the `destRoot` join; `emitAgyPlugin` stops threading `dest` into them. Relative is the only emit-time form that survives the copy, and it makes the staging, install-copy, and in-place discovery flows agree.

**Grounding (honest):**
- **hooks.json** — well-grounded. agy runs a hook command with CWD = the directory containing `hooks.json` (= the plugin root), per the agy docs the emitter already cites. Relative resolves correctly post-copy.
- **mcp_config.json** — relative is the strictly-better bet (absolute is provably broken for the copy flow), but agy's MCP-server subprocess CWD is **not** independently confirmed in the agy docs, and the #174 spike validated MCP only with absolute paths. So the emitter does not overclaim: when `--out` is used it prints a discovery-primary + `agy plugin validate forge` advisory, and the guide names the **in-place discovery flow (no `--out`) as the recommended primary path** with a verification note. Live confirmation lands with the #290 dogfood. This satisfies AC.1 on both axes — relocatable relative emission **and** a warn+document-discovery-as-primary fallback for the unverified MCP CWD.

## Acceptance criteria
- [x] **AC-307.1** — a package emitted with `--out` and copied elsewhere keeps working after the `--out` dir is deleted: configs carry no absolute path; every relative ref resolves under the package root. Tested via a copy-then-delete relocation simulation + no-absolute-path assertions.
- [x] **AC-307.2** — `docs/guides/cross-gai.md` reflects the relocatable flow (relative config examples, relocatability rationale, discovery-flow-as-primary, MCP verification note).

## Verification
- `pnpm verify` — **714 passed / 59 files**, green.
- Gates: **acgate** (AC-307.1, AC-307.2 covered by passing tests), **plandrift** clean, **depguard** no new deps, **docsync** clean.
- **testintent** flags **6 changed assertions** in `tests/agy/emit.test.mjs` — **requires reviewer sign-off (this section is it).** All 6 are the intentional inversion of assertions that encoded the *old, buggy* absolute-path behavior (e.g. `expect(mcpRaw).toContain(destPosix)` — the coupling itself — and the pure-builder `.toContain('C:/x/forge/...')` command check). They are replaced by a strict **superset**: the new AC-307.1 suite asserts the *absence* of any absolute path (drive-letter, POSIX-absolute, install/discovery dirs), the positive relative-path content, and a full install-copy-then-delete-source lifecycle. No coverage lost.
- Adversarial passes run (reviewer + security). Both converged on the MCP-CWD grounding gap; resolved by the caveat + `--out` advisory + guide verification note above rather than reverting to the provably-broken absolute form. Security pass confirmed the change is a net **injection-surface reduction** (the user-supplied `--out` dest is no longer interpolated into the hooks command — it is now a fixed literal).
- `agy` is not runnable in CI, so relocatability is asserted **structurally** (copy + delete + resolve under the new root). Residual: agy MCP-subprocess CWD to be confirmed at the #290 dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)