### PR TITLE
feat(commands): add /forge:docsync-check (#385)

### DIFF
--- a/docs/guides/handbook.md
+++ b/docs/guides/handbook.md
@@ -127,4 +127,4 @@ Opt-in, **private-repo-only** free CI on a local GitHub Actions runner. `/forge:
 
 ## 11. When something's wrong
 
-`/forge:doctor` first — every ✗ has a fix hint. Known issues + recovery ladders: [troubleshooting guide](troubleshooting.md). Gate refused: read its message, it names the unlock. Pipeline halted: check 🚩 decisions (`board status`). Board ids dangling: re-run `/forge:init`. Anything the platform can't decide arrives as a decision comment — answer it and work resumes.
+`/forge:doctor` first — every ✗ has a fix hint. Known issues + recovery ladders: [troubleshooting guide](troubleshooting.md). Gate refused: read its message, it names the unlock. Pipeline halted: check 🚩 decisions (`board status`). Board ids dangling: re-run `/forge:init`. Anything the platform can't decide arrives as a decision comment — answer it and work resumes. Docs feel out of sync (a doc that's not linked anywhere, a skill nobody documented): `/forge:docsync-check` runs the same route-index/handbook/badge check `forge:ship` runs before a PR, on demand.

--- a/plugin/commands/docsync-check.md
+++ b/plugin/commands/docsync-check.md
@@ -1,0 +1,17 @@
+---
+description: Read-only docs-structure check — every doc under docs/ linked in the route index, every new skill mentioned in the handbook, README version badge in sync
+---
+
+Run the docs-sync check from the repo root:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/gates/docsync.mjs"
+```
+
+It checks that every file under `docs/` is linked from `docs/README.md` (the route index), that any newly-added skill is mentioned in the handbook, and that the README version badge matches `package.json` — the same check `forge:ship` runs before a PR, exposed here to run on demand. It prints one ✗ line per gap with the exact fix (e.g. "docs/X is not linked in docs/README.md"), and exits nonzero when anything is out of sync. If `docs/README.md` doesn't exist yet, it says so and skips — this repo hasn't adopted the route-index convention.
+
+Relay the results to the user:
+- Clean: say the docs are in sync (state the doc count it indexed).
+- Gaps: list each ✗ line with its fix hint. Route-index gaps are usually a one-line addition to `docs/README.md`; offer to add it. Skill-handbook gaps need a short description in `docs/guides/handbook.md`. A README badge gap means `package.json`'s version and the badge have drifted — usually from a release that didn't go through `forge:release`.
+
+This command is read-only — it never mutates the repo.


### PR DESCRIPTION
Closes #385.

Exposes the already-tested `docsync.mjs` gate script as a user-facing `/forge:docsync-check` command — mirrors `doctor.md`/`runner-check.md`'s exact pattern, no changes to the check logic itself. Confirmed working: `node plugin/scripts/gates/docsync.mjs` reports `doc-sync: clean (59 docs indexed)` on this repo today.

## AC
- [x] AC.1 `plugin/commands/docsync-check.md` follows the established command-file convention
- [x] AC.2 no changes to `docsync.mjs` — command-surface addition only
- [x] AC.3 docsync stays clean; handbook mentions the new command (§11, troubleshooting)

Full `pnpm verify` green (739/739).

🤖 Generated with [Claude Code](https://claude.com/claude-code)