### PR TITLE
fix(autopilot): bind ciGreen's fresh-transition shortcut to the PR's head SHA (#411)

### DIFF
--- a/plugin/scripts/autopilot/merge.mjs
+++ b/plugin/scripts/autopilot/merge.mjs
@@ -52,18 +52,26 @@ export function evaluateMergeBar(signals = {}, { critical = false } = {}) {
 export const DEFAULT_FRESH_TRANSITION_MAX_AGE_MS = 20000;
 
 /**
- * #407 AC.2 — is a monitor-observed transition (`{pr, state, at}`, written by
- * `monitors/ci-watch.mjs`) fresh enough to satisfy `ciGreen` WITHOUT firing a
+ * #407 AC.2 — is a monitor-observed transition (`{pr, state, sha, at}`, written
+ * by `monitors/ci-watch.mjs`) fresh enough to satisfy `ciGreen` WITHOUT firing a
  * redundant GraphQL re-fetch? Pure: no IO, so the boundary is unit-tested
- * directly. Deliberately narrow — same PR, state exactly `'pass'`, and within
- * `maxAgeMs` of `now` — anything else (wrong PR, stale, pending/fail, missing/
- * unparsable timestamp) returns false and the caller falls through to the real
- * re-check. This is what keeps "nothing merges on red" intact (spec §3.1/§5):
- * the shortcut can only ever confirm an ALREADY-fresh green, never skip past a
- * red or stale one.
+ * directly. Deliberately narrow — same PR, state exactly `'pass'`, within
+ * `maxAgeMs` of `now`, AND (#411) bound to the caller's confirmed current head
+ * commit (`headRefOid`) — anything else (wrong PR, stale, pending/fail,
+ * missing/unparsable timestamp, missing/mismatched sha) returns false and the
+ * caller falls through to the real re-check. The sha bind closes a gap #407
+ * shipped: without it, a push landing on the PR inside the freshness window
+ * (after the monitor's last "pass" poll, before its next one) could leave a
+ * stale green reading for the OLD commit that this check would otherwise
+ * accept for the NEW one. This is what keeps "nothing merges on red" intact
+ * (spec §3.1/§5): the shortcut can only ever confirm an ALREADY-fresh green
+ * for the CURRENT commit, never skip past a red, stale, or superseded one.
  */
-export function isFreshGreenTransition(state, pr, { now = Date.now(), maxAgeMs = DEFAULT_FRESH_TRANSITION_MAX_AGE_MS } = {}) {
+export function isFreshGreenTransition(state, pr, { now = Date.now(), maxAgeMs = DEFAULT_FRESH_TRANSITION_MAX_AGE_MS, headRefOid } = {}) {
   if (!state || state.pr !== pr || state.state !== 'pass') return false;
+  // #411: fail closed unless both sides of the sha bind are present and equal —
+  // an omitted/unresolvable headRefOid must never silently skip the check.
+  if (!headRefOid || !state.sha || state.sha !== headRefOid) return false;
   const at = Date.parse(state.at ?? '');
   if (Number.isNaN(at)) return false;
   const age = now - at;
@@ -82,13 +90,20 @@ export function isFreshGreenTransition(state, pr, { now = Date.now(), maxAgeMs =
  * real re-fetch always runs, so the mandatory pre-merge green confirmation is
  * never skipped, only its network cost is — the safety property spec §5 calls
  * out is untouched.
+ *
+ * #411: `headRefOid` is the caller's live-confirmed current head commit for
+ * this PR (see `runMerge` — a local `git rev-parse HEAD`, zero GraphQL cost,
+ * so the call-reduction intent above is unaffected). `isFreshGreenTransition`
+ * fails closed without it, so a caller that can't cheaply confirm the current
+ * head (e.g. a `ctx` with no `cwd`) always falls through to the real re-fetch
+ * below rather than trusting a possibly-stale cached reading.
  */
-export async function ciGreen(gh, pr, { freshState = null, now, maxAgeMs } = {}) {
+export async function ciGreen(gh, pr, { freshState = null, now, maxAgeMs, headRefOid } = {}) {
   // #407 review nit: destructuring defaults already fire on an explicit `undefined`
   // (isFreshGreenTransition's own `now = Date.now()`/`maxAgeMs = ...` params handle
   // that), so passing `now`/`maxAgeMs` straight through is equivalent to — and
   // simpler than — conditionally spreading them in.
-  if (isFreshGreenTransition(freshState, pr, { now, maxAgeMs })) {
+  if (isFreshGreenTransition(freshState, pr, { now, maxAgeMs, headRefOid })) {
     return { ok: true, green: true, viaFreshTransition: true };
   }
   const res = await gh(['pr', 'view', String(pr), '--json', 'statusCheckRollup'], { parseJson: true });
@@ -102,6 +117,16 @@ export async function ciGreen(gh, pr, { freshState = null, now, maxAgeMs } = {})
   return { ok: true, green: bad.length === 0, pending: bad.map((c) => c.name ?? c.context) };
 }
 
+/** #411: the shortcut's own binding check — a cheap LOCAL `git rev-parse HEAD`
+ * (no GraphQL call, so AC.2's call-reduction intent is unaffected). Returns
+ * null on any failure (detached weirdness, not a repo, etc.) so the caller
+ * fails closed to the real re-fetch rather than binding to a wrong/empty sha. */
+async function currentHeadSha(cwd, execFn) {
+  const res = await execFn('git', ['-C', cwd, 'rev-parse', 'HEAD']);
+  const sha = res.ok ? res.stdout.trim() : '';
+  return sha || null;
+}
+
 /**
  * Live merge, gated by the bar. `signals` carries the orchestrator's held
  * verdicts (ship/gates/reviewer/security); CI is checked here. When auto-merge
@@ -110,9 +135,10 @@ export async function ciGreen(gh, pr, { freshState = null, now, maxAgeMs } = {})
  * grant) — park at the PR (awaiting-human) and let the loop continue. `mode` is
  * the effective merge mode from the preflight, recorded in run.json; pr-only
  * carries autoMergeEnabled:false semantics so a run with no live grant never
- * attempts a merge that would stall.
+ * attempts a merge that would stall. `execFn` (default `run`) is the injected
+ * process runner for the #411 local head-sha check — swappable in tests.
  */
-export async function runMerge(ctx, { issue, pr, signals = {}, critical = false, mode = null }, log = console.log) {
+export async function runMerge(ctx, { issue, pr, signals = {}, critical = false, mode = null }, log = console.log, execFn = run) {
   if (!Number.isInteger(issue) || !Number.isInteger(pr)) return { ok: false, error: '--issue and --pr are required' };
   if (mode === 'pr-only' || !autoMergeEnabled(ctx.config)) {
     const why = mode === 'pr-only' ? 'merge-auth preflight resolved pr-only (no in-session grant)' : 'features.autopilotAutoMerge=false';
@@ -127,7 +153,11 @@ export async function runMerge(ctx, { issue, pr, signals = {}, critical = false,
   // loadCiWatchState already never throws (internal try/catch in ci-watch.mjs) —
   // no .catch() needed here (#407 review nit).
   const freshState = ctx.cwd ? await loadCiWatchState(ctx.cwd) : null;
-  const ci = await ciGreen(ctx.gh, pr, { freshState });
+  // #411: only bother resolving the local head sha when there's an actual
+  // freshState candidate to bind it to — no point paying even a local spawn
+  // for the (common, once CI is slow) case where there's nothing on disk yet.
+  const headRefOid = freshState && ctx.cwd ? await currentHeadSha(ctx.cwd, execFn) : null;
+  const ci = await ciGreen(ctx.gh, pr, { freshState, headRefOid });
   if (!ci.ok) return { ok: false, error: ci.error };
   const bar = evaluateMergeBar({ ...signals, ci: ci.green }, { critical });
   if (!bar.merge) {

--- a/plugin/scripts/autopilot/merge.mjs
+++ b/plugin/scripts/autopilot/merge.mjs
@@ -91,12 +91,22 @@ export function isFreshGreenTransition(state, pr, { now = Date.now(), maxAgeMs =
  * never skipped, only its network cost is — the safety property spec §5 calls
  * out is untouched.
  *
- * #411: `headRefOid` is the caller's live-confirmed current head commit for
+ * #411: `headRefOid` is the caller's cheaply-confirmed current head commit for
  * this PR (see `runMerge` — a local `git rev-parse HEAD`, zero GraphQL cost,
  * so the call-reduction intent above is unaffected). `isFreshGreenTransition`
- * fails closed without it, so a caller that can't cheaply confirm the current
+ * fails closed without it, so a caller that can't cheaply confirm a candidate
  * head (e.g. a `ctx` with no `cwd`) always falls through to the real re-fetch
- * below rather than trusting a possibly-stale cached reading.
+ * below rather than trusting a possibly-stale cached reading. IMPORTANT: this
+ * local read is a CHEAP PRE-FILTER, not the authoritative check — it can only
+ * ever confirm "this process's own checkout hasn't moved," not "GitHub's PR
+ * head hasn't moved" (an out-of-band push from another actor/bot would leave
+ * both the local checkout AND the cached reading stale together, so this
+ * comparison alone can't catch it). The AUTHORITATIVE bind is downstream, at
+ * the live `gh pr merge --match-head-commit` call in `runMerge` — this
+ * function also returns the `headRefOid` it green-lit (from `freshState.sha`
+ * via the shortcut, or freshly fetched below) precisely so that call can pin
+ * to it and have GitHub itself reject a merge if the real remote head has
+ * since moved, atomically, with no TOCTOU between this check and the merge.
  */
 export async function ciGreen(gh, pr, { freshState = null, now, maxAgeMs, headRefOid } = {}) {
   // #407 review nit: destructuring defaults already fire on an explicit `undefined`
@@ -104,9 +114,9 @@ export async function ciGreen(gh, pr, { freshState = null, now, maxAgeMs, headRe
   // that), so passing `now`/`maxAgeMs` straight through is equivalent to — and
   // simpler than — conditionally spreading them in.
   if (isFreshGreenTransition(freshState, pr, { now, maxAgeMs, headRefOid })) {
-    return { ok: true, green: true, viaFreshTransition: true };
+    return { ok: true, green: true, viaFreshTransition: true, headRefOid: freshState.sha };
   }
-  const res = await gh(['pr', 'view', String(pr), '--json', 'statusCheckRollup'], { parseJson: true });
+  const res = await gh(['pr', 'view', String(pr), '--json', 'statusCheckRollup,headRefOid'], { parseJson: true });
   if (!res.ok) return { ok: false, green: false, error: res.stderr || 'pr view failed' };
   const rollup = res.json?.statusCheckRollup ?? [];
   if (rollup.length === 0) return { ok: true, green: false, reason: 'no checks reported yet' };
@@ -114,7 +124,7 @@ export async function ciGreen(gh, pr, { freshState = null, now, maxAgeMs, headRe
     const state = c.conclusion ?? c.state; // CheckRun uses conclusion; StatusContext uses state
     return state !== 'SUCCESS' && state !== 'NEUTRAL' && state !== 'SKIPPED';
   });
-  return { ok: true, green: bad.length === 0, pending: bad.map((c) => c.name ?? c.context) };
+  return { ok: true, green: bad.length === 0, pending: bad.map((c) => c.name ?? c.context), headRefOid: res.json?.headRefOid ?? null };
 }
 
 /** #411: the shortcut's own binding check — a cheap LOCAL `git rev-parse HEAD`
@@ -164,7 +174,19 @@ export async function runMerge(ctx, { issue, pr, signals = {}, critical = false,
     log(`autopilot: merge bar RED for #${issue} — blocked on ${bar.blockedOn.join(', ')}${bar.escalate ? ' (escalate)' : ''}`);
     return { ok: false, merged: false, blockedOn: bar.blockedOn, escalate: bar.escalate };
   }
-  const merged = await ctx.gh(['pr', 'merge', String(pr), '--squash', '--delete-branch']);
+  // #411: pin the LIVE merge to the exact commit `ciGreen` just confirmed green
+  // — `--match-head-commit` is validated server-side by GitHub at the moment
+  // of merge, atomically. This is the AUTHORITATIVE bind (see the `ciGreen`
+  // doc comment): it closes the gap the local `headRefOid` pre-filter above
+  // can't — an out-of-band push that moved the PR's real remote head between
+  // the check and this call (or one this checkout was never even aware of)
+  // makes `gh pr merge` fail instead of squashing an uncorroborated commit.
+  // `ci.headRefOid` can be null in a degenerate case (a `gh` double/response
+  // that omits it) — degrade to the pre-#411 unpinned call rather than
+  // blocking a legitimately green merge on a missing hardening signal.
+  const mergeArgs = ['pr', 'merge', String(pr), '--squash', '--delete-branch'];
+  if (ci.headRefOid) mergeArgs.push('--match-head-commit', ci.headRefOid);
+  const merged = await ctx.gh(mergeArgs);
   if (!merged.ok) return { ok: false, error: merged.stderr || 'gh pr merge failed' };
   log(`autopilot: merged #${issue} via PR #${pr} (squash)`);
   return { ok: true, merged: true, outcome: 'merged' };

--- a/plugin/scripts/monitors/ci-watch.mjs
+++ b/plugin/scripts/monitors/ci-watch.mjs
@@ -17,6 +17,7 @@
  */
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { lstat } from 'node:fs/promises';
 import { run, makeGh } from '../lib/exec.mjs';
 import { writeJson, readJson } from '../lib/jsonfile.mjs';
 import { freshGuard, trackFailure } from './poll-guard.mjs';
@@ -26,20 +27,35 @@ export const CI_WATCH_RELPATH = join('.forge', 'autopilot', 'ci-watch.json');
 
 /** Best-effort persist of the last observed rollup state. A write failure must
  * never crash the monitor loop — it only means the fresh-transition shortcut
- * is unavailable next merge, not that anything is broken. */
-export async function writeCiWatchState(cwd, { pr, state, at = new Date().toISOString() }) {
+ * is unavailable next merge, not that anything is broken. `sha` (#411) is the
+ * commit (`headRefOid`) this observation was taken at, so a consumer can bind
+ * the reading to a specific commit instead of trusting the timestamp alone. */
+export async function writeCiWatchState(cwd, { pr, state, sha = null, at = new Date().toISOString() }) {
   try {
-    await writeJson(join(cwd, CI_WATCH_RELPATH), { pr, state, at });
+    await writeJson(join(cwd, CI_WATCH_RELPATH), { pr, state, sha, at });
     return true;
   } catch {
     return false;
   }
 }
 
-/** Tolerant read: an absent or corrupt file both mean "no fresh data" (mirrors `sessionpause.mjs`'s `loadUsage`). */
+/** Tolerant read: an absent or corrupt file both mean "no fresh data" (mirrors
+ * `sessionpause.mjs`'s `loadUsage`). #411: the write path is symlink-safe
+ * (atomic temp-file + rename, `jsonfile.mjs`), but a plain `readFile` follows
+ * symlinks — a local attacker with pre-existing write access to `.forge/autopilot/`
+ * could otherwise plant a symlink here to forge a fake green reading. `lstat`
+ * (which does NOT follow links) gates the read so a symlinked path is treated
+ * exactly like a missing/corrupt file — never dereferenced. */
 export async function loadCiWatchState(cwd) {
+  const path = join(cwd, CI_WATCH_RELPATH);
   try {
-    return await readJson(join(cwd, CI_WATCH_RELPATH));
+    const st = await lstat(path);
+    if (st.isSymbolicLink()) return null;
+  } catch {
+    return null; // absent (or unstattable) — readJson would treat it the same way
+  }
+  try {
+    return await readJson(path);
   } catch {
     return null;
   }
@@ -72,17 +88,18 @@ export function isNoPr(res) {
 }
 
 export async function poll(gh, prev) {
-  const res = await gh(['pr', 'view', '--json', 'number,headRefName,statusCheckRollup'], { parseJson: true });
+  const res = await gh(['pr', 'view', '--json', 'number,headRefName,headRefOid,statusCheckRollup'], { parseJson: true });
   if (!res.ok) {
     // Distinguish "no PR yet" (benign, quiet) from a standing gh failure (#318).
-    if (isNoPr(res)) return { prev, pr: null, line: null, ok: true };
-    return { prev, pr: null, line: null, ok: false, reason: String(res?.stderr || 'gh pr view failed') };
+    if (isNoPr(res)) return { prev, pr: null, sha: null, line: null, ok: true };
+    return { prev, pr: null, sha: null, line: null, ok: false, reason: String(res?.stderr || 'gh pr view failed') };
   }
   const state = rollupState(res.json?.statusCheckRollup);
   const pr = res.json?.number ?? null;
+  const sha = res.json?.headRefOid ?? null; // #411: the commit this rollup reading belongs to
   const changed = transition(prev, state);
-  if (!changed) return { prev: state, pr, line: null, ok: true };
-  return { prev: state, pr, line: `CI ${state} on PR #${res.json.number} (${res.json.headRefName})`, ok: true };
+  if (!changed) return { prev: state, pr, sha, line: null, ok: true };
+  return { prev: state, pr, sha, line: `CI ${state} on PR #${res.json.number} (${res.json.headRefName})`, ok: true };
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
@@ -101,7 +118,10 @@ if (isMain) {
       prev = r.prev;
       // #407 AC.2: persist every observed reading (not just transitions) so
       // ciGreen()'s freshness window always has an accurate "at" timestamp.
-      if (r.ok && r.pr != null) await writeCiWatchState(process.cwd(), { pr: r.pr, state: r.prev });
+      // #411: also persist the commit (`sha`) this reading was taken at, so
+      // ciGreen() can bind the fresh-transition shortcut to the PR's CURRENT
+      // head instead of trusting the timestamp alone.
+      if (r.ok && r.pr != null) await writeCiWatchState(process.cwd(), { pr: r.pr, state: r.prev, sha: r.sha });
       if (r.line) console.log(r.line);
       surface(r.ok, r.reason);
     } catch (err) {

--- a/tests/autopilot/engine.test.mjs
+++ b/tests/autopilot/engine.test.mjs
@@ -356,7 +356,9 @@ describe('autopilot enforced merge path (#315, AC-315.1/AC-315.2) — runMerge i
     const res = await runMerge({ config: {}, gh, cwd }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {}, execFn);
     expect(res).toMatchObject({ ok: true, merged: true, outcome: 'merged' });
     expect(calls.some((c) => c.startsWith('pr view'))).toBe(false);
-    expect(calls).toContain('pr merge 9 --squash --delete-branch');
+    // #411: the live merge is pinned to the exact sha ciGreen just confirmed —
+    // the AUTHORITATIVE bind (GitHub validates this server-side at merge time).
+    expect(calls).toContain('pr merge 9 --squash --delete-branch --match-head-commit aaa111');
   });
 
   it('AC-407.2: a stale/absent ci-watch.json still runs the real pre-merge re-check (no ctx.cwd or no file = today\'s behavior)', async () => {
@@ -364,7 +366,27 @@ describe('autopilot enforced merge path (#315, AC-315.1/AC-315.2) — runMerge i
     // no cwd on ctx at all — must behave exactly as before this ticket
     const res = await runMerge({ config: {}, gh }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {});
     expect(res.merged).toBe(true);
-    expect(calls).toContain('pr view 9 --json statusCheckRollup');
+    expect(calls).toContain('pr view 9 --json statusCheckRollup,headRefOid');
+  });
+
+  it('#411: the real re-fetch path ALSO pins the live merge — --match-head-commit uses the freshly-fetched headRefOid', async () => {
+    const calls = [];
+    const gh = async (args) => {
+      calls.push(args.join(' '));
+      if (args[0] === 'pr' && args[1] === 'view') return { ok: true, json: { statusCheckRollup: green, headRefOid: 'live-sha' } };
+      return { ok: true };
+    };
+    // no cwd → no shortcut candidate at all — this exercises the plain re-fetch path picking up headRefOid.
+    const res = await runMerge({ config: {}, gh }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {});
+    expect(res.merged).toBe(true);
+    expect(calls).toContain('pr merge 9 --squash --delete-branch --match-head-commit live-sha');
+  });
+
+  it('#411: a gh response that omits headRefOid degrades to the pre-#411 unpinned merge call — never blocks an otherwise-green merge', async () => {
+    const { calls, gh } = ghDouble(green); // ghDouble's mocked pr-view response has no headRefOid field
+    const res = await runMerge({ config: {}, gh }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {});
+    expect(res.merged).toBe(true);
+    expect(calls).toContain('pr merge 9 --squash --delete-branch'); // no --match-head-commit appended
   });
 
   it('#411: a stale-SHA transition (HEAD moved since the cached "pass") is rejected — the merge still succeeds, but via the real re-check', async () => {

--- a/tests/autopilot/engine.test.mjs
+++ b/tests/autopilot/engine.test.mjs
@@ -196,26 +196,59 @@ describe('autopilot merge bar (#127, AC-3) — the trust reversal', () => {
   describe('ciGreen fresh-transition shortcut (AC-407.2) — reduces the 3 idle CI pollers to 2', () => {
     const now = Date.parse('2026-08-08T12:00:00Z');
 
-    it('isFreshGreenTransition: same pr + pass + within the window -> true', () => {
-      const state = { pr: 9, state: 'pass', at: new Date(now - 5000).toISOString() };
-      expect(isFreshGreenTransition(state, 9, { now, maxAgeMs: 20000 })).toBe(true);
+    it('isFreshGreenTransition: same pr + pass + within the window + matching headRefOid -> true', () => {
+      const state = { pr: 9, state: 'pass', sha: 'aaa111', at: new Date(now - 5000).toISOString() };
+      expect(isFreshGreenTransition(state, 9, { now, maxAgeMs: 20000, headRefOid: 'aaa111' })).toBe(true);
     });
 
     it('isFreshGreenTransition: wrong pr, non-pass, stale, or unparsable timestamp all fall through', () => {
       const at = new Date(now - 5000).toISOString();
-      expect(isFreshGreenTransition({ pr: 10, state: 'pass', at }, 9, { now, maxAgeMs: 20000 })).toBe(false); // wrong pr
-      expect(isFreshGreenTransition({ pr: 9, state: 'pending', at }, 9, { now, maxAgeMs: 20000 })).toBe(false); // not pass
-      expect(isFreshGreenTransition({ pr: 9, state: 'fail', at }, 9, { now, maxAgeMs: 20000 })).toBe(false); // not pass
-      expect(isFreshGreenTransition({ pr: 9, state: 'pass', at: new Date(now - 999999).toISOString() }, 9, { now, maxAgeMs: 20000 })).toBe(false); // stale
-      expect(isFreshGreenTransition({ pr: 9, state: 'pass', at: 'not-a-date' }, 9, { now })).toBe(false); // unparsable
-      expect(isFreshGreenTransition(null, 9, { now })).toBe(false); // no state at all
+      const opts = { now, maxAgeMs: 20000, headRefOid: 'aaa111' };
+      expect(isFreshGreenTransition({ pr: 10, state: 'pass', sha: 'aaa111', at }, 9, opts)).toBe(false); // wrong pr
+      expect(isFreshGreenTransition({ pr: 9, state: 'pending', sha: 'aaa111', at }, 9, opts)).toBe(false); // not pass
+      expect(isFreshGreenTransition({ pr: 9, state: 'fail', sha: 'aaa111', at }, 9, opts)).toBe(false); // not pass
+      expect(isFreshGreenTransition({ pr: 9, state: 'pass', sha: 'aaa111', at: new Date(now - 999999).toISOString() }, 9, opts)).toBe(false); // stale
+      expect(isFreshGreenTransition({ pr: 9, state: 'pass', sha: 'aaa111', at: 'not-a-date' }, 9, { now, headRefOid: 'aaa111' })).toBe(false); // unparsable
+      expect(isFreshGreenTransition(null, 9, { now, headRefOid: 'aaa111' })).toBe(false); // no state at all
     });
 
-    it('ciGreen: a fresh known-green transition satisfies the check WITHOUT calling gh', async () => {
+    // #411 — the fresh-transition shortcut must bind to the PR's CURRENT head
+    // commit, not just replay a same-pr/pass/timestamp match. Without this, a
+    // push landing inside the freshness window (after the monitor's last
+    // "pass" poll, before its next one) could let a stale green for the OLD
+    // commit satisfy the check for the NEW one.
+    describe('#411 — the shortcut is bound to the current commit, not just pr/state/age', () => {
+      it('isFreshGreenTransition: a stale sha (HEAD moved since the cached pass) is rejected even though pr/state/age all match', () => {
+        const state = { pr: 9, state: 'pass', sha: 'aaa111', at: new Date(now - 5000).toISOString() };
+        expect(isFreshGreenTransition(state, 9, { now, maxAgeMs: 20000, headRefOid: 'bbb222' })).toBe(false);
+      });
+
+      it('isFreshGreenTransition: no headRefOid supplied at all fails closed (never silently skips the sha check)', () => {
+        const state = { pr: 9, state: 'pass', sha: 'aaa111', at: new Date(now - 5000).toISOString() };
+        expect(isFreshGreenTransition(state, 9, { now, maxAgeMs: 20000 })).toBe(false);
+      });
+
+      it('isFreshGreenTransition: a cached reading with no sha of its own is rejected even against a real current head', () => {
+        const state = { pr: 9, state: 'pass', at: new Date(now - 5000).toISOString() }; // pre-#411 shape, no sha
+        expect(isFreshGreenTransition(state, 9, { now, maxAgeMs: 20000, headRefOid: 'aaa111' })).toBe(false);
+      });
+
+      it('ciGreen: a stale-SHA transition is rejected — falls through to the real gh re-fetch even though pr/state/age all matched', async () => {
+        let calls = 0;
+        const gh = async () => { calls++; return { ok: true, json: { statusCheckRollup: [{ conclusion: 'SUCCESS' }] } }; };
+        const freshState = { pr: 9, state: 'pass', sha: 'aaa111', at: new Date(now - 3000).toISOString() };
+        const res = await ciGreen(gh, 9, { freshState, now, maxAgeMs: 20000, headRefOid: 'bbb222' }); // HEAD moved since the cached pass
+        expect(res.green).toBe(true); // still green — but via the real re-fetch, not the shortcut
+        expect(res.viaFreshTransition).toBeUndefined();
+        expect(calls).toBe(1); // the re-fetch DID fire — a stale sha never short-circuits the check
+      });
+    });
+
+    it('ciGreen: a fresh, SHA-bound known-green transition satisfies the check WITHOUT calling gh', async () => {
       let calls = 0;
       const gh = async () => { calls++; return { ok: true, json: { statusCheckRollup: [] } }; }; // would be NOT green if actually called
-      const freshState = { pr: 9, state: 'pass', at: new Date(now - 3000).toISOString() };
-      const res = await ciGreen(gh, 9, { freshState, now, maxAgeMs: 20000 });
+      const freshState = { pr: 9, state: 'pass', sha: 'aaa111', at: new Date(now - 3000).toISOString() };
+      const res = await ciGreen(gh, 9, { freshState, now, maxAgeMs: 20000, headRefOid: 'aaa111' });
       expect(res).toMatchObject({ ok: true, green: true, viaFreshTransition: true });
       expect(calls).toBe(0); // the redundant GraphQL re-fetch never fired
     });
@@ -223,9 +256,9 @@ describe('autopilot merge bar (#127, AC-3) — the trust reversal', () => {
     it('ciGreen: a stale/wrong-pr/missing freshState always falls through to the real re-fetch — the safety property stays intact', async () => {
       let calls = 0;
       const gh = async () => { calls++; return { ok: true, json: { statusCheckRollup: [{ conclusion: 'SUCCESS' }] } }; };
-      await ciGreen(gh, 9, { freshState: null });
-      await ciGreen(gh, 9, { freshState: { pr: 10, state: 'pass', at: new Date(now - 1000).toISOString() }, now });
-      await ciGreen(gh, 9, { freshState: { pr: 9, state: 'pass', at: new Date(now - 999999).toISOString() }, now });
+      await ciGreen(gh, 9, { freshState: null, headRefOid: 'aaa111' });
+      await ciGreen(gh, 9, { freshState: { pr: 10, state: 'pass', sha: 'aaa111', at: new Date(now - 1000).toISOString() }, now, headRefOid: 'aaa111' });
+      await ciGreen(gh, 9, { freshState: { pr: 9, state: 'pass', sha: 'aaa111', at: new Date(now - 999999).toISOString() }, now, headRefOid: 'aaa111' });
       expect(calls).toBe(3); // every one of these re-fetched — never skipped a red/stale/wrong-pr case
     });
   });
@@ -305,16 +338,22 @@ describe('autopilot enforced merge path (#315, AC-315.1/AC-315.2) — runMerge i
     expect(calls.some((c) => c.startsWith('pr merge'))).toBe(false);
   });
 
-  it('AC-407.2: a fresh forge-ci monitor transition on disk lets runMerge skip its own "pr view" re-fetch', async () => {
+  it('AC-407.2/#411: a fresh, SHA-bound forge-ci monitor transition on disk lets runMerge skip its own "pr view" re-fetch', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'forge-merge-'));
-    await writeCiWatchState(cwd, { pr: 9, state: 'pass' }); // "at" defaults to now
+    await writeCiWatchState(cwd, { pr: 9, state: 'pass', sha: 'aaa111' }); // "at" defaults to now
     const calls = [];
     const gh = async (args) => {
       calls.push(args.join(' '));
-      if (args[0] === 'pr' && args[1] === 'view') throw new Error('should not re-fetch — a fresh transition was already on disk');
+      if (args[0] === 'pr' && args[1] === 'view') throw new Error('should not re-fetch — a fresh, SHA-bound transition was already on disk');
       return { ok: true };
     };
-    const res = await runMerge({ config: {}, gh, cwd }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {});
+    // #411: the local head-sha lookup (`git rev-parse HEAD`) is injected — HEAD matches the cached reading's sha.
+    const execFn = async (cmd, args) => {
+      expect(cmd).toBe('git');
+      expect(args).toEqual(['-C', cwd, 'rev-parse', 'HEAD']);
+      return { ok: true, stdout: 'aaa111\n', stderr: '' };
+    };
+    const res = await runMerge({ config: {}, gh, cwd }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {}, execFn);
     expect(res).toMatchObject({ ok: true, merged: true, outcome: 'merged' });
     expect(calls.some((c) => c.startsWith('pr view'))).toBe(false);
     expect(calls).toContain('pr merge 9 --squash --delete-branch');
@@ -326,6 +365,31 @@ describe('autopilot enforced merge path (#315, AC-315.1/AC-315.2) — runMerge i
     const res = await runMerge({ config: {}, gh }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {});
     expect(res.merged).toBe(true);
     expect(calls).toContain('pr view 9 --json statusCheckRollup');
+  });
+
+  it('#411: a stale-SHA transition (HEAD moved since the cached "pass") is rejected — the merge still succeeds, but via the real re-check', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-merge-'));
+    await writeCiWatchState(cwd, { pr: 9, state: 'pass', sha: 'old-sha' }); // cached BEFORE a push moved HEAD
+    const calls = [];
+    const gh = async (args) => {
+      calls.push(args.join(' '));
+      if (args[0] === 'pr' && args[1] === 'view') return { ok: true, json: { statusCheckRollup: green } };
+      return { ok: true };
+    };
+    const execFn = async () => ({ ok: true, stdout: 'new-sha\n', stderr: '' }); // HEAD has since moved past the cached reading
+    const res = await runMerge({ config: {}, gh, cwd }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {}, execFn);
+    expect(res).toMatchObject({ ok: true, merged: true, outcome: 'merged' }); // still merges — CI IS green, just confirmed for real
+    expect(calls.some((c) => c.startsWith('pr view'))).toBe(true); // the stale cached "pass" did NOT short-circuit the check
+  });
+
+  it('#411: a failed local `git rev-parse HEAD` (execFn error) fails closed to the real re-check, never crashes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'forge-merge-'));
+    await writeCiWatchState(cwd, { pr: 9, state: 'pass', sha: 'aaa111' });
+    const { gh, calls } = ghDouble(green);
+    const execFn = async () => ({ ok: false, stdout: '', stderr: 'not a git repo' });
+    const res = await runMerge({ config: {}, gh, cwd }, { issue: 1, pr: 9, signals: heldVerdicts }, () => {}, execFn);
+    expect(res).toMatchObject({ ok: true, merged: true, outcome: 'merged' });
+    expect(calls.some((c) => c.startsWith('pr view'))).toBe(true);
   });
 });
 

--- a/tests/monitors/monitors.test.mjs
+++ b/tests/monitors/monitors.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFile, mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { readFile, mkdtemp, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,28 +27,37 @@ describe('CI monitor (#151)', () => {
   it('poll stays quiet with no PR, and reports the transition when checks land', async () => {
     const quiet = await ciPoll(async () => ({ ok: false }), null);
     expect(quiet.line).toBe(null);
-    const gh = async () => ({ ok: true, json: { number: 42, headRefName: 'feat/x', statusCheckRollup: [{ conclusion: 'SUCCESS' }] } });
+    const gh = async () => ({ ok: true, json: { number: 42, headRefName: 'feat/x', headRefOid: 'aaa111', statusCheckRollup: [{ conclusion: 'SUCCESS' }] } });
     const first = await ciPoll(gh, null);
     expect(first.line).toMatch(/CI pass on PR #42 \(feat\/x\)/);
     expect(first.pr).toBe(42); // #407 AC.2: poll() now surfaces the pr number so the caller can persist it
+    expect(first.sha).toBe('aaa111'); // #411: poll() also surfaces the commit this rollup reading belongs to
     const second = await ciPoll(gh, first.prev); // unchanged → silent
     expect(second.line).toBe(null);
     expect(second.pr).toBe(42);
+    expect(second.sha).toBe('aaa111');
   });
 
   // #407 AC.2 — the monitor persists its last observed state so merge.mjs's
   // ciGreen() can thread a very-recent known-green transition into the
   // pre-merge check instead of firing a redundant GraphQL re-fetch.
   describe('ci-watch state persistence (AC-407.2)', () => {
-    it('writeCiWatchState -> loadCiWatchState round-trips {pr, state, at}', async () => {
+    it('writeCiWatchState -> loadCiWatchState round-trips {pr, state, sha, at}', async () => {
       const cwd = await mkdtemp(join(tmpdir(), 'forge-ciwatch-'));
       expect(await loadCiWatchState(cwd)).toBeNull(); // absent -> null, never throws
-      await writeCiWatchState(cwd, { pr: 9, state: 'pass' });
+      await writeCiWatchState(cwd, { pr: 9, state: 'pass', sha: 'aaa111' });
       const loaded = await loadCiWatchState(cwd);
       expect(loaded.pr).toBe(9);
       expect(loaded.state).toBe('pass');
+      expect(loaded.sha).toBe('aaa111'); // #411: the commit this reading was taken at
       expect(typeof loaded.at).toBe('string'); // defaulted to "now" when the caller omits it
       expect(Date.parse(loaded.at)).not.toBeNaN();
+    });
+
+    it('writeCiWatchState defaults sha to null when the caller omits it', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'forge-ciwatch-'));
+      await writeCiWatchState(cwd, { pr: 9, state: 'pass' });
+      expect((await loadCiWatchState(cwd)).sha).toBeNull();
     });
 
     it('loadCiWatchState tolerates a corrupt file — never throws', async () => {
@@ -63,6 +72,30 @@ describe('CI monitor (#151)', () => {
       await writeCiWatchState(cwd, { pr: 9, state: 'pending' });
       await writeCiWatchState(cwd, { pr: 9, state: 'pass' });
       expect((await loadCiWatchState(cwd)).state).toBe('pass');
+    });
+
+    // #411 — the write path was already symlink-safe (atomic temp-file + rename);
+    // the read path used a plain `readFile`, which DOES follow symlinks. A local
+    // attacker with pre-existing write access to `.forge/autopilot/` could plant
+    // a symlink at the ci-watch.json path pointing at attacker-controlled content
+    // to forge a fake green reading. `loadCiWatchState` must never dereference it.
+    it('loadCiWatchState never follows a symlink planted at the state path', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'forge-ciwatch-'));
+      const targetDir = await mkdtemp(join(tmpdir(), 'forge-ciwatch-target-'));
+      const target = join(targetDir, 'forged.json');
+      await writeFile(target, JSON.stringify({ pr: 9, state: 'pass', sha: 'forged-sha', at: new Date().toISOString() }));
+      const linkPath = join(cwd, CI_WATCH_RELPATH);
+      await mkdir(dirname(linkPath), { recursive: true });
+      try {
+        await symlink(target, linkPath, 'file');
+      } catch (err) {
+        // Symlink creation needs elevated privilege on some platforms (notably
+        // Windows without Developer Mode/admin) — the guard itself is exercised
+        // by the platforms that CAN create one; skip rather than false-fail here.
+        if (err?.code === 'EPERM' || err?.code === 'EACCES') return;
+        throw err;
+      }
+      await expect(loadCiWatchState(cwd)).resolves.toBeNull(); // never dereferenced — treated as absent, not as the forged content
     });
   });
 });


### PR DESCRIPTION
Closes #411.

Stacked on #410 (`feat/407-graphql-call-reduction`) — this fix targets `isFreshGreenTransition`, which #407 added and which is still only on that open PR's branch, not yet on `main`. Retarget/rebase onto `main` once #410 merges.

## What

#407's `ciGreen()` fresh-transition shortcut (`merge.mjs`) matched a `forge-ci` monitor-observed transition on `{pr, state, at}` only — no commit binding. A push landing on the PR inside the ~20s freshness window (after the monitor's last "pass" poll, before its next one) could leave a stale "pass" reading on disk that the shortcut would accept without re-confirming the rollup reflects the new HEAD. Flagged non-blocking (bounded window; GitHub branch protection is an independent backstop on the live `gh pr merge`) by the #407 security pass, journaled as this hardening follow-up.

- `ci-watch.mjs`'s `poll()` now requests `headRefOid` and `writeCiWatchState` persists it as `sha` alongside `{pr, state, at}`.
- `isFreshGreenTransition` gains a `headRefOid` param (the caller's live-confirmed current head) and fails **closed** unless it's present and equals the cached reading's `sha` — a missing/mismatched sha never silently skips the check.
- `runMerge` resolves the current head via a local `git rev-parse HEAD` (via an injectable `execFn`, defaulting to `run` — zero GraphQL cost, so #407 AC.2's call-reduction intent is unaffected) and threads it through `ciGreen`.
- `loadCiWatchState` no longer follows a symlink planted at the state path (`lstat` guard before the read) — the write path was already symlink-safe via atomic temp-file + rename. Folded in from the same #407 review since it's the exact file/AC this ticket is already touching.

The `lib/board.mjs` WeakMap/`process.chdir()` note from that same review is filed separately as #415 (speculative, different file, no current exploit path — out of scope here).

## AC checklist

- [x] The fresh-transition shortcut is bound to the PR's current head SHA — a cached `{pr, state, at}` match alone is no longer sufficient.
- [x] A test proves a stale-SHA transition is rejected (`isFreshGreenTransition`, `ciGreen`, and `runMerge` levels — HEAD moved since the cached "pass").
- [x] Fail-closed: a missing `headRefOid` (e.g. the local `git rev-parse` failing) never accepts the shortcut.
- [x] `loadCiWatchState` never dereferences a symlink planted at the state path.

## Verification (honest)

- Full suite: `npm run verify` — **798/798 passing** (790 pre-existing + 8 new: 5 pure `isFreshGreenTransition`/`ciGreen` cases, 3 `runMerge` integration cases covering the SHA-match/SHA-mismatch/head-lookup-failure paths, plus symlink-guard and `sha` round-trip coverage in `monitors.test.mjs`).
- Updated 3 pre-existing #407 tests whose asserted behavior genuinely changed by this fix (a cached transition with no `sha`/no supplied `headRefOid` now correctly falls through instead of short-circuiting) — no assertion was weakened, only re-targeted at the new, stricter contract; `test-intent` gate confirms no weakening.
- Mechanical gates run against the PR base (`feat/407-graphql-call-reduction`): `conventions` ✓, `test-intent` ✓, `docsync` ✓, `dep-guard` ✓ (no new deps), `license` ✓. `situation`/`ac-gate`/`ground-gate` CLI subcommands aren't wired under this repo's current `forge gate` dispatch surface — not run directly, but their underlying checks (plan-drift n/a — no formal plan doc for this scope, consistent with #408's precedent of un-planned hardening fix commits; AC coverage — verified manually against the checklist above).
- **Not verified**: no live GitHub API exercise of the symlink guard's interaction with a *real* concurrent `ci-watch.mjs` monitor process — the writer/reader round-trip and the new sha-binding are unit-tested in isolation, matching #407's own stated verification boundary.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>