### PR TITLE
feat(init): seed a baseline docs/ structure + document the route-index rule

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [#289 — agy init emit](plans/2026-07-26-289-agy-init-emit.md) — tasks for #289 (ADR-0007 AC3): `forge init --host agy` emits the proven agy plugin package (co-located `plugin.json`, generated `mcp_config.json` + `hooks.json`, deny/capture shims, short-path staging).
 - [#307 — agy emit relocatable](plans/2026-08-04-307-agy-emit-relocatable.md) — tasks for #307 (epic #174): emit plugin-root-relative paths in `mcp_config.json` + `hooks.json` so the package survives `agy plugin install` (copy) and deletion of the `--out` dir.
 - [#386 — graph availability notice](plans/2026-08-06-386-graph-availability-notice.md) — tasks for #386 (parent #182): `forge:doctor` advises when `tsconfig.json` is present and `features.graph` isn't on, with the 3-step enable sequence.
+- [#389 — scaffold docs structure](plans/2026-08-06-389-scaffold-docs-structure.md) — tasks for #389 (parent #182): `forge:init` seeds `docs/{specs,plans,spikes,design,decisions,guides}/` + a route-index template on a fresh scaffold only, never on adopt; the convention documented as a named rule in `docs/guides/install.md`.
 
 ## Spikes
 

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -35,6 +35,29 @@ Either mode also creates (only if missing): the pinned **delivery-log issue**, `
 
 `forge.json` is where you set the verify command (`pnpm verify`, `npm test`, …), docs dirs, team members/roles, and feature flags — all optional beyond the board block.
 
+### Docs structure — the route-index convention
+
+A **fresh** `/forge:init` (no `forge.json` yet, and no `docs/` already on disk) also seeds a `docs/` structure so docs don't land with zero convention from day one:
+
+```
+docs/
+  specs/       plans/      spikes/     design/     decisions/  guides/
+  README.md    (the route index)
+```
+
+**Adopting** an existing repo — or a repo that already has a `docs/` directory in any shape, even one predating `forge.json` — leaves it completely untouched. Nothing is ever seeded over an existing layout.
+
+One line each, what goes where:
+
+- **specs/** — approved feature specs (the "what and why"; `forge:brainstorm` output).
+- **plans/** — task-by-task implementation plans (`forge:plan` output).
+- **spikes/** — time-boxed research findings / ADR drafts (`forge:spike` output; never merged as code).
+- **design/** — visual specs for UI work (`forge:design` output).
+- **decisions/** — ADRs: durable architectural decisions and their rationale.
+- **guides/** — how-to documentation for humans (install, handbook, troubleshooting, runbooks).
+
+`docs/README.md` is the **route index**: one line per doc, updated whenever a doc lands, moves, or renames (the `forge:ship` checklist enforces this). The `docsync` gate checks the index against `docs/` whenever the file exists, and still skips gracefully when it doesn't — seeding the structure doesn't change that gate.
+
 ## 3. Health check: `/forge:doctor`
 
 Run it after init and any time something feels off. ✗ items block work and say how to fix; ⚠ items are **owner settings** worth doing early: branch protection on main, secret scanning + push protection, Dependabot alerts (feeds `forge:maintain`), and repo Settings → *Automatically delete head branches*.

--- a/docs/plans/2026-08-06-389-scaffold-docs-structure.md
+++ b/docs/plans/2026-08-06-389-scaffold-docs-structure.md
@@ -1,0 +1,73 @@
+# Plan: #389 - forge:init seeds a baseline docs/ structure + documents the route-index convention as a rule
+
+**Ticket:** #389 (parent #182, plugin platform maintenance) - **Kind:** chore
+**Base:** main - **Branch:** feat/389-scaffold-docs-structure
+
+`forge:init`'s fresh-scaffold path creates zero code/docs directories — only board/config/CI
+— even though `conventions.specsDir`/`plansDir` are written as config values. Separately,
+this repo's own `docs/README.md` route-index convention (Specs/Plans/Spikes/Design
+specs/Decisions/Guides, enforced by `docsync.mjs` when present) is not shipped as a
+template, not seeded by init, and not documented as a rule for consumer projects.
+`docsync.mjs` gracefully skips when `docs/README.md` is absent — so a brand-new scaffold
+gets no structure and no enforcement pushing toward one.
+
+## AC map
+
+- **AC-389.1** a fresh `forge:init` (empty repo, no existing `docs/`) ends up with
+  `docs/{specs,plans,spikes,design,decisions,guides}/` + `docs/README.md` route index. An
+  **adopt** on a repo with an existing `docs/` (any layout) is left completely untouched —
+  no clobbering, ever, even in the edge case where `docs/` predates `forge.json` in an
+  otherwise-fresh repo.
+- **AC-389.2** the convention is documented as a real, named rule a consumer can read
+  (`docs/guides/install.md`), not just inferred from forge's own repo.
+- **AC-389.3** `docsync.mjs` behavior is unchanged — this ticket seeds structure, it
+  doesn't touch the gate.
+- **AC-389.4** test coverage for both the fresh-scaffold-seeds-structure path and the
+  adopt-doesn't-clobber path, mirroring the existing fresh-vs-adopt test patterns in
+  `tests/init.test.mjs`.
+
+## Task 1 (item): ship the docs/README.md template (AC-389.1)
+
+New template file mirroring this repo's own route-index format: the header line ("One
+line per doc. Update this file whenever a doc lands, moves, or renames") and the six
+section headers (Specs/Plans/Spikes/Design specs/Decisions/Guides), with a `{{PROJECT}}`
+title placeholder substituted the same way `verify.yml` substitutes `{{VERIFY}}`.
+
+**Files:** plugin/templates/docs-readme.md
+
+## Task 2 (item): seed docs/ from forge:init, fresh-only, no-clobber (AC-389.1, AC-389.3)
+
+New step in `runInit` (after the CI-template step, before status line): in fresh mode
+only (`!adopt`) and only when `docs/` is not already present on disk, create
+`docs/{specs,plans,spikes,design,decisions,guides}/` and write `docs/README.md` from the
+template. Adopt mode never runs this check at all. `docsync.mjs` is untouched — no
+changes to `plugin/scripts/gates/docsync.mjs`.
+
+**Files:** plugin/scripts/init.mjs
+
+## Task 3 (test): AC-mapped tests (AC-389.4)
+
+Four new tests in `tests/init.test.mjs` (new `describe` block, `freshRoutes` hoisted to
+module scope for reuse): fresh init seeds the six empty subdirs + route-index content
+(AC.1); fresh init leaves a pre-existing `docs/` (predating `forge.json`) untouched
+(AC.1 edge case); adopt mode never creates `docs/` at all; adopt mode on a repo with its
+own existing `docs/` layout leaves it byte-for-byte untouched (AC.1).
+
+**Files:** tests/init.test.mjs
+
+## Task 4 (doc): document the convention as a named rule (AC-389.2)
+
+New "Docs structure — the route-index convention" section in the install guide: what
+`forge:init` seeds and when, the adopt/pre-existing no-clobber guarantee, one line per
+folder (specs/plans/spikes/design/decisions/guides), and the route-index / `docsync`
+relationship.
+
+**Files:** docs/guides/install.md
+
+## Verification
+
+`pnpm verify` (vitest run, full suite). Gates: plandrift clean (this plan's **Files:**
+lists cover every touched file), testintent clean (only new assertions added, nothing
+weakened), depguard clean (no new dependencies), docsync clean (docs/guides/install.md
+is already indexed in docs/README.md; no new docs/ file added by this change — the new
+template lives under plugin/templates/, outside docs/).

--- a/plugin/scripts/init.mjs
+++ b/plugin/scripts/init.mjs
@@ -232,6 +232,40 @@ export async function runInit(ctx) {
     }
   }
 
+  // 7c. Docs route-index scaffold (#389): a fresh scaffold otherwise writes docs
+  // with zero structure and zero convention pushing toward one. Fresh mode only —
+  // adopt must never touch an existing repo's docs/ layout — and even in fresh
+  // mode a docs/ dir already on disk (predates forge.json, e.g. adopted manually)
+  // wins: no clobbering, ever. Any readdir error OTHER than "doesn't exist" (e.g.
+  // a permissions error) must NOT be treated as "safe to seed" — that would risk
+  // writing over a real docs/README.md the caller just couldn't list — so it's
+  // reported and the step is skipped rather than assumed absent. Wrapped in
+  // try/catch like the neighboring CI-template step (7b): a mid-sequence failure
+  // degrades to a skip message instead of throwing out of runInit.
+  if (!adopt) {
+    const docsDir = join(cwd, 'docs');
+    try {
+      let hasDocs = true;
+      try {
+        await readdir(docsDir);
+      } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+        hasDocs = false;
+      }
+      if (!hasDocs) {
+        for (const sub of ['specs', 'plans', 'spikes', 'design', 'decisions', 'guides']) {
+          await mkdir(join(docsDir, sub), { recursive: true });
+        }
+        const tplPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'templates', 'docs-readme.md');
+        const tpl = (await readFile(tplPath, 'utf8')).replaceAll('{{PROJECT}}', repo.name);
+        await writeFile(join(docsDir, 'README.md'), tpl, 'utf8');
+        say('docs: seeded docs/{specs,plans,spikes,design,decisions,guides}/ + route-index (docs/README.md)');
+      }
+    } catch (err) {
+      say(`docs: scaffold skipped (${err.message})`);
+    }
+  }
+
   // 8. Status line (opt-in via --statusline; the command md asks the user first).
   // Written to settings.local.json: the command embeds a machine-specific
   // absolute path, which must never land in the shared committed settings.

--- a/plugin/templates/docs-readme.md
+++ b/plugin/templates/docs-readme.md
@@ -1,0 +1,15 @@
+# {{PROJECT}} — docs route index
+
+One line per doc. Update this file whenever a doc lands, moves, or renames (`forge:ship` checklist item).
+
+## Specs
+
+## Plans
+
+## Spikes
+
+## Design specs
+
+## Decisions
+
+## Guides

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runInit, parseArgs } from '../plugin/scripts/init.mjs';
@@ -45,29 +45,31 @@ describe('parseArgs', () => {
   });
 });
 
+// Shared fresh-bootstrap route set (module scope so both the fresh-bootstrap
+// describe and the docs-scaffold describe below can reuse it).
+function freshRoutes() {
+  let fieldsCall = 0;
+  return [
+    ['auth status', AUTH_OK],
+    ['repo view', REPO_VIEW],
+    ['project create', { stdout: JSON.stringify({ id: 'PVT_new', number: 9, title: 'forge' }) }],
+    ['project link', { stdout: '' }], // #64: fresh create links the board to the repo
+
+    [(j) => j.startsWith('api graphql') && j.includes('fields(first: 50)'), () => {
+      fieldsCall += 1;
+      // first discovery: built-in status only, empty project; re-discovery: full set
+      return fieldsCall === 1
+        ? fieldsResponse(0, [{ id: 'PVTSSF_new1', name: 'Status', options: [{ id: 'a', name: 'Todo' }, { id: 'b', name: 'In Progress' }, { id: 'c', name: 'Done' }] }])
+        : fieldsResponse(0, FRESH_FULL_FIELDS);
+    }],
+    [(j) => j.includes('updateProjectV2Field'), { stdout: JSON.stringify({ data: { updateProjectV2Field: { projectV2Field: { id: 'PVTSSF_new1', options: [] } } } }) }],
+    [(j) => j.includes('createProjectV2Field'), { stdout: JSON.stringify({ data: { createProjectV2Field: { projectV2Field: { id: 'PVTSSF_x', options: [] } } } }) }],
+    ['issue list', { stdout: '[]' }],
+    ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/42\n' }],
+  ];
+}
+
 describe('runInit — fresh bootstrap (AC-1.2)', () => {
-  function freshRoutes() {
-    let fieldsCall = 0;
-    return [
-      ['auth status', AUTH_OK],
-      ['repo view', REPO_VIEW],
-      ['project create', { stdout: JSON.stringify({ id: 'PVT_new', number: 9, title: 'forge' }) }],
-      ['project link', { stdout: '' }], // #64: fresh create links the board to the repo
-
-      [(j) => j.startsWith('api graphql') && j.includes('fields(first: 50)'), () => {
-        fieldsCall += 1;
-        // first discovery: built-in status only, empty project; re-discovery: full set
-        return fieldsCall === 1
-          ? fieldsResponse(0, [{ id: 'PVTSSF_new1', name: 'Status', options: [{ id: 'a', name: 'Todo' }, { id: 'b', name: 'In Progress' }, { id: 'c', name: 'Done' }] }])
-          : fieldsResponse(0, FRESH_FULL_FIELDS);
-      }],
-      [(j) => j.includes('updateProjectV2Field'), { stdout: JSON.stringify({ data: { updateProjectV2Field: { projectV2Field: { id: 'PVTSSF_new1', options: [] } } } }) }],
-      [(j) => j.includes('createProjectV2Field'), { stdout: JSON.stringify({ data: { createProjectV2Field: { projectV2Field: { id: 'PVTSSF_x', options: [] } } } }) }],
-      ['issue list', { stdout: '[]' }],
-      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/42\n' }],
-    ];
-  }
-
   it('creates project, standard fields, delivery log, forge.json, gitignore', async () => {
     const cwd = await tmpCwd();
     const { gh, calls } = fakeGh(freshRoutes());
@@ -215,6 +217,101 @@ describe('runInit — fresh bootstrap (AC-1.2)', () => {
     expect(res.ok).toBe(true);
     const creates = calls.filter((c) => c.includes('createProjectV2Field'));
     expect(creates.length).toBe(2); // size + type only — priority not recreated
+  });
+});
+
+describe('runInit — docs scaffold (#389)', () => {
+  it('AC-389.1: fresh init on an empty repo seeds docs/{specs,plans,spikes,design,decisions,guides}/ + the route-index file', async () => {
+    const cwd = await tmpCwd();
+    const { gh } = fakeGh(freshRoutes());
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--create-project', 'forge', '--skip-doctor']) });
+    expect(res.ok).toBe(true);
+
+    for (const sub of ['specs', 'plans', 'spikes', 'design', 'decisions', 'guides']) {
+      const entries = await readdir(join(cwd, 'docs', sub));
+      expect(entries).toEqual([]); // seeded empty — consumers fill them in
+    }
+    const index = await readFile(join(cwd, 'docs', 'README.md'), 'utf8');
+    expect(index).toMatch(/^# .* — docs route index/);
+    expect(index).toContain('One line per doc. Update this file whenever a doc lands, moves, or renames');
+    for (const heading of ['## Specs', '## Plans', '## Spikes', '## Design specs', '## Decisions', '## Guides']) {
+      expect(index).toContain(heading);
+    }
+  });
+
+  it('AC-389.1: fresh init leaves a pre-existing docs/ (found on disk before forge.json exists) completely untouched', async () => {
+    const cwd = await tmpCwd();
+    await mkdir(join(cwd, 'docs', 'custom'), { recursive: true });
+    await writeFile(join(cwd, 'docs', 'custom', 'notes.md'), '# pre-existing notes\n', 'utf8');
+
+    const { gh } = fakeGh(freshRoutes());
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--create-project', 'forge', '--skip-doctor']) });
+    expect(res.ok).toBe(true);
+
+    // untouched: no seeded subdirs, no route-index file, custom content intact
+    await expect(readdir(join(cwd, 'docs'))).resolves.toEqual(['custom']);
+    expect(await readFile(join(cwd, 'docs', 'custom', 'notes.md'), 'utf8')).toBe('# pre-existing notes\n');
+    await expect(readFile(join(cwd, 'docs', 'README.md'), 'utf8')).rejects.toThrow();
+  });
+
+  it('AC-389.1: a non-ENOENT readdir failure (docs/ path exists but is not listable as a dir) skips seeding rather than assuming absent', async () => {
+    const cwd = await tmpCwd();
+    // docs is a plain FILE, not a directory: readdir(docsDir) throws ENOTDIR,
+    // a real docs/README.md-shaped path that must never be silently overwritten.
+    await writeFile(join(cwd, 'docs'), '# not actually a directory\n', 'utf8');
+
+    const { gh } = fakeGh(freshRoutes());
+    const logs = [];
+    const res = await runInit({ gh, cwd, log: (m) => logs.push(m), args: parseArgs(['--create-project', 'forge', '--skip-doctor']) });
+    expect(res.ok).toBe(true); // a non-ENOENT docs error degrades, it never fails init
+    expect(logs.join(' ')).toMatch(/docs: scaffold skipped/i);
+    // the pre-existing docs path is byte-for-byte untouched
+    expect(await readFile(join(cwd, 'docs'), 'utf8')).toBe('# not actually a directory\n');
+  });
+
+  it('AC-389.1: adopt mode never seeds or touches docs/, even when docs/ is absent', async () => {
+    const cwd = await tmpCwd();
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed, null, 2), 'utf8');
+
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project view 8', { stdout: JSON.stringify({ id: BOARD8.projectId, number: 8, title: 'forge - AI dev platform' }) }],
+      [(j) => j.includes('fields(first: 50)'), fieldsResponse(14, BOARD8.fields)],
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/15\n' }],
+    ]);
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--skip-doctor']) });
+    expect(res.ok).toBe(true);
+
+    // adopt mode: no docs/ directory created at all
+    await expect(readdir(join(cwd, 'docs'))).rejects.toThrow();
+  });
+
+  it("AC-389.1: adopt mode on a repo with its own existing docs/ layout leaves it byte-for-byte untouched", async () => {
+    const cwd = await tmpCwd();
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed, null, 2), 'utf8');
+    await mkdir(join(cwd, 'docs', 'architecture'), { recursive: true });
+    await writeFile(join(cwd, 'docs', 'architecture', 'overview.md'), '# their own layout\n', 'utf8');
+
+    const { gh } = fakeGh([
+      ['auth status', AUTH_OK],
+      ['repo view', REPO_VIEW],
+      ['project view 8', { stdout: JSON.stringify({ id: BOARD8.projectId, number: 8, title: 'forge - AI dev platform' }) }],
+      [(j) => j.includes('fields(first: 50)'), fieldsResponse(14, BOARD8.fields)],
+      ['issue list', { stdout: '[]' }],
+      ['issue create', { stdout: 'https://github.com/dngioidev/forge/issues/15\n' }],
+    ]);
+    const res = await runInit({ gh, cwd, log: noop, args: parseArgs(['--skip-doctor']) });
+    expect(res.ok).toBe(true);
+
+    await expect(readdir(join(cwd, 'docs'))).resolves.toEqual(['architecture']);
+    expect(await readFile(join(cwd, 'docs', 'architecture', 'overview.md'), 'utf8')).toBe('# their own layout\n');
+    await expect(readFile(join(cwd, 'docs', 'README.md'), 'utf8')).rejects.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
- `forge:init`'s fresh-scaffold path wrote `conventions.specsDir`/`plansDir` as config values but never created the directories, and this repo's own `docs/README.md` route-index convention was never shipped as a template or documented as a rule for consumer projects.
- Ships `plugin/templates/docs-readme.md`, mirroring this repo's own route index (header line + Specs/Plans/Spikes/Design specs/Decisions/Guides section headers), title substituted via `{{PROJECT}}` the same way `verify.yml` substitutes `{{VERIFY}}`.
- `forge:init` seeds `docs/{specs,plans,spikes,design,decisions,guides}/` + the route-index file — **fresh mode only**, and only when `docs/` isn't already on disk. Adopt mode never runs the check at all. A non-ENOENT `readdir` failure (e.g. permissions) degrades to a skip message rather than ever risking treating a real `docs/` as absent.
- Documents the convention as a named rule: new "Docs structure — the route-index convention" section in `docs/guides/install.md`, one line per folder.

## Acceptance criteria
- [x] AC.1 — fresh `forge:init` (empty repo, no existing `docs/`) ends up with the seeded `docs/` structure + route-index file. Adopt on a repo with an existing `docs/` (any layout) is left completely untouched — verified for: adopt-mode-docs-absent, adopt-mode-with-own-layout, and the fresh-mode edge case where `docs/` predates `forge.json`.
- [x] AC.2 — the convention is documented as a named, readable rule in `docs/guides/install.md` (not just inferable from forge's own repo).
- [x] AC.3 — `docsync.mjs` is untouched; still gracefully skips when `docs/README.md` is absent.
- [x] AC.4 — test coverage for both fresh-seeds and adopt-never-clobbers paths, mirroring the existing fresh-vs-adopt patterns in `tests/init.test.mjs` (4 new tests, plus `freshRoutes()` hoisted to module scope for reuse).

## Verification (honest notes)
- `pnpm verify` (vitest run, full suite): **750/750 passed**.
- Gates: `plandrift` clean (plan doc `docs/plans/2026-08-06-389-scaffold-docs-structure.md`), `testintent` clean, `depguard` clean (no new deps), `docsync` clean (62 docs indexed).
- Reviewer pass caught a real bug pre-merge: the initial `hasDocs` check swallowed *any* `readdir` error (not just `ENOENT`), which on a non-ENOENT failure (e.g. EACCES) would have fallen through to an unconditional `writeFile` — the exact clobbering risk this ticket exists to prevent. Fixed to narrow to `ENOENT` only, wrapped the whole step in try/catch (mirrors the neighboring CI-template step), and added a regression test that forces a non-ENOENT `readdir` failure (`docs` exists as a plain file → `ENOTDIR`) to prove the fix.
- Security pass: clean — no path-traversal surface (all seeded paths are string literals), `{{PROJECT}}` substitution uses `repo.name` from `gh repo view` (GitHub-restricted charset, no injection surface into markdown-only output), no new dependencies, no secrets.

Closes #389