### PR TITLE
fix(mcp): board_status calls the shared runStatus instead of reimplementing it

### DIFF
--- a/docs/decisions/0007-cross-gai-mcp-first.md
+++ b/docs/decisions/0007-cross-gai-mcp-first.md
@@ -97,7 +97,7 @@ Proposed `forge-core` tools (beyond the 6 graph tools):
 | `board_comment` | `{ issue, phase:enum, body, actor?, session? }` | `{ ok, action }` | Trail law; `phase` enum validated |
 | `board_create` | `{ title, body?, type?, priority?, size?, area?, parent? }` | `{ ok, number, url }` | Caller needs the new number |
 | `board_escalate` | `{ issue, reason, options[>=2], recommend?, context? }` | `{ ok, id, boardNote, pending }` | The halt-and-ask spine |
-| `board_status` | `{ issue? }` | `{ ok, items[] }` | Read-model to reason over |
+| `board_status` | `{ issue? }` | `{ ok, items[], owner, repo, projectNumber, situation, counts, blocked[], inProgress[], openPrs[], next }` | The CLI's catch-up card (via `runStatus`, #399) plus the items[] read-model |
 | `gate_run` | `{ gate:enum(ac|dep|docsync|ground|plandrift|situation|testintent), ...args }` | `{ ok, level:pass\|fail, findings[] }` | Gates ARE decision points |
 | `release_readiness` | `{}` | `{ ok, items:[{name,level,msg}] }` | Checklist evaluated item-by-item |
 | `autopilot_select` | `{ area?, shape? }` | `{ ok, next\|null, queue[] }` | Picks next ticket; structured return is the point |

--- a/plugin/mcp/forge/server.mjs
+++ b/plugin/mcp/forge/server.mjs
@@ -30,6 +30,7 @@ import { runMove } from '../../scripts/board/move.mjs';
 import { runComment, PHASES } from '../../scripts/board/comment.mjs';
 import { runCreate, withDefaults } from '../../scripts/board/create.mjs';
 import { runEscalate } from '../../scripts/board/escalate.mjs';
+import { runStatus } from '../../scripts/board/status.mjs';
 import { selectNext, actionableQueue, normalize } from '../../scripts/autopilot/select.mjs';
 import { isShaped } from '../../scripts/autopilot/readiness.mjs';
 import { evaluateMergeBar, runMerge } from '../../scripts/autopilot/merge.mjs';
