### PR TITLE
fix(tests): stop hardcoding pnpm/action-setup's pinned SHA in AC-343.1

### DIFF
--- a/tests/ci-template.test.mjs
+++ b/tests/ci-template.test.mjs
@@ -91,7 +91,10 @@ describe('license gate CI wiring (#343)', () => {
     const licenseJob = wf.slice(wf.indexOf('\n  license:'));
     expect(licenseJob).toContain('runs-on: ubuntu-latest');
     expect(licenseJob).toContain('actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1');
-    expect(licenseJob).toContain('pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda');
+    // pnpm/action-setup: assert it's wired in and pinned to a full commit SHA
+    // (not a floating tag), but NOT the exact SHA — a routine Dependabot version
+    // bump re-pins this line and shouldn't require a companion test edit (#420).
+    expect(licenseJob).toMatch(/pnpm\/action-setup@[0-9a-f]{40}/);
     expect(licenseJob).toContain('actions/setup-node@820762786026740c76f36085b0efc47a31fe5020');
     expect(licenseJob).toContain('pnpm install --frozen-lockfile');
   });

--- a/tests/ci-template.test.mjs
+++ b/tests/ci-template.test.mjs
@@ -94,7 +94,7 @@ describe('license gate CI wiring (#343)', () => {
     // pnpm/action-setup: assert it's wired in and pinned to a full commit SHA
     // (not a floating tag), but NOT the exact SHA — a routine Dependabot version
     // bump re-pins this line and shouldn't require a companion test edit (#420).
-    expect(licenseJob).toMatch(/pnpm\/action-setup@[0-9a-f]{40}/);
+    expect(licenseJob).toMatch(/pnpm\/action-setup@[0-9a-f]{40}(?![0-9a-f])/);
     expect(licenseJob).toContain('actions/setup-node@820762786026740c76f36085b0efc47a31fe5020');
     expect(licenseJob).toContain('pnpm install --frozen-lockfile');
   });


### PR DESCRIPTION
## Summary
- `tests/ci-template.test.mjs`'s `AC-343.1` hardcoded the exact pinned commit SHA of `pnpm/action-setup` inside `verify.yml`'s `license` job, so every routine Dependabot action-version bump breaks this test (currently blocking PR #361's `pnpm/action-setup` 4.1.0 -> 6.0.9 bump) even though the wiring itself is unaffected.
- Replaced the exact-SHA `toContain` assertion with a regex that requires the action be present and pinned to a full 40-hex-char commit SHA (`/pnpm\/action-setup@[0-9a-f]{40}/`), rejecting floating tags/branches (`@v4`, `@main`) while no longer caring which SHA. The `actions/checkout` and `actions/setup-node` exact-SHA assertions, and the `pnpm install --frozen-lockfile` assertion, are unchanged.

Closes #420

## Test plan
- [x] `pnpm vitest run tests/ci-template.test.mjs` — 6/6 pass
- [x] `pnpm vitest run` (full suite) — 908/908 pass
- [x] Manually verified the new regex matches PR #361's target SHA (`0ebf47130e4866e96fce0953f49152a61190b271`) as well as the current SHA
- [x] reviewer + security subagent passes — no critical/high findings

## Notes
PR #361 (`dependabot/github_actions/pnpm/action-setup-6.0.9`) still needs a rebase onto `main` **after** this PR merges, since the dependabot-owned branch can't pick up this fix until it's on `main`. That rebase is a follow-up, not done here.