### PR TITLE
docs(readme): annotate removed forge-control/console lines in route index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 ## Specs
 
 - [Platform design spec](specs/2026-07-15-forge-platform-design.md) — the whole platform: pipeline skills, agent roster + backends, board automation, team model, escalation, learning loop, graph RAG, console. Start here.
-- [forge-control spec](specs/2026-07-18-forge-control.md) — local agent management & control plane (SP9b local-first): orchestration mechanics, guardrails, epics C1–C5 on board #12.
+- [forge-control spec](specs/2026-07-18-forge-control.md) — *(removed, see ADR-0003)* local agent management & control plane (SP9b local-first): orchestration mechanics, guardrails, epics C1–C5 on board #12.
 - [forge:autopilot spec](specs/2026-07-21-forge-autopilot.md) — continuous autonomous board-clearing engine (epic #125, v0.9.0): the loop, selection order, the auto-merge bar that replaces the human PR gate, the only-pauses escalation model, run ledger + safety rails.
 - [autopilot crazy mode spec](specs/2026-07-21-forge-autopilot-crazy-mode.md) — autonomous backlog shaping (epic #139): the `--shape` front door, `forge:shape`, the grounded-only boundary + ground gate, front-of-pipeline routing (ideate/brainstorm/spike/design).
 
@@ -21,19 +21,19 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [SP6 — Front of pipeline](plans/2026-07-17-sp6-ideate-brainstorm-spike-design.md) — tasks T1–T6 for epic #8: ideate/brainstorm/spike/design skills, visual-spec template + lint.
 - [SP7 — Learning loop](plans/2026-07-17-sp7-learning-loop.md) — tasks T1–T6 for epic #9: capture hooks, /distill skill + mechanics, digest flow metrics.
 - [SP8 — Graph RAG MCP](plans/2026-07-17-sp8-graph-rag.md) — tasks T1–T7 for epic #10: SQLite structural index, ts-morph indexer, MCP stdio tools, incremental reindex + ticket edges.
-- [SP9a — Console daemon](plans/2026-07-17-sp9a-console-daemon.md) — tasks T1–T6 for epic #11: collectors, metadata-only sanitizer, file/Firestore transports, daemon once/watch + decision write-back.
+- [SP9a — Console daemon](plans/2026-07-17-sp9a-console-daemon.md) — *(removed, see ADR-0003)* tasks T1–T6 for epic #11: collectors, metadata-only sanitizer, file/Firestore transports, daemon once/watch + decision write-back.
 - [SP10 — Hotfix + respond](plans/2026-07-17-sp10-hotfix-respond.md) — tasks T1–T6 for epic #13: incident mechanics, situation gate, backend freeze, hotfix/respond skills, rollback + data-recovery runbooks.
 - [SP11 — Maintain](plans/2026-07-17-sp11-maintain.md) — tasks T1–T5 for epic #14: outdated scan, patch/minor batch plan, majors bundled, CVE triage with SLA.
-- [Local web console](plans/2026-07-17-local-web-console.md) — tasks T1–T4 for #37: localhost serve, state + decide APIs, self-contained page.
-- [Console UI v2](plans/2026-07-17-console-ui-v2.md) — tasks T1–T5 for #39: decision-flow defect fixes, a11y floor, identity variants + owner pick.
-- [C1 — Control queue](plans/2026-07-18-c1-control-queue.md) — control queue + machine registry + CLI (forge-control epic; see the forge-control spec).
-- [C2 — Control runner](plans/2026-07-19-c2-control-runner.md) — the forge-control runner that spawns + supervises headless sessions.
-- [C3 — Console control tab](plans/2026-07-19-c3-console-control-tab.md) — the console's control tab: sessions, queue, command audit.
-- [C4 — situationgate paused flag](plans/2026-07-19-c4-situationgate-paused.md) — situationgate reads the machine-level paused flag (global kill switch).
-- [C5 — Dogfood end-to-end](plans/2026-07-19-c5-dogfood-end-to-end.md) — one real ticket end-to-end through the control queue.
-- [C6 — Trace + conformance](plans/2026-07-19-c6-trace-conformance.md) — agent-work trace + structure-conformance badge.
-- [C7 — Alerts](plans/2026-07-19-c7-alerts.md) — alerts on session/queue events.
-- [C8 — Quota panel](plans/2026-07-19-c8-quota-panel.md) — Claude Code quota panel in the console.
+- [Local web console](plans/2026-07-17-local-web-console.md) — *(removed, see ADR-0003)* tasks T1–T4 for #37: localhost serve, state + decide APIs, self-contained page.
+- [Console UI v2](plans/2026-07-17-console-ui-v2.md) — *(removed, see ADR-0003)* tasks T1–T5 for #39: decision-flow defect fixes, a11y floor, identity variants + owner pick.
+- [C1 — Control queue](plans/2026-07-18-c1-control-queue.md) — *(removed, see ADR-0003)* control queue + machine registry + CLI (forge-control epic; see the forge-control spec).
+- [C2 — Control runner](plans/2026-07-19-c2-control-runner.md) — *(removed, see ADR-0003)* the forge-control runner that spawns + supervises headless sessions.
+- [C3 — Console control tab](plans/2026-07-19-c3-console-control-tab.md) — *(removed, see ADR-0003)* the console's control tab: sessions, queue, command audit.
+- [C4 — situationgate paused flag](plans/2026-07-19-c4-situationgate-paused.md) — *(removed, see ADR-0003)* situationgate reads the machine-level paused flag (global kill switch).
+- [C5 — Dogfood end-to-end](plans/2026-07-19-c5-dogfood-end-to-end.md) — *(removed, see ADR-0003)* one real ticket end-to-end through the control queue.
+- [C6 — Trace + conformance](plans/2026-07-19-c6-trace-conformance.md) — *(removed, see ADR-0003)* agent-work trace + structure-conformance badge.
+- [C7 — Alerts](plans/2026-07-19-c7-alerts.md) — *(removed, see ADR-0003)* alerts on session/queue events.
+- [C8 — Quota panel](plans/2026-07-19-c8-quota-panel.md) — *(removed, see ADR-0003)* Claude Code quota panel in the console.
 - [Batch close](plans/2026-07-20-batch-close.md) — tasks for #123: comma-separated `--issue` in `board/close.mjs`.
 - [#289 — agy init emit](plans/2026-07-26-289-agy-init-emit.md) — tasks for #289 (ADR-0007 AC3): `forge init --host agy` emits the proven agy plugin package (co-located `plugin.json`, generated `mcp_config.json` + `hooks.json`, deny/capture shims, short-path staging).
 - [#307 — agy emit relocatable](plans/2026-08-04-307-agy-emit-relocatable.md) — tasks for #307 (epic #174): emit plugin-root-relative paths in `mcp_config.json` + `hooks.json` so the package survives `agy plugin install` (copy) and deletion of the `--out` dir.


### PR DESCRIPTION
## Summary
`docs/README.md`'s Specs and Plans sections listed the forge-control/console system's docs (forge-control spec, SP9a console daemon, local web console, console UI v2, C1-C8) with no removal signal — identical formatting to genuinely live specs. The only indication these were removed is 50+ lines away in the unrelated Decisions section (ADR-0003, #95).

## Fix
Added a `*(removed, see ADR-0003)*` marker to every Specs/Plans line describing a component ADR-0003 removed: the forge-control spec line, SP9a console daemon, local web console, console UI v2, and each of C1-C8. No other content changed — historical doc files under `docs/specs`, `docs/plans`, `docs/decisions` are untouched, and non-removed lines are untouched (12 lines annotated total).

Closes #401

## Acceptance criteria
- [x] AC.1 every Specs/Plans line describing a component ADR-0003 removed carries a visible "(removed, see ADR-0003)" marker — verified all 12 lines (forge-control spec, SP9a, local web console, console UI v2, C1-C8).
- [x] AC.2 no other content changes — `git diff main --stat` shows only `docs/README.md` touched; historical docs and the 3 other Specs lines untouched.
- [x] AC.3 docsync stays clean — `node plugin/scripts/gates/docsync.mjs` → "doc-sync: clean (64 docs indexed)".

## Verification notes
- `pnpm verify`: 759/759 tests passed, 59 files.
- `docsync.mjs`: clean.
- Reviewer pass: no findings — confirmed the 12-line annotation set matches ADR-0003's removed-component list exactly, marker wording consistent, no other lines touched.
- Security pass: pass — docs-only, no secrets/injection/link changes.
- Scope note: line 55 (Design specs section, "Console — heat identity") is deliberately out of scope per the ticket text, which restricts this fix to the Specs/Plans sections only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SATRHKa6mDHDuirhP6QuwL