### PR TITLE
fix(board): key the repo/field cache by cwd, not just the gh instance

### DIFF
--- a/plugin/scripts/lib/board.mjs
+++ b/plugin/scripts/lib/board.mjs
@@ -61,12 +61,23 @@ export function optionKey(name) {
  * caller that just mutated what a fresh read must reflect (init.mjs's
  * post-create re-discovery). A failed lookup is never cached, so a transient gh
  * hiccup can still recover on the next call.
+ *
+ * #415 — the outer WeakMap is keyed by `gh` alone, which silently assumes one
+ * `gh` instance == one repo for that instance's entire lifetime. Today every
+ * caller upholds that (a fresh `gh`/ctx is constructed per repo — never
+ * `process.chdir()`'d into a different one mid-lifetime), so this is a latent
+ * footgun, not a live bug. The inner cache is additionally keyed by
+ * `process.cwd()` so a future caller that DID reuse one `gh` instance across a
+ * `chdir()` into a different repo would fetch fresh instead of silently
+ * serving the previous repo's owner/name/field IDs. Do not drop the cwd key.
  */
-const repoInfoCache = new WeakMap(); // gh -> value
-const projectFieldsCache = new WeakMap(); // gh -> Map(projectId -> value)
+const repoInfoCache = new WeakMap(); // gh -> Map(cwd -> value)
+const projectFieldsCache = new WeakMap(); // gh -> Map(`${cwd}::${projectId}` -> value)
 
 export async function getRepoInfo(gh, { refresh = false } = {}) {
-  if (!refresh && repoInfoCache.has(gh)) return repoInfoCache.get(gh);
+  const cwd = process.cwd();
+  const byCwd = repoInfoCache.get(gh);
+  if (!refresh && byCwd?.has(cwd)) return byCwd.get(cwd);
   const res = await gh(['repo', 'view', '--json', 'owner,name,defaultBranchRef'], { parseJson: true });
   if (!res.ok) return { ok: false, error: res.stderr || 'gh repo view failed' };
   const value = {
@@ -75,7 +86,9 @@ export async function getRepoInfo(gh, { refresh = false } = {}) {
     name: res.json.name,
     defaultBranch: res.json.defaultBranchRef?.name ?? 'main',
   };
-  repoInfoCache.set(gh, value);
+  const cache = byCwd ?? new Map();
+  cache.set(cwd, value);
+  repoInfoCache.set(gh, cache);
   return value;
 }
 
@@ -119,10 +132,11 @@ const FIELDS_QUERY = `query($id: ID!) {
 }`;
 
 /** Returns { itemsCount, fields: { <lowercased name>: {id, name, options:[{id,name}]} } }
- * Memoized per (gh, projectId) — #407 AC.3, see the cache docblock above `getRepoInfo`. */
+ * Memoized per (gh, cwd, projectId) — #407 AC.3 / #415, see the cache docblock above `getRepoInfo`. */
 export async function getProjectFields(gh, projectId, { refresh = false } = {}) {
-  const byProject = projectFieldsCache.get(gh);
-  if (!refresh && byProject?.has(projectId)) return byProject.get(projectId);
+  const key = `${process.cwd()}::${projectId}`;
+  const byKey = projectFieldsCache.get(gh);
+  if (!refresh && byKey?.has(key)) return byKey.get(key);
   const res = await gh(['api', 'graphql', '-f', `query=${FIELDS_QUERY}`, '-f', `id=${projectId}`], { parseJson: true });
   if (!res.ok) return { ok: false, error: res.stderr || 'fields query failed' };
   const node = res.json.data?.node;
@@ -132,8 +146,8 @@ export async function getProjectFields(gh, projectId, { refresh = false } = {}) 
     if (f && f.name) fields[f.name.toLowerCase()] = f;
   }
   const value = { ok: true, itemsCount: node.items.totalCount, fields };
-  const cache = byProject ?? new Map();
-  cache.set(projectId, value);
+  const cache = byKey ?? new Map();
+  cache.set(key, value);
   projectFieldsCache.set(gh, cache);
   return value;
 }

--- a/plugin/scripts/lib/board.mjs
+++ b/plugin/scripts/lib/board.mjs
@@ -134,6 +134,9 @@ const FIELDS_QUERY = `query($id: ID!) {
 /** Returns { itemsCount, fields: { <lowercased name>: {id, name, options:[{id,name}]} } }
  * Memoized per (gh, cwd, projectId) — #407 AC.3 / #415, see the cache docblock above `getRepoInfo`. */
 export async function getProjectFields(gh, projectId, { refresh = false } = {}) {
+  // `::` separator: safe in practice — projectId is a GitHub ProjectV2 node id
+  // (alphanumeric, e.g. "PVT_..."), and a cwd can't contain ':' outside a
+  // Windows drive letter, so no real (cwd, projectId) pair can collide here.
   const key = `${process.cwd()}::${projectId}`;
   const byKey = projectFieldsCache.get(gh);
   if (!refresh && byKey?.has(key)) return byKey.get(key);

--- a/tests/lib/board.test.mjs
+++ b/tests/lib/board.test.mjs
@@ -196,7 +196,9 @@ describe('getRepoInfo / getProjectFields memoization (AC-407.3)', () => {
 // footgun rather than a live bug — but a `process.chdir()` reuse of the SAME
 // `gh` instance must still fetch fresh instead of silently serving the
 // previous cwd's cached owner/name/field IDs.
-describe('cache key includes cwd, not just the gh instance (AC-415.1-3)', () => {
+// AC-415.3 (the regression test requirement) is satisfied by both `it`s below —
+// each IS the chdir regression test for its respective function.
+describe('cache key includes cwd, not just the gh instance (AC-415.1, AC-415.2, AC-415.3)', () => {
   const repoViewFor = (owner, name, branch) => ({
     ok: true,
     json: { owner: { login: owner }, name, defaultBranchRef: { name: branch } },

--- a/tests/lib/board.test.mjs
+++ b/tests/lib/board.test.mjs
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { tmpdir } from 'node:os';
 import { buildStatusMutation, replaceStatusOptions, STANDARD_STATUS, linkProject, optionKey, getRepoInfo, getProjectFields } from '../../plugin/scripts/lib/board.mjs';
 
 describe('linkProject (AC-B64.1, #64)', () => {
@@ -186,5 +187,63 @@ describe('getRepoInfo / getProjectFields memoization (AC-407.3)', () => {
     const second = await getProjectFields(gh, 'PVT_1');
     expect(second.ok).toBe(true);
     expect(calls).toBe(2);
+  });
+});
+
+// #415 — the cache key must incorporate the working directory, not just the `gh`
+// instance. Today every caller constructs a fresh `gh`/ctx per repo (never
+// `chdir()`s a long-lived `gh` into a different repo), so this was a latent
+// footgun rather than a live bug — but a `process.chdir()` reuse of the SAME
+// `gh` instance must still fetch fresh instead of silently serving the
+// previous cwd's cached owner/name/field IDs.
+describe('cache key includes cwd, not just the gh instance (AC-415.1-3)', () => {
+  const repoViewFor = (owner, name, branch) => ({
+    ok: true,
+    json: { owner: { login: owner }, name, defaultBranchRef: { name: branch } },
+  });
+  const fieldsFor = (itemsCount) => ({
+    ok: true,
+    json: { data: { node: { items: { totalCount: itemsCount }, fields: { nodes: [{ __typename: 'ProjectV2SingleSelectField', id: 'f1', name: 'Status', options: [] }] } } } },
+  });
+
+  it('AC-415.1: getRepoInfo does not leak across a process.chdir() reuse of the same gh instance', async () => {
+    const originalCwd = process.cwd();
+    try {
+      let calls = 0;
+      const gh = async () => {
+        calls++;
+        return calls === 1 ? repoViewFor('repoA-owner', 'repoA', 'main') : repoViewFor('repoB-owner', 'repoB', 'trunk');
+      };
+      const a = await getRepoInfo(gh);
+      process.chdir(tmpdir());
+      const b = await getRepoInfo(gh);
+      expect(a).toMatchObject({ owner: 'repoA-owner', name: 'repoA' });
+      expect(b).toMatchObject({ owner: 'repoB-owner', name: 'repoB' }); // NOT repoA's cached value
+      expect(calls).toBe(2); // the chdir forced a fresh fetch, not a cache hit
+
+      // and returning to the original cwd is still served from ITS own cache entry
+      process.chdir(originalCwd);
+      const aAgain = await getRepoInfo(gh);
+      expect(aAgain).toEqual(a);
+      expect(calls).toBe(2);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('AC-415.2: getProjectFields does not leak across a process.chdir() reuse for the SAME projectId', async () => {
+    const originalCwd = process.cwd();
+    try {
+      let calls = 0;
+      const gh = async () => { calls++; return fieldsFor(calls); };
+      const a = await getProjectFields(gh, 'PVT_1');
+      process.chdir(tmpdir());
+      const b = await getProjectFields(gh, 'PVT_1'); // same projectId, different cwd
+      expect(a.itemsCount).toBe(1);
+      expect(b.itemsCount).toBe(2); // NOT served from the original cwd's cache entry
+      expect(calls).toBe(2);
+    } finally {
+      process.chdir(originalCwd);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `getRepoInfo`/`getProjectFields` in `plugin/scripts/lib/board.mjs` memoized per injected `gh` function reference via a `WeakMap`, implicitly assuming one `gh` instance == one repo for that instance's whole lifetime.
- No current caller breaks that invariant (every long-lived caller binds one `gh` to one fixed cwd/repo), but a future caller that reused a single `gh` instance across a `process.chdir()` into a different repo would silently serve the first repo's `owner`/`name`/field IDs to the second — a documented latent footgun from the #411 security pass on #407's PR #410.
- Folds `process.cwd()` into both cache keys (`gh -> Map(cwd -> value)` for repo info, `gh -> Map(\`${cwd}::${projectId}\` -> value)` for project fields) to remove the assumption entirely, per the ticket's proposed scope. All existing memoization behavior (same-gh-same-cwd cache hits, `refresh:true` bypass, failed lookups never cached, per-projectId caching) is preserved.

Closes #415

## Test plan
- [x] `tests/lib/board.test.mjs`: new `AC-415.1-3` describe block — constructs one `gh` double, calls `getRepoInfo`/`getProjectFields`, `process.chdir()`s to a different real directory mid-lifetime, calls again, and asserts the second call is NOT served the first cwd's cached value (and does re-hit `gh`); also confirms returning to the original cwd still hits its own cache entry.
- [x] Full existing `AC-407.3` memoization suite still passes unmodified.
- [x] `npx vitest run` — 908/908 passing.
- [x] gates: conventions, testintent, docsync, dep — all pass.