@@ -109,7 +110,7 @@ export const TOOLS = [
   },
   {
     name: 'board_status',
-    description: 'Board read-model: normalized items (number/title/status/priority/type/area), optionally filtered to one issue.',
+    description: 'The same catch-up card `forge board status` prints (situation, pending decisions, counts, blocked/in-progress, open PRs, next expected human action), plus normalized items[] (number/title/status/priority/type/area), optionally filtered to one issue.',
     inputSchema: { type: 'object', properties: { issue: { type: 'integer' } }, required: [] },
   },
   {
@@ -179,7 +180,7 @@ export const TOOLS = [
 
 /** Default engine bindings; injectable so each tool's contract is testable without live gh/git. */
 export const DEFAULT_DEPS = {
-  runMove, runComment, runCreate, runEscalate,
+  runMove, runComment, runCreate, runEscalate, runStatus,
   selectNext, actionableQueue, normalize, isShaped,
   evaluateMergeBar, runMerge, computeReadiness, loadConfig,
   execFn: run,
@@ -317,12 +318,20 @@ export function makeHandler({ root, getCtx, deps = DEFAULT_DEPS }) {
           });
 
         case 'board_status':
+          // #399: delegate the catch-up card (situation/counts/blocked/next) to the
+          // SAME runStatus the CLI (`forge board status`) uses, instead of a separate
+          // inline reimplementation — the two paths now compute identical data for the
+          // same board state. items[] (optionally filtered to one issue) stays a
+          // separate, additive read-model on top, unaffected by that computation.
           return board(id, async (ctx) => {
             const list = await ctx.listItems();
             if (!list.ok) return teach(id, list.error);
             let items = list.items.filter((i) => i.content?.number != null).map((i) => deps.normalize(ctx, i));
             if (args.issue != null) items = items.filter((t) => t.number === args.issue);
-            return toolText(id, { ok: true, items });
+            const status = await deps.runStatus(ctx, noop);
+            if (!status.ok) return teach(id, status.error);
+            const { owner, repo, projectNumber, situation, counts, blocked, inProgress, openPrs, next } = status.data;
+            return toolText(id, { ok: true, items, owner, repo, projectNumber, situation, counts, blocked, inProgress, openPrs, next });
           });
 
         case 'gate_run': {

--- a/plugin/scripts/board/status.mjs
+++ b/plugin/scripts/board/status.mjs
@@ -9,7 +9,14 @@ import { run, makeGh } from '../lib/exec.mjs';
 import { makeBoardCtx } from '../lib/boardctx.mjs';
 import { deriveSituation } from '../lib/situation.mjs';
 
-export async function runStatus(ctx, log = console.log) {
+/**
+ * The catch-up card's underlying data (#399): the same computation `runStatus`
+ * formats into CLI text, factored out so a non-CLI caller (the `board_status`
+ * MCP tool) can consume it as structured JSON instead of scraping/reimplementing
+ * a subset of this logic. Returns the same shape whether called from the CLI
+ * path or directly.
+ */
+export async function computeStatus(ctx) {
   const list = await ctx.listItems();
   if (!list.ok) return list;
   const items = list.items.filter((i) => i.content?.number != null);
@@ -21,26 +28,53 @@ export async function runStatus(ctx, log = console.log) {
     byKey.get(key).push(i);
   }
   const count = (k) => (byKey.get(k) ?? []).length;
-  const show = (i) => `#${i.content.number} ${i.title ?? i.content?.title ?? ''}`.trim();
+  // Deliberately NOT trimmed here (#399 review): the CLI text line trims the whole
+  // "#N title" substring as one unit (see `show` in runStatus below), which is not
+  // the same as trimming the title alone first — a title with leading whitespace
+  // would otherwise render with different internal spacing than before this split.
+  const summarize = (i) => ({ number: i.content.number, title: i.title ?? i.content?.title ?? '' });
 
   const prs = await ctx.gh(['pr', 'list', '--state', 'open', '--json', 'number,title,isDraft'], { parseJson: true });
-  const openPrs = prs.ok ? prs.json : [];
+  const openPrs = (prs.ok ? prs.json : []).map((p) => ({ number: p.number, title: p.title, isDraft: !!p.isDraft }));
+
+  const blocked = byKey.get('blocked') ?? [];
+  const inProgress = byKey.get('inProgress') ?? [];
+  const situation = await deriveSituation(ctx.cwd, { blocked: blocked.length, inProgress: inProgress.length });
+  const next = blocked.length ? 'answer the blocked decision(s)' : openPrs.length ? 'review/merge the open PR(s)' : inProgress.length ? 'continue the in-progress work' : 'pick the next ready/backlog item';
+
+  return {
+    ok: true,
+    owner: ctx.owner,
+    repo: ctx.repo,
+    projectNumber: ctx.projectNumber,
+    situation: { key: situation.key, glyph: situation.glyph, label: situation.label, pendingCount: situation.pendingCount, pending: situation.pending },
+    counts: { backlog: count('backlog'), ready: count('ready'), inProgress: inProgress.length, inReview: count('inReview'), blocked: blocked.length, done: count('done') },
+    blocked: blocked.map(summarize),
+    inProgress: inProgress.map(summarize),
+    openPrs,
+    next,
+  };
+}
+
+export async function runStatus(ctx, log = console.log) {
+  const data = await computeStatus(ctx);
+  if (!data.ok) return data;
 
   const lines = [];
-  lines.push(`forge status — ${ctx.owner}/${ctx.repo} · board #${ctx.projectNumber}`);
-  const blocked = byKey.get('blocked') ?? [];
-  const situation = await deriveSituation(ctx.cwd, { blocked: blocked.length, inProgress: count('inProgress') });
+  lines.push(`forge status — ${data.owner}/${data.repo} · board #${data.projectNumber}`);
+  const { situation, counts, blocked, inProgress, openPrs, next } = data;
+  const show = (i) => `#${i.number} ${i.title}`.trim(); // matches the original show(item) exactly
   lines.push(`situation: ${situation.glyph} ${situation.label}${situation.pendingCount ? ` (${situation.pendingCount} pending decision${situation.pendingCount > 1 ? 's' : ''})` : ''}`);
   for (const d of situation.pending) lines.push(`  🚩 decision pending: #${d.issue} — ${d.reason} (${d.id})`);
-  lines.push(`counts: backlog ${count('backlog')} · ready ${count('ready')} · in-progress ${count('inProgress')} · in-review ${count('inReview')} · blocked ${blocked.length} · done ${count('done')}`);
+  lines.push(`counts: backlog ${counts.backlog} · ready ${counts.ready} · in-progress ${counts.inProgress} · in-review ${counts.inReview} · blocked ${counts.blocked} · done ${counts.done}`);
   for (const b of blocked) lines.push(`  🚩 blocked: ${show(b)}`);
-  for (const w of byKey.get('inProgress') ?? []) lines.push(`  ▶ in progress: ${show(w)}`);
+  for (const w of inProgress) lines.push(`  ▶ in progress: ${show(w)}`);
   for (const p of openPrs) lines.push(`  ⇡ open PR: #${p.number} ${p.title}${p.isDraft ? ' (draft)' : ''}`);
-  lines.push(`next: ${blocked.length ? 'answer the blocked decision(s)' : openPrs.length ? 'review/merge the open PR(s)' : count('inProgress') ? 'continue the in-progress work' : 'pick the next ready/backlog item'}`);
+  lines.push(`next: ${next}`);
 
   const text = lines.join('\n');
   log(text);
-  return { ok: true, text };
+  return { ok: true, text, data };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -916,4 +916,42 @@ describe('status (AC-2.6)', () => {
     expect(res.text).toContain('⇡ open PR: #17');
     expect(res.text).toContain('next: answer the blocked decision(s)');
   });
+
+  it('AC-399.1: also returns the same catch-up card as structured data (for MCP callers)', async () => {
+    const { ctx } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([
+        { id: 'a', content: { number: 1 }, title: 'One', status: 'Done' },
+        { id: 'b', content: { number: 2 }, title: 'Two', status: 'In progress' },
+        { id: 'c', content: { number: 3 }, title: 'Three', status: 'Blocked / Needs decision' },
+      ])],
+      ['pr list', { stdout: JSON.stringify([{ number: 17, title: 'feat: x', isDraft: false }]) }],
+    ]);
+    const res = await runStatus(ctx, noop);
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({
+      situation: { key: 'awaiting-decision', glyph: '🚩', label: 'awaiting-decision', pendingCount: 1 },
+      counts: { backlog: 0, ready: 0, inProgress: 1, inReview: 0, blocked: 1, done: 1 },
+      blocked: [{ number: 3, title: 'Three' }],
+      inProgress: [{ number: 2, title: 'Two' }],
+      openPrs: [{ number: 17, title: 'feat: x', isDraft: false }],
+      next: 'answer the blocked decision(s)',
+    });
+  });
+
+  it('AC-399.1: a title with leading whitespace renders identically to before the computeStatus split (#399 review)', async () => {
+    // Regression pin: the CLI's old `show(item)` trimmed the WHOLE "#N title" string as
+    // one unit, so a title with its own leading space keeps the resulting double space
+    // (`#3  Foo`) rather than collapsing to a single space. The data/text split must not
+    // change this — data.blocked[].title stays untrimmed so the CLI text line is unchanged.
+    const { ctx } = await ctxWith([
+      [(j) => j.startsWith('project item-list'), itemList([
+        { id: 'c', content: { number: 3 }, title: ' Foo', status: 'Blocked / Needs decision' },
+      ])],
+      ['pr list', { stdout: JSON.stringify([]) }],
+    ]);
+    const res = await runStatus(ctx, noop);
+    expect(res.ok).toBe(true);
+    expect(res.text).toContain('🚩 blocked: #3  Foo'); // two spaces, same as the pre-split behavior
+    expect(res.data.blocked).toEqual([{ number: 3, title: ' Foo' }]); // raw title in the data
+  });
 });

--- a/tests/mcp-forge/forge-core.test.mjs
+++ b/tests/mcp-forge/forge-core.test.mjs
@@ -2,15 +2,24 @@ import { describe, it, expect } from 'vitest';
 import { makeHandler, makeCtxResolver, TOOLS, GATE_NAMES, DEFAULT_DEPS } from '../../plugin/mcp/forge/server.mjs';
 import { validateInput, canonicalize } from '../../plugin/mcp/lib/rpc.mjs';
 import { validateInput as graphValidate, canonicalize as graphCanon } from '../../plugin/mcp/graph/server.mjs';
+import { runStatus } from '../../plugin/scripts/board/status.mjs';
+import { optionKey } from '../../plugin/scripts/lib/board.mjs';
 
 // ---- harness -------------------------------------------------------------
+// board_status now delegates to runStatus (#399), which needs cwd (journal/decisions
+// lookup — a nonexistent path reads as empty, i.e. no pending decisions) and
+// itemFieldKey (status bucketing); gh() branches so 'pr list' gets an array while every
+// other call keeps the pre-existing generic {body} stub other tests rely on.
 const okCtx = {
   ok: true,
   owner: 'dngioidev',
   repo: 'forge',
+  projectNumber: 8,
+  cwd: '/repo',
   config: {},
-  gh: async () => ({ ok: true, json: { body: '## Acceptance criteria\n- AC' } }),
+  gh: async (a) => (a[0] === 'pr' && a[1] === 'list' ? { ok: true, json: [] } : { ok: true, json: { body: '## Acceptance criteria\n- AC' } }),
   listItems: async () => ({ ok: true, items: [] }),
+  itemFieldKey: (item, fieldKey) => { const name = item?.[fieldKey]; return typeof name === 'string' ? optionKey(name) : null; },
 };
 
 function build({ deps = {}, getCtx = async () => okCtx, root = '/repo' } = {}) {
@@ -89,15 +98,18 @@ describe('AC-288.2: every tool is callable and returns its documented structured
     expect(seen.options).toEqual(['legit', 'a|b|c|d|e|f']); // still 2 options, not 7
   });
 
-  it('AC-288.2: board_status -> {ok,items[]} filtered by issue', async () => {
+  it('AC-288.2: board_status -> {ok,items[],...catch-up card} filtered by issue', async () => {
     const items = [
       { content: { number: 1 }, title: 'one' },
       { content: { number: 2 }, title: 'two' },
     ];
     const ctx = { ...okCtx, listItems: async () => ({ ok: true, items }) };
     const h = build({ getCtx: async () => ctx, deps: { normalize: (_c, i) => ({ number: i.content.number, title: i.title }) } });
-    expect(body(await call(h, 'board_status', {})).items).toHaveLength(2);
+    const out = body(await call(h, 'board_status', {}));
+    expect(out.items).toHaveLength(2);
     expect(body(await call(h, 'board_status', { issue: 2 })).items).toEqual([{ number: 2, title: 'two' }]);
+    // #399: the catch-up card (same fields runStatus/the CLI compute) rides along.
+    expect(out).toMatchObject({ ok: true, counts: { backlog: 0, ready: 0, inProgress: 0, inReview: 0, blocked: 0, done: 0 }, next: 'pick the next ready/backlog item' });
   });
 
   it('AC-288.2: gate_run situation -> {ok,level:pass,findings[]}', async () => {
@@ -373,6 +385,44 @@ describe('AC-296.3: release_readiness teaches on a missing/broken forge.json ins
       computeReadiness: async () => ({ ok: true, items: [{ name: 'branch', level: 'pass', msg: 'on main' }] }),
     } });
     expect(body(await call(h, 'release_readiness', {}))).toEqual({ ok: true, items: [{ name: 'branch', level: 'pass', msg: 'on main' }] });
+  });
+});
+
+// =========================================================================
+describe('AC-399.1: board_status (MCP) and board/status.mjs (CLI) return equivalent data', () => {
+  it('AC-399.1: the same mocked board yields the same catch-up card from both paths (via the shared runStatus)', async () => {
+    const items = [
+      { content: { number: 1 }, title: 'One', status: 'Done' },
+      { content: { number: 2 }, title: 'Two', status: 'In progress' },
+      { content: { number: 3 }, title: 'Three', status: 'Blocked / Needs decision' },
+    ];
+    const ctx = {
+      ...okCtx,
+      listItems: async () => ({ ok: true, items }),
+      gh: async (a) => (a[0] === 'pr' && a[1] === 'list'
+        ? { ok: true, json: [{ number: 17, title: 'feat: x', isDraft: false }] }
+        : { ok: true, json: { body: '' } }),
+    };
+
+    // CLI path: runStatus directly (what `forge board status` calls).
+    const cli = await runStatus(ctx, () => {});
+    expect(cli.ok).toBe(true);
+
+    // MCP path: the board_status tool, over the identical ctx/board state.
+    const h = build({ getCtx: async () => ctx, deps: { normalize: (_c, i) => ({ number: i.content.number, title: i.title }) } });
+    const mcp = body(await call(h, 'board_status', {}));
+    expect(mcp.ok).toBe(true);
+
+    // Both compute the catch-up card via the same runStatus — assert the data matches.
+    expect(mcp.situation).toEqual(cli.data.situation);
+    expect(mcp.counts).toEqual(cli.data.counts);
+    expect(mcp.blocked).toEqual(cli.data.blocked);
+    expect(mcp.inProgress).toEqual(cli.data.inProgress);
+    expect(mcp.openPrs).toEqual(cli.data.openPrs);
+    expect(mcp.next).toEqual(cli.data.next);
+    // Sanity: this is the actual "less useful answer" the ticket describes fixed.
+    expect(mcp.next).toBe('answer the blocked decision(s)');
+    expect(mcp.blocked).toEqual([{ number: 3, title: 'Three' }]);
   });
 });
 


### PR DESCRIPTION
Closes #399

## Problem
`board_status` in `plugin/mcp/forge/server.mjs` reimplemented a subset of `plugin/scripts/board/status.mjs`'s `runStatus` inline as a flat, un-summarized `items[]` list — it never computed the "catch-up card" (situation, pending decisions, counts, blocked/in-progress, next expected human action) that `runStatus` computes and that `forge board status` (CLI) / `docs/guides/handbook.md` document as the tool's whole point. A host calling `board_status` via MCP (e.g. Antigravity per ADR-0007) got a materially different, less useful answer than the CLI for the identical board state.

## Fix
- `plugin/scripts/board/status.mjs`: split `runStatus` into `computeStatus(ctx)` (returns the catch-up card as structured JSON: `situation`, `counts`, `blocked[]`, `inProgress[]`, `openPrs[]`, `next`) and `runStatus(ctx, log)` (formats the exact same CLI text from that data, now also returning it as `data`).
- `plugin/mcp/forge/server.mjs`: `board_status` now calls the same `deps.runStatus` (added to `DEFAULT_DEPS`, injectable in tests like every other tool) and merges its `data` into the MCP response, alongside the pre-existing normalized/issue-filtered `items[]` (kept — it's a documented ADR-0007 contract and a different, still-useful capability, not the reimplementation the ticket flagged).
- `docs/decisions/0007-cross-gai-mcp-first.md`: updated the `board_status` return-shape row to match.

## Acceptance criteria
- **AC.1** — new test `AC-399.1` in `tests/mcp-forge/forge-core.test.mjs` calls both the MCP tool and `runStatus` directly against the identical mocked ctx/board state and asserts `situation`/`counts`/`blocked`/`inProgress`/`openPrs`/`next` match exactly.
- **AC.2** — `runStatus`'s CLI text output is unchanged: existing `tests/board.test.mjs` status test still passes verbatim, plus a new regression-pin test for a title-with-leading-whitespace edge case caught in review (the `computeStatus`/`runStatus` split must not collapse internal spacing that the original single-string `.trim()` preserved).
- **AC.3** — full `pnpm verify` is green (759/759 tests, 59 files).

## Verification
- Ran the full suite twice (before and after a review-driven fix) — green both times.
- `testintent`, `depguard`, `docsync` gates: clean.
- `plandrift`: not applicable — this is a direct, scoped fix with no `docs/plans/**` plan file (small code-reuse bug fix, not planned via `forge:plan`).
- Reviewer pass: found one real medium-severity issue (title-trim edge case changing CLI text spacing) — fixed and pinned with a regression test; two low-severity doc/description nits — fixed.
- Security pass: no new attack surface, no leak beyond what's already reachable via the CLI/existing escalate mechanics, no fail-open regression. Verdict: pass, zero findings.
- NOT independently verified: live MCP transport round-trip against a real GitHub board (tests use mocked ctx, consistent with the rest of this test file's pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)