### PR TITLE
feat(mcp): expose receipt/log/digest/reparent/close as forge-core MCP tools

### DIFF
--- a/docs/guides/cross-gai.md
+++ b/docs/guides/cross-gai.md
@@ -152,10 +152,11 @@ were declared only in `plugin.json`. agy reads a sibling plugin-root
   it on your build with `agy plugin validate forge` after install; the in-place
   discovery flow avoids the question entirely. Live confirmation lands with the
   #290 dogfood.
-- `forge-graph` is always registered. `forge-core` (the 9-tool board/gate/
-  autopilot server from [#288](https://github.com/dngioidev/forge/issues/288)) is
-  registered **only when its server file exists** in the source — the emitter
-  guards on `mcp/forge/server.mjs` being present. Since #288 merged, a fresh emit
+- `forge-graph` is always registered. `forge-core` (the 15-tool board/gate/
+  autopilot server from [#288](https://github.com/dngioidev/forge/issues/288),
+  [#400](https://github.com/dngioidev/forge/issues/400)) is registered **only
+  when its server file exists** in the source — the emitter guards on
+  `mcp/forge/server.mjs` being present. Since #288 merged, a fresh emit
   registers both.
 - Note that agy's plugin MCP config has **no `httpUrl` / `timeout`** support and
   buggy env-expansion; both forge servers are plain stdio (`command`/`args`),
@@ -166,6 +167,43 @@ agent has a `run_command` tool, so the entire `forge <area> <cmd>` shell tier
 runs on agy without MCP at all. `forge-core` exists so board/gate/autopilot
 branching gets typed returns (pass/fail, the merge-bar vector) instead of
 stdout-scraping.
+
+### Tool usage reference (15 tools: forge-core 9 + forge-graph 6)
+
+One line each — what it does, and when a host calls it. Full schemas live in
+each server's `TOOLS` export ([`plugin/mcp/forge/server.mjs`](../../plugin/mcp/forge/server.mjs),
+[`plugin/mcp/graph/server.mjs`](../../plugin/mcp/graph/server.mjs)).
+
+**forge-core** (board/gate/release/autopilot — typed returns over `scripts/*.mjs`):
+
+| Tool | Does | Call it when |
+| --- | --- | --- |
+| `board_move` | Moves a ticket to a board status; reports whether it changed and re-verified. | The ticket needs to change lifecycle column (e.g. ready -> inProgress). |
+| `board_comment` | Posts an idempotent ticket-trail comment for a lifecycle phase. | Every trail milestone (started/plan/pr/ci-green/...) — never re-narrate, just call it. |
+| `board_create` | Creates (or resumes) a ticket with board item + fields. | New work is identified and needs a ticket before it can be picked up. |
+| `board_escalate` | Blocks a ticket, posts a decision comment with >=2 options, writes a pending decision. | Genuinely blocked on a human call — the halt-and-ask spine. |
+| `board_status` | Returns the same catch-up card as `forge board status`, plus normalized items[]. | Resuming work, or a host needs the current board picture / next action. |
+| `board_receipt` | Posts/updates the idempotent merge receipt on an issue for a PR (#400). | A PR that closes an issue has merged — record the receipt on that issue. |
+| `board_log` | Posts/updates one delivery-log row on the pinned delivery-log issue (#400). | A PR merged and the delivery log needs its one-line row. |
+| `board_digest` | Refreshes an epic's managed digest block (child table + flow metrics) (#400). | An epic's children changed state and its summary needs to reflect that. |
+| `board_reparent` | Moves a sub-issue to a different parent epic (#400). | A ticket was filed under the wrong epic and needs restructuring. |
+| `board_close` | Closes an issue for a special reason (completed/not-planned/etc.) and reflects it on the board (#400). | Closing something that isn't a normal "done" move — duplicate, superseded, won't do. |
+| `gate_run` | Runs one mechanical gate (ac/conventions/dep/docsync/ground/license/plandrift/situation/testintent) and returns its pass/fail verdict. | Before shipping, or whenever a specific gate's verdict is needed programmatically. |
+| `release_readiness` | Evaluates the release-readiness checklist item-by-item. | Deciding whether the repo is safe to cut a release. |
+| `autopilot_select` | Picks the next actionable ticket and the ordered queue (read-only). | Autopilot (or a host driving it) needs to know what to work on next. |
+| `autopilot_merge_bar` | Computes the {merge, blockedOn} vector from a signal set — pure, no side effect. | A host wants to know if a PR *would* pass the merge bar without merging it. |
+| `autopilot_merge` | Executes the gated live merge — the single sanctioned auto-merge path (Claude-only by policy). | All signals are believed green and the PR should actually be squash-merged now. |
+
+**forge-graph** (read-only code-graph RAG over `plugin/mcp/graph/queries.mjs`; requires `features.graph`):
+
+| Tool | Does | Call it when |
+| --- | --- | --- |
+| `find_component` | Finds components/exports by name substring. | Before writing anything new — check whether it already exists. |
+| `who_uses` | Finds who renders/imports a symbol or uses a token. | Assessing the impact of touching a symbol/token before changing it. |
+| `similar_props` | Ranks props interfaces by member overlap. | Looking for a near-duplicate interface to reuse instead of adding a new one. |
+| `blast_radius` | Finds transitive dependents (files, tests, stories) of a set of files. | Deciding the test set for a change. |
+| `code_for_ticket` | Finds files linked to a ticket via commit-message issue refs. | Picking up a ticket and needing to know what code it previously touched. |
+| `reuse_candidates` | Ranks existing exports/components against a feature description. | Before creating new files — check for reuse candidates first. |
 
 ---
 
@@ -363,4 +401,4 @@ parallel subagent fan-out, and slash-command UX. The only differences are:
 - [0007-agy-adapter reference](../decisions/0007-agy-adapter/README.md) — the
   verified-working spike output the emitter productizes.
 - `plugin/scripts/agy/emit.mjs` — the `forge init --host agy` emitter (#289).
-- `plugin/mcp/forge/server.mjs` — the `forge-core` MCP server, 9 tools (#288).
+- `plugin/mcp/forge/server.mjs` — the `forge-core` MCP server, 15 tools (#288, #400).

--- a/docs/guides/cross-gai.md
+++ b/docs/guides/cross-gai.md
@@ -168,7 +168,7 @@ runs on agy without MCP at all. `forge-core` exists so board/gate/autopilot
 branching gets typed returns (pass/fail, the merge-bar vector) instead of
 stdout-scraping.
 
-### Tool usage reference (15 tools: forge-core 9 + forge-graph 6)
+### Tool usage reference (21 tools: forge-core 15 + forge-graph 6)
 
 One line each — what it does, and when a host calls it. Full schemas live in
 each server's `TOOLS` export ([`plugin/mcp/forge/server.mjs`](../../plugin/mcp/forge/server.mjs),

--- a/plugin/mcp/forge/server.mjs
+++ b/plugin/mcp/forge/server.mjs
@@ -31,6 +31,11 @@ import { runComment, PHASES } from '../../scripts/board/comment.mjs';
 import { runCreate, withDefaults } from '../../scripts/board/create.mjs';
 import { runEscalate } from '../../scripts/board/escalate.mjs';
 import { runStatus } from '../../scripts/board/status.mjs';
+import { runReceipt } from '../../scripts/board/receipt.mjs';
+import { runLog } from '../../scripts/board/log.mjs';
+import { runDigest } from '../../scripts/board/digest.mjs';
+import { runReparent } from '../../scripts/board/reparent.mjs';
+import { runClose, REASONS as CLOSE_REASONS } from '../../scripts/board/close.mjs';
 import { selectNext, actionableQueue, normalize } from '../../scripts/autopilot/select.mjs';
 import { isShaped } from '../../scripts/autopilot/readiness.mjs';
 import { evaluateMergeBar, runMerge } from '../../scripts/autopilot/merge.mjs';
@@ -114,6 +119,66 @@ export const TOOLS = [
     inputSchema: { type: 'object', properties: { issue: { type: 'integer' } }, required: [] },
   },
   {
+    name: 'board_receipt',
+    description: 'Post/update the idempotent merge receipt on an issue for a given PR (marker receipt:pr-<n>); returns whether the comment was created or updated.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        issue: { type: 'integer' },
+        pr: { type: 'integer' },
+        sha: { type: 'string' },
+        title: { type: 'string' },
+      },
+      required: ['issue', 'pr'],
+    },
+  },
+  {
+    name: 'board_log',
+    description: 'Post/update one delivery-log row (marker log:pr-<n>) on the pinned delivery-log issue (board.deliveryLogIssue); returns whether the row was created or updated.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pr: { type: 'integer' },
+        sha: { type: 'string' },
+        title: { type: 'string' },
+        issues: { type: 'string' },
+        date: { type: 'string' },
+      },
+      required: ['pr'],
+    },
+  },
+  {
+    name: 'board_digest',
+    description: "Refresh an epic's managed digest block (blocked-first child table + flow metrics) from the current board + journal state; returns whether it changed and the child count.",
+    inputSchema: {
+      type: 'object',
+      properties: { epic: { type: 'integer' } },
+      required: ['epic'],
+    },
+  },
+  {
+    name: 'board_reparent',
+    description: 'Move a sub-issue to a different parent epic (addSubIssue with replaceParent); idempotent no-op if the issue is already under that parent.',
+    inputSchema: {
+      type: 'object',
+      properties: { issue: { type: 'integer' }, parent: { type: 'integer' } },
+      required: ['issue', 'parent'],
+    },
+  },
+  {
+    name: 'board_close',
+    description: "Close an issue for a special reason (completed/not-planned/not-needed/superseded/duplicate), reflect it on the board honestly (done vs Won't do), and post a trail:closed note. Idempotent on an already-closed issue.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        issue: { type: 'integer' },
+        reason: { type: 'string', enum: Object.keys(CLOSE_REASONS) },
+        note: { type: 'string' },
+      },
+      required: ['issue', 'reason'],
+    },
+  },
+  {
     name: 'gate_run',
     description: 'Run one mechanical gate and return its verdict as {level:pass|fail, findings[]}. gate is one of ac|conventions|dep|docsync|ground|license|plandrift|situation|testintent.',
     inputSchema: {
@@ -181,6 +246,7 @@ export const TOOLS = [
 /** Default engine bindings; injectable so each tool's contract is testable without live gh/git. */
 export const DEFAULT_DEPS = {
   runMove, runComment, runCreate, runEscalate, runStatus,
+  runReceipt, runLog, runDigest, runReparent, runClose,
   selectNext, actionableQueue, normalize, isShaped,
   evaluateMergeBar, runMerge, computeReadiness, loadConfig,
   execFn: run,
@@ -332,6 +398,44 @@ export function makeHandler({ root, getCtx, deps = DEFAULT_DEPS }) {
             if (!status.ok) return teach(id, status.error);
             const { owner, repo, projectNumber, situation, counts, blocked, inProgress, openPrs, next } = status.data;
             return toolText(id, { ok: true, items, owner, repo, projectNumber, situation, counts, blocked, inProgress, openPrs, next });
+          });
+
+        case 'board_receipt':
+          return board(id, async (ctx) => {
+            const r = await deps.runReceipt(ctx, { issue: args.issue, pr: args.pr, sha: args.sha ?? null, title: args.title ?? '' }, noop);
+            if (!r.ok) return teach(id, r.error);
+            return toolText(id, { ok: true, action: r.action, id: r.id ?? null });
+          });
+
+        case 'board_log':
+          return board(id, async (ctx) => {
+            const r = await deps.runLog(ctx, { pr: args.pr, sha: args.sha ?? null, title: args.title ?? '', issues: args.issues ?? '', date: args.date ?? null }, noop);
+            if (!r.ok) return teach(id, r.error);
+            return toolText(id, { ok: true, action: r.action, id: r.id ?? null });
+          });
+
+        case 'board_digest':
+          return board(id, async (ctx) => {
+            const r = await deps.runDigest(ctx, { epic: args.epic }, noop);
+            if (!r.ok) return teach(id, r.error);
+            return toolText(id, { ok: true, changed: r.changed, rows: r.rows });
+          });
+
+        case 'board_reparent':
+          // runReparent's signature is (gh, owner, repo, args, log) rather than ctx-first
+          // like the other board tools (#87 predates boardctx.mjs's ctx shape) — destructure
+          // the same gh/owner/repo the resolved ctx already carries so no new logic is added.
+          return board(id, async (ctx) => {
+            const r = await deps.runReparent(ctx.gh, ctx.owner, ctx.repo, { issue: args.issue, parent: args.parent }, noop);
+            if (!r.ok) return teach(id, r.error);
+            return toolText(id, { ok: true, moved: r.moved, from: r.from ?? null, to: r.to ?? null });
+          });
+
+        case 'board_close':
+          return board(id, async (ctx) => {
+            const r = await deps.runClose(ctx, { issue: args.issue, reason: args.reason, note: args.note ?? null }, noop);
+            if (!r.ok) return teach(id, r.error);
+            return toolText(id, { ok: true, issue: r.issue, reason: r.reason, status: r.status });
           });
 
         case 'gate_run': {

--- a/tests/mcp-forge/forge-core.test.mjs
+++ b/tests/mcp-forge/forge-core.test.mjs
@@ -44,7 +44,12 @@ describe('AC-288.1: rpc.mjs is the shared transport (forge-graph regression-free
     expect(init.result.serverInfo.name).toBe('forge-core');
     const list = await h({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
     expect(list.result.tools.map((t) => t.name).sort()).toEqual(
-      ['autopilot_merge', 'autopilot_merge_bar', 'autopilot_select', 'board_comment', 'board_create', 'board_escalate', 'board_move', 'board_status', 'gate_run', 'release_readiness'],
+      [
+        'autopilot_merge', 'autopilot_merge_bar', 'autopilot_select',
+        'board_close', 'board_comment', 'board_create', 'board_digest', 'board_escalate',
+        'board_log', 'board_move', 'board_receipt', 'board_reparent', 'board_status',
+        'gate_run', 'release_readiness',
+      ],
     );
     expect((await call(h, 'nope_tool', {})).error.code).toBe(-32602);
     expect((await h({ jsonrpc: '2.0', id: 9, method: 'bogus' })).error.code).toBe(-32601);
@@ -52,8 +57,8 @@ describe('AC-288.1: rpc.mjs is the shared transport (forge-graph regression-free
     expect(await h({ jsonrpc: '2.0', method: 'notifications/initialized' })).toBe(null);
   });
 
-  it('exposes exactly the 10 documented tools and the 9 gate names', () => {
-    expect(TOOLS).toHaveLength(10);
+  it('exposes exactly the 15 documented tools and the 9 gate names', () => {
+    expect(TOOLS).toHaveLength(15);
     expect(GATE_NAMES).toEqual(['ac', 'conventions', 'dep', 'docsync', 'ground', 'license', 'plandrift', 'situation', 'testintent']);
   });
 });
@@ -110,6 +115,64 @@ describe('AC-288.2: every tool is callable and returns its documented structured
     expect(body(await call(h, 'board_status', { issue: 2 })).items).toEqual([{ number: 2, title: 'two' }]);
     // #399: the catch-up card (same fields runStatus/the CLI compute) rides along.
     expect(out).toMatchObject({ ok: true, counts: { backlog: 0, ready: 0, inProgress: 0, inReview: 0, blocked: 0, done: 0 }, next: 'pick the next ready/backlog item' });
+  });
+
+  it('AC-400.1: board_receipt -> {ok,action,id}; args pass through to runReceipt unchanged', async () => {
+    let seen;
+    const h = build({ deps: { runReceipt: async (_ctx, a) => { seen = a; return { ok: true, action: 'created', id: 55 }; } } });
+    const out = body(await call(h, 'board_receipt', { issue: 400, pr: 401, sha: 'abc1234', title: 'a title' }));
+    expect(out).toEqual({ ok: true, action: 'created', id: 55 });
+    expect(seen).toEqual({ issue: 400, pr: 401, sha: 'abc1234', title: 'a title' });
+  });
+
+  it('AC-400.1: board_log -> {ok,action,id}; args pass through to runLog unchanged', async () => {
+    let seen;
+    const h = build({ deps: { runLog: async (_ctx, a) => { seen = a; return { ok: true, action: 'updated', id: 9 }; } } });
+    const out = body(await call(h, 'board_log', { pr: 401, sha: 'abc1234', title: 'a title', issues: '400', date: '2026-08-08' }));
+    expect(out).toEqual({ ok: true, action: 'updated', id: 9 });
+    expect(seen).toEqual({ pr: 401, sha: 'abc1234', title: 'a title', issues: '400', date: '2026-08-08' });
+  });
+
+  it('AC-400.1: board_digest -> {ok,changed,rows}', async () => {
+    let seen;
+    const h = build({ deps: { runDigest: async (_ctx, a) => { seen = a; return { ok: true, changed: true, rows: 3 }; } } });
+    const out = body(await call(h, 'board_digest', { epic: 182 }));
+    expect(out).toEqual({ ok: true, changed: true, rows: 3 });
+    expect(seen).toEqual({ epic: 182 });
+  });
+
+  it('AC-400.1: board_reparent -> {ok,moved,from,to}; ctx gh/owner/repo thread through to runReparent(gh,owner,repo,args,log)', async () => {
+    let seenArgs;
+    const seenGh = [];
+    const ctx = { ...okCtx, gh: async (...a) => { seenGh.push(a); return { ok: true }; } };
+    const h = build({
+      getCtx: async () => ctx,
+      deps: { runReparent: async (gh, owner, repo, a) => { seenArgs = { gh, owner, repo, a }; return { ok: true, moved: true, from: 10, to: 182 }; } },
+    });
+    const out = body(await call(h, 'board_reparent', { issue: 400, parent: 182 }));
+    expect(out).toEqual({ ok: true, moved: true, from: 10, to: 182 });
+    expect(seenArgs.gh).toBe(ctx.gh);
+    expect(seenArgs.owner).toBe(ctx.owner);
+    expect(seenArgs.repo).toBe(ctx.repo);
+    expect(seenArgs.a).toEqual({ issue: 400, parent: 182 });
+  });
+
+  it('AC-400.1: board_reparent no-op -> {ok,moved:false,from:null,to:null}', async () => {
+    const h = build({ deps: { runReparent: async () => ({ ok: true, moved: false }) } });
+    expect(body(await call(h, 'board_reparent', { issue: 400, parent: 182 }))).toEqual({ ok: true, moved: false, from: null, to: null });
+  });
+
+  it('AC-400.1: board_close -> {ok,issue,reason,status}; note optional', async () => {
+    let seen;
+    const h = build({ deps: { runClose: async (_ctx, a) => { seen = a; return { ok: true, issue: 400, reason: 'completed', status: 'done' }; } } });
+    const out = body(await call(h, 'board_close', { issue: 400, reason: 'completed' }));
+    expect(out).toEqual({ ok: true, issue: 400, reason: 'completed', status: 'done' });
+    expect(seen).toEqual({ issue: 400, reason: 'completed', note: null });
+  });
+
+  it('AC-400.1: board_close rejects a reason outside the enum with a teaching -32602 error', async () => {
+    const h = build();
+    expect((await call(h, 'board_close', { issue: 400, reason: 'because' })).error.message).toMatch(/'reason' must be one of/);
   });
 
   it('AC-288.2: gate_run situation -> {ok,level:pass,findings[]}', async () => {
@@ -275,6 +338,13 @@ describe('AC-288.4: at least one failure path per tool group', () => {
     expect(res.result.isError).toBe(true);
     expect(body(res)).toMatchObject({ ok: false });
     expect(body(res).error).toMatch(/did NOT persist/);
+  });
+
+  it('AC-400.2: board group — an engine error from a newly-wrapped tool surfaces as isError + {ok:false,error}', async () => {
+    const h = build({ deps: { runDigest: async () => ({ ok: false, error: '--epic <number> is required' }) } });
+    const res = await call(h, 'board_digest', { epic: 182 });
+    expect(res.result.isError).toBe(true);
+    expect(body(res)).toEqual({ ok: false, error: '--epic <number> is required' });
   });
 
   it('AC-288.4: board group — an unavailable board context teaches instead of crashing', async () => {


### PR DESCRIPTION
## Summary
- `plugin/mcp/forge/server.mjs` ("forge-core") wrapped only 4 of 9 `plugin/scripts/board/` scripts as MCP tools (move/comment/create/escalate). Adds 5 more thin wrappers: `board_receipt`, `board_log`, `board_digest`, `board_reparent`, `board_close`, each calling the existing `runReceipt`/`runLog`/`runDigest`/`runReparent`/`runClose` unchanged.
- `board_reparent` threads `ctx.gh`/`ctx.owner`/`ctx.repo` into `runReparent`'s `(gh, owner, repo, args, log)` signature (differs from the ctx-first convention the other board scripts use) — same `gh` client, no new logic.
- `board_close` wraps single-issue `runClose` (not the batch `runCloseBatch`), matching the MCP schema's single `issue: integer`.
- Adds a per-tool usage table to `docs/guides/cross-gai.md` covering all 21 tools (forge-core 15 + forge-graph 6) — what each does and when a host calls it. Neither server had this before.
- Tests added to `tests/mcp-forge/forge-core.test.mjs` mirroring the existing tool-test pattern: success pass-through, no-op/edge cases, and a failure-path example for the new group.

Closes #400

## Acceptance criteria
- [x] AC.1 — all 5 scripts exposed as MCP tools, with tests mirroring the existing pattern (47 tests total in the file, all passing).
- [x] AC.2 — no behavior change to the underlying scripts; verified the wrapper passes the same ctx and equivalent args through to `runX` unchanged (spot-checked live with a probe script), and reviewer pass confirmed no scope creep/drift.
- [x] AC.3 — usage doc lists every forge-core AND forge-graph tool (21 total, corrected from a stale "15" estimate after a reviewer catch on the heading).
- [x] AC.4 — docsync clean, existing MCP tests still pass, full `pnpm verify` green (767/767 tests).

## Verification notes
- `pnpm verify` (vitest run): 59 files, 767 tests, all passing.
- Gates run individually: docsync clean, depguard clean (no new deps), testintent clean (no weakened assertions), conventions clean.
- Reviewer pass (forge:reviewer): found and fixed one doc-count inconsistency (heading said "15 tools" but forge-core alone now has 15, total is 21) — fixed in a follow-up commit. No correctness/scope-creep findings otherwise.
- Security pass (forge:security): verdict pass, no findings. Confirmed `board_reparent`/`board_close` (the two state-mutating new tools) sit at the identical authorization baseline as the existing mutating tools (`board_move`/`board_create`/`board_escalate`) — no separate per-tool ACL exists anywhere in the server by design, and none was added or skipped here. Input validation (enum for `reason`, integer types) and injection surface (parametrized gh CLI args, no shell interpolation) match the established pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SATRHKa6mDHDuirhP6QuwL