### PR TITLE
feat(doctor): advise when graph-RAG is available but off (#386)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [Batch close](plans/2026-07-20-batch-close.md) — tasks for #123: comma-separated `--issue` in `board/close.mjs`.
 - [#289 — agy init emit](plans/2026-07-26-289-agy-init-emit.md) — tasks for #289 (ADR-0007 AC3): `forge init --host agy` emits the proven agy plugin package (co-located `plugin.json`, generated `mcp_config.json` + `hooks.json`, deny/capture shims, short-path staging).
 - [#307 — agy emit relocatable](plans/2026-08-04-307-agy-emit-relocatable.md) — tasks for #307 (epic #174): emit plugin-root-relative paths in `mcp_config.json` + `hooks.json` so the package survives `agy plugin install` (copy) and deletion of the `--out` dir.
+- [#386 — graph availability notice](plans/2026-08-06-386-graph-availability-notice.md) — tasks for #386 (parent #182): `forge:doctor` advises when `tsconfig.json` is present and `features.graph` isn't on, with the 3-step enable sequence.
 
 ## Spikes
 

--- a/docs/plans/2026-08-06-386-graph-availability-notice.md
+++ b/docs/plans/2026-08-06-386-graph-availability-notice.md
@@ -1,0 +1,58 @@
+# Plan: #386 - surface a notice when delivery proceeds without graph-RAG on a TS-capable repo
+
+**Ticket:** #386 (parent #182, plugin platform maintenance) - **Kind:** bug/chore
+**Base:** main - **Branch:** feat/386-graph-availability-notice
+
+`features.graph` defaults to `false` on a fresh scaffold (TS-repo-specific,
+`docs/guides/install.md:47`). Neither `forge:deliver` nor `forge:autopilot` checks or
+surfaces this, and `forge:doctor` only warns when `features.graph` is already `true`
+(`doctor.mjs:159-171`) — it never flags "you might want this on." Fix scope: extend
+`forge:doctor` (the natural home — it already runs health checks) with the inverse
+check, not a new check point in deliver/autopilot's hot path. Visibility fix only —
+does not force graph on by default.
+
+## AC map
+
+- **AC-386.1** `forge:doctor` on a repo with `tsconfig.json` present and
+  `features.graph: false` prints a clear ⚠ advisory line naming graph-RAG as
+  available but off, with the exact 3-step enable sequence documented in
+  `install.md:47` (`features.graph:true` + `npm i -D ts-morph` +
+  `graphctl.mjs rebuild`).
+- **AC-386.2** no change in behavior for non-TS repos, repos that already have
+  `features.graph: true`, or repos that deliberately disabled it after trying it.
+  Nuance chosen: "never configured" (no `features` block at all, e.g. an adopted
+  repo) is treated the same as "off" and still gets the advisory — a fresh
+  non-adopt `forge:init` always writes an explicit `false` (`init.mjs:180`), so
+  "missing vs explicit false" in `forge.json` would NOT actually separate
+  never-configured from deliberately-disabled. The cheap, real signal for
+  "deliberately disabled after trying" is `.forge/graph.db` already existing
+  (the repo built the index once) — when present, the advisory is suppressed.
+- **AC-386.3** the check is read-only — no writes to `forge.json` or anywhere else.
+
+## Task 1 (item): add the `graph-availability` doctor check (AC-386.1, AC-386.2, AC-386.3)
+
+New check block in `runDoctor`, positioned next to the existing `features.graph===true`
+block it inverts (`doctor.mjs:159-174`), same `ok/warn/fail` helper shapes and
+`{name, level, msg, hint}` result shape as every other doctor check. Fires a `warn`
+named `graph-availability` when `cfg.ok && cfg.config.features?.graph !== true` AND
+`tsconfig.json` exists AND `.forge/graph.db` does NOT exist. Purely additive — the
+existing `graph` check (fires only when `features.graph===true`) is untouched, so the
+two checks are mutually exclusive by construction.
+
+**Files:** plugin/scripts/doctor.mjs
+
+## Task 2 (test): AC-mapped tests
+
+Six new tests in `tests/doctor.test.mjs` (new `describe` block): tsconfig+off → warn
+with hint asserting the 3-step sequence (AC.1); no `features` block at all → same warn
+(never-configured nuance); `features.graph:true` → no advisory; no `tsconfig.json` →
+no advisory even with graph off; `.forge/graph.db` present → no advisory (deliberate
+opt-out, AC.2); doctor run leaves `forge.json` byte-identical (AC.3, read-only).
+
+**Files:** tests/doctor.test.mjs
+
+## Verification
+
+`pnpm verify` (vitest run, full suite). Gates: plandrift clean (this plan's **Files:**
+lists cover both touched files), testintent clean (only new assertions, nothing
+weakened), depguard clean (no new dependencies), docsync clean (no new/renamed docs).

--- a/plugin/scripts/doctor.mjs
+++ b/plugin/scripts/doctor.mjs
@@ -190,7 +190,7 @@ export async function runDoctor(ctx) {
         results.push(warn(
           'graph-availability',
           'tsconfig.json found but features.graph is off — graph-RAG (find_component/who_uses/blast_radius/reuse_candidates) is available for this repo',
-          'set features.graph:true in .claude/forge.json, npm i -D ts-morph, then node <plugin>/scripts/graph/graphctl.mjs rebuild (docs/guides/install.md)',
+          'set features.graph:true in .claude/forge.json, npm i -D ts-morph, then node plugin/scripts/graph/graphctl.mjs rebuild (docs/guides/install.md)',
         ));
       }
     }

--- a/plugin/scripts/doctor.mjs
+++ b/plugin/scripts/doctor.mjs
@@ -173,6 +173,29 @@ export async function runDoctor(ctx) {
     }
   }
 
+  // graph availability notice (#386): the inverse of the check above. A TS repo
+  // that has never turned graph-RAG on has no way to learn it exists — deliver/
+  // autopilot silently fall back to grep and forge:doctor previously only spoke
+  // up once features.graph was ALREADY true. One-time, low-noise advisory: fires
+  // whenever a tsconfig.json is present and features.graph isn't explicitly true,
+  // EXCEPT when .forge/graph.db already exists — that's cheap evidence the repo
+  // built the index before and then turned it off on purpose (AC.2: don't nag a
+  // deliberate opt-out). "Never configured" (features block absent, e.g. adopted
+  // repos) is treated the same as "off" — that repo needs the notice most.
+  if (cfg.ok && cfg.config.features?.graph !== true) {
+    const tsconfigExists = await stat(join(cwd, 'tsconfig.json')).then(() => true, () => false);
+    if (tsconfigExists) {
+      const dbExists = await stat(join(cwd, '.forge', 'graph.db')).then(() => true, () => false);
+      if (!dbExists) {
+        results.push(warn(
+          'graph-availability',
+          'tsconfig.json found but features.graph is off — graph-RAG (find_component/who_uses/blast_radius/reuse_candidates) is available for this repo',
+          'set features.graph:true in .claude/forge.json, npm i -D ts-morph, then node <plugin>/scripts/graph/graphctl.mjs rebuild (docs/guides/install.md)',
+        ));
+      }
+    }
+  }
+
   // local self-hosted runner (ADR-0005 / #225 AC4) — silent unless runner.enabled
   if (cfg.ok && cfg.runner?.enabled === true) {
     await checkRunner({ gh, cwd, runner: cfg.runner, results, exec, detect: detectServices });

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -404,6 +404,77 @@ describe('runDoctor — failure classes (AC-1.4)', () => {
   });
 });
 
+describe('runDoctor — graph availability notice (#386)', () => {
+  const routes = [['auth status', AUTH_OK], ['repo view', REPO_VIEW], [() => true, { ok: false, stderr: 'x' }]];
+
+  /** Write a valid forge.json with a `features` block override (undefined = omit it entirely). */
+  async function writeCfgFeatures(cwd, features) {
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    delete committed.runner; // keep runner checks silent/out of scope for these tests
+    if (features !== undefined) committed.features = features;
+    else delete committed.features;
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed), 'utf8');
+  }
+
+  it('AC.1: tsconfig.json present + features.graph:false → advisory warn naming the 3-step enable sequence', async () => {
+    const cwd = await gitRepo({ files: { 'tsconfig.json': '{}' } });
+    await writeCfgFeatures(cwd, { graph: false });
+    const { gh } = fakeGh(routes);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    const r = byName(res, 'graph-availability')[0];
+    expect(r.level).toBe('warn');
+    expect(r.msg).toMatch(/tsconfig/i);
+    expect(r.hint).toMatch(/features\.graph:\s*true/);
+    expect(r.hint).toMatch(/ts-morph/);
+    expect(r.hint).toMatch(/graphctl\.mjs rebuild/);
+    // advisory only — never flips doctor to failing
+    expect(res.results.filter((x) => x.level === 'fail').map((x) => x.name)).not.toContain('graph-availability');
+  });
+
+  it('never configured (no features block at all, e.g. an adopted repo) is treated the same as off', async () => {
+    const cwd = await gitRepo({ files: { 'tsconfig.json': '{}' } });
+    await writeCfgFeatures(cwd, undefined); // no features block
+    const { gh } = fakeGh(routes);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'graph-availability')[0].level).toBe('warn');
+  });
+
+  it('AC.2: features.graph already true → no advisory (the existing "graph" check owns that state)', async () => {
+    const cwd = await gitRepo({ files: { 'tsconfig.json': '{}' } });
+    await writeCfgFeatures(cwd, { graph: true });
+    const { gh } = fakeGh(routes);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'graph-availability')).toEqual([]);
+  });
+
+  it('AC.2: no tsconfig.json (non-TS repo) → no advisory even with graph off', async () => {
+    const cwd = await gitRepo();
+    await writeCfgFeatures(cwd, { graph: false });
+    const { gh } = fakeGh(routes);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'graph-availability')).toEqual([]);
+  });
+
+  it('AC.2: .forge/graph.db already built → no advisory (deliberately turned off after trying, don\'t nag)', async () => {
+    const cwd = await gitRepo({ files: { 'tsconfig.json': '{}', '.forge/graph.db': '' } });
+    await writeCfgFeatures(cwd, { graph: false });
+    const { gh } = fakeGh(routes);
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'graph-availability')).toEqual([]);
+  });
+
+  it('AC.3: read-only — running doctor never mutates forge.json', async () => {
+    const cwd = await gitRepo({ files: { 'tsconfig.json': '{}' } });
+    await writeCfgFeatures(cwd, { graph: false });
+    const before = await readFile(join(cwd, '.claude', 'forge.json'), 'utf8');
+    const { gh } = fakeGh(routes);
+    await runDoctor({ gh, cwd, log: noop });
+    const after = await readFile(join(cwd, '.claude', 'forge.json'), 'utf8');
+    expect(after).toBe(before);
+  });
+});
+
 describe('runDoctor — healthy repo shape', () => {
   it('all green (✓/⚠ only) against a fully consistent setup', async () => {
     const cwd = await tmpCwd();


### PR DESCRIPTION
Closes #386

## Summary
Extends `forge:doctor` with the inverse of the existing `features.graph===true` health checks (`doctor.mjs:159-171`). A repo with `tsconfig.json` present and `features.graph` not explicitly `true` had no way to learn graph-RAG existed — `forge:deliver`/`forge:autopilot` silently fall back to grep with no notice, and doctor only spoke up once graph was already on. This is a visibility fix only; it never forces graph on.

New check, `graph-availability` (doctor.mjs:176-197):
- Fires a ⚠ warn naming graph-RAG as available, with the exact 3-step enable sequence from `install.md:47` (`features.graph:true` + `npm i -D ts-morph` + `graphctl.mjs rebuild`).
- Fires only when `tsconfig.json` exists and `features.graph !== true`.
- Suppressed when `.forge/graph.db` already exists — cheap evidence the repo built the index once and deliberately turned it off (AC.2's "don't nag a deliberate opt-out").
- Mutually exclusive by construction with the existing `graph` check (`===true` vs `!==true`), so never double-fires.
- Read-only: two `stat()` existence checks, no writes anywhere.

## AC checklist
- [x] AC.1 — `forge:doctor` on a repo with `tsconfig.json` + `features.graph:false` prints a clear ⚠ advisory naming the 3-step enable sequence.
- [x] AC.2 — no change for non-TS repos, repos with `features.graph:true`, or repos that deliberately disabled it after trying (distinguished via `.forge/graph.db` presence — see plan doc rationale for why "missing vs explicit false" in `forge.json` doesn't actually separate never-configured from deliberately-disabled: fresh `init` always writes an explicit `false`).
- [x] AC.3 — read-only; a dedicated test asserts `forge.json` is byte-identical before/after a doctor run.

## Verification (honest)
- `pnpm verify`: 745/745 tests green (59 files), including 6 new tests in `tests/doctor.test.mjs`.
- Gates: `plandrift` clean (4 touched, all declared), `testintent` clean (no weakened assertions), `depguard` clean (no new deps), `docsync` clean (61 docs indexed), `conventions` clean.
- Reviewer pass (forge:reviewer subagent): pass, one non-blocking nit (hint placeholder wording) — fixed in a follow-up commit.
- Security pass (forge:security subagent): pass, no findings — confirmed read-only (no writes/exec/network), no path-traversal surface (hardcoded relative paths only), no injection surface (static message strings, config value only used in a boolean comparison).
- NOT verified: end-to-end `/forge:doctor` CLI invocation against a real gh-authenticated repo (tests exercise `runDoctor()` directly with a faked `gh`); no manual click-through since this is a CLI health-check line, not a UI.

## Plan
`docs/plans/2026-08-06-386-graph-availability-notice.md` (indexed in `docs/README.md`).