### PR TITLE
docs(install): surface Antigravity (agy) alongside Claude Code (#423)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [#389 — scaffold docs structure](plans/2026-08-06-389-scaffold-docs-structure.md) — tasks for #389 (parent #182): `forge:init` seeds `docs/{specs,plans,spikes,design,decisions,guides}/` + a route-index template on a fresh scaffold only, never on adopt; the convention documented as a named rule in `docs/guides/install.md`.
 - [#407 — GraphQL call reduction](plans/2026-08-08-407-graphql-call-reduction.md) — tasks for #407 (parent #183): wires the dead `rateBudget()` preflight into autopilot's run-start + periodic checks, threads the `forge-ci` monitor's fresh transition into `merge.mjs`'s `ciGreen()` to cut a redundant CI-status poll, and memoizes `lib/board.mjs`'s repo/field lookups per `gh` instance.
 - [#408 — outage detection + recovery](plans/2026-08-08-408-outage-detection.md) — tasks for #408 (parent #183): `isPlatformOutage()` in `exec.mjs`, stuck-queued wiring in the CI-watch monitor, and bounded rebase+repush recovery in the merge bar — distinguishes a GitHub Actions platform outage from a real gate failure.
+- [#423 — clarify AGY install docs](plans/2026-08-12-423-agy-install-docs.md) — tasks for #423: splits `docs/guides/install.md`'s "Install the plugin" step into Claude Code / Antigravity (agy) subsections and adds an agy install box to `site/index.html`'s Install section, grounded in the existing Cross-GAI guide.
 
 ## Spikes
 
@@ -76,7 +77,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 
 ## Guides
 
-- [Install](guides/install.md) — forge into any project: prerequisites, marketplace install, init adopt-vs-create, doctor, per-feature wiring, superpowers migration.
+- [Install](guides/install.md) — forge into any project: prerequisites, marketplace install (Claude Code or Antigravity), init adopt-vs-create, doctor, per-feature wiring, superpowers migration.
 - [Handbook](guides/handbook.md) — daily use: the laws, the cockpit, the Build loop, every human interaction point, care/knowledge/scale flows, gates + situations tables.
 - [Cross-GAI (agy)](guides/cross-gai.md) — run forge on Antigravity: `forge init --host agy` emit flow, plugin layout, MCP/hooks wiring, the deny/capture shims, Windows gotchas (MAX_PATH), and the honest capability/parity matrix.
 - [Troubleshooting](guides/troubleshooting.md) — known issues: update-not-visible ladder, statusline wiring overwrites, board drift, hooks, environment.

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -11,7 +11,13 @@ The full path from any repo — fresh or existing (cms included) — to a workin
 | gh CLI, authed, `project` scope | `gh auth status` | `gh auth login -s project` (existing auth: `gh auth refresh -s project`) |
 | a git repo on GitHub | `git remote -v` | push it first — the board, tickets, and trail all live there |
 
+> Running Antigravity instead of Claude Code? Same Node/git/gh prerequisites, plus the `agy` CLI on PATH (`agy --version`) — skip to [Antigravity (agy)](#antigravity-agy) below.
+
 ## 1. Install the plugin
+
+Pick your host. From step 2 on this guide is host-agnostic — `/forge:init`, doctor, the gates, and everything after work the same way regardless of which one installed the plugin.
+
+### Claude Code
 
 In a Claude Code session inside the target repo:
 
@@ -23,6 +29,16 @@ In a Claude Code session inside the target repo:
 (or from the terminal: `claude plugin marketplace add dngioidev/forge` then `claude plugin install forge@forge`.)
 
 This brings the 20 skills, the `/forge:*` commands, the safety + learning hooks, and the graph MCP server. Nothing runs against your repo yet.
+
+### Antigravity (agy)
+
+forge's engine is host-agnostic ([ADR-0007](../decisions/0007-cross-gai-mcp-first.md)); Antigravity, via its `agy` CLI, is the one adapter **proven end-to-end today** (Codex is deferred, see [#292](https://github.com/dngioidev/forge/issues/292)). From a forge checkout:
+
+```
+node plugin/scripts/init.mjs --host agy
+```
+
+No `--out` is the recommended path: the package emits in place to `.agents/plugins/forge/` and agy discovers it there — nothing to copy or relocate. agy ingests the Claude plugin format natively (skills, agents, and commands copied byte-for-byte, slash commands auto-converted to skills), so you get the same 20 skills and `/forge:*` commands as Claude Code. For a custom `--out` staging path, the MCP/hook wiring detail, Windows gotchas (MAX_PATH), and the full capability/parity matrix, see the [Cross-GAI guide](cross-gai.md).
 
 ## 2. Bootstrap: `/forge:init`
 

--- a/docs/plans/2026-08-12-423-agy-install-docs.md
+++ b/docs/plans/2026-08-12-423-agy-install-docs.md
@@ -1,0 +1,70 @@
+# Plan: #423 - clarify AGY installation on landing page and install guide
+
+**Ticket:** #423 (board #8) - **Kind:** docs
+**Base:** main - **Branch:** docs/423-agy-install
+
+Feedback: installing with Antigravity (`agy`) is not shown on the landing page
+(`site/index.html`) and `docs/guides/install.md`'s Step 1 is Claude-Code-only,
+so an agy user can't tell how to install forge from either doc. forge's engine
+is already host-agnostic (ADR-0007) and the agy adapter is proven end-to-end
+(`docs/guides/cross-gai.md`) — the gap is presentation, not capability.
+
+**Owner-approved approach** (decision `esc-423-msnjwjfk`, approved): update both
+`site/index.html` and `docs/guides/install.md` to explicitly mention and
+separate AGY instructions. Avoid duplicating the `/plugin` slash-command /
+terminal-command pair for agy (agy has no slash-command form, so there is
+nothing to duplicate against); state AGY as a primary environment with the one
+real fallback terminal command it does have, and defer full detail to the
+existing Cross-GAI guide rather than re-deriving agy install steps here.
+
+Every agy fact below is grounded in `docs/guides/cross-gai.md` (Steps 1-4,
+prerequisites table) — no new AGY installation steps are invented.
+
+## AC map
+
+- **AC-423.1** `site/index.html`'s Install section (`#install`) explicitly
+  names Antigravity as an install path alongside Claude Code, with a concrete
+  agy command (not just a passing mention), and links to the Cross-GAI guide.
+- **AC-423.2** `docs/guides/install.md`'s "Install the plugin" step is split
+  into a **Claude Code** subsection (existing content, unchanged) and an
+  **Antigravity (agy)** subsection: the grounded emit command
+  (`node plugin/scripts/init.mjs --host agy`), the in-place-discovery
+  rationale, and a link to `cross-gai.md` for the full walkthrough — without
+  duplicating the Claude-Code slash/terminal pair for agy.
+- **AC-423.3** the prerequisites table in `docs/guides/install.md` is
+  cross-referenced for agy users (same Node/git/gh prerequisites plus the
+  `agy` CLI) so the table isn't read as Claude-Code-exclusive.
+
+## Task 1 (docs): surface AGY on the landing page (AC-423.1)
+
+Add a second, labeled install box to the `#install` section's right column
+(`site/index.html`) showing the agy emit command
+(`node plugin/scripts/init.mjs --host agy`), and extend the prerequisites
+paragraph to cross-link `docs/guides/cross-gai.md`. Mirror the existing
+`.installbox`/`.top`/`.p` markup idiom exactly — no new CSS.
+
+**Files:** site/index.html
+
+## Task 2 (docs): split Step 1 of the install guide by host (AC-423.2, AC-423.3)
+
+Restructure `docs/guides/install.md` `## 1. Install the plugin` into `### Claude
+Code` (existing content) and `### Antigravity (agy)` (new), and add a one-line
+cross-reference under the prerequisites table pointing agy users at the new
+subsection.
+
+**Files:** docs/guides/install.md
+
+## Task 3 (test): grounding tests for the AGY doc content (AC-423.1, AC-423.2, AC-423.3)
+
+New vitest file that reads both files and asserts the required substrings are
+present (mirrors the AC-307.2 doc-content-assertion pattern in
+`tests/agy/emit.test.mjs`) — machine evidence for the ac-gate on a docs-only
+change.
+
+**Files:** tests/docs/agy-install-docs.test.mjs
+
+## Task 4 (docs): route index (AC-423.2)
+
+Add this plan to the docs route index.
+
+**Files:** docs/README.md

--- a/site/index.html
+++ b/site/index.html
@@ -442,7 +442,7 @@
   <div class="wrap">
     <div>
       <span class="eyebrow">Install</span>
-      <h2>Three commands, inside Claude Code — or Antigravity.</h2>
+      <h2>Three commands inside Claude Code — one to emit for Antigravity.</h2>
       <div class="steps" style="margin-top:26px">
         <div class="step"><span class="num">01</span><span class="txt">Add the marketplace, install the plugin.</span></div>
         <div class="step"><span class="num">02</span><span class="txt">Run <span class="c">/forge:init</span> — adopt or create, wire the board, gates, hooks.</span></div>

--- a/site/index.html
+++ b/site/index.html
@@ -442,13 +442,13 @@
   <div class="wrap">
     <div>
       <span class="eyebrow">Install</span>
-      <h2>Three commands, inside Claude Code.</h2>
+      <h2>Three commands, inside Claude Code — or Antigravity.</h2>
       <div class="steps" style="margin-top:26px">
         <div class="step"><span class="num">01</span><span class="txt">Add the marketplace, install the plugin.</span></div>
         <div class="step"><span class="num">02</span><span class="txt">Run <span class="c">/forge:init</span> — adopt or create, wire the board, gates, hooks.</span></div>
         <div class="step"><span class="num">03</span><span class="txt">Describe work as tickets. Run <span class="c">/forge:deliver</span> or <span class="c">/forge:autopilot</span>.</span></div>
       </div>
-      <p class="req">Prerequisites: <code>Claude Code</code>, <code>Node ≥ 22.13</code>, <code>pnpm 10.14+</code>, and a GitHub account. Full wiring in the <a href="https://github.com/dngioidev/forge/blob/main/docs/guides/install.md" style="color:var(--claude)">install guide</a>.</p>
+      <p class="req">Prerequisites: <code>Claude Code</code>, <code>Node ≥ 22.13</code>, <code>pnpm 10.14+</code>, and a GitHub account. Full wiring in the <a href="https://github.com/dngioidev/forge/blob/main/docs/guides/install.md" style="color:var(--claude)">install guide</a>. Running <a href="https://github.com/dngioidev/forge/blob/main/docs/guides/cross-gai.md" style="color:var(--claude)">Antigravity</a> instead? Same plugin, its own one-command emit flow — see the box alongside.</p>
     </div>
     <div>
       <div class="installbox">
@@ -456,6 +456,10 @@
 <pre><span class="p">/plugin</span> marketplace add dngioidev/forge
 <span class="p">/plugin</span> install forge@forge
 <span class="p">/forge:init</span></pre>
+      </div>
+      <div class="installbox" style="margin-top:14px">
+        <div class="top">or, running Antigravity (agy)</div>
+<pre><span class="p">node</span> plugin/scripts/init.mjs --host agy</pre>
       </div>
       <div class="cta-row" style="margin-top:22px">
         <a class="btn btn-primary" href="https://github.com/dngioidev/forge">Star on GitHub</a>

--- a/tests/docs/agy-install-docs.test.mjs
+++ b/tests/docs/agy-install-docs.test.mjs
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('#423 — AGY install docs', () => {
+  it('AC-423.1: site/index.html surfaces Antigravity as an install path in the #install section', async () => {
+    const html = await readFile(join(repoRoot, 'site', 'index.html'), 'utf8');
+    const installSection = html.slice(html.indexOf('id="install"'), html.indexOf('</section>', html.indexOf('id="install"')));
+    expect(installSection).toMatch(/Antigravity/);
+    expect(installSection).toContain('plugin/scripts/init.mjs --host agy');
+    expect(installSection).toContain('docs/guides/cross-gai.md');
+  });
+
+  it('AC-423.2: docs/guides/install.md splits Step 1 into Claude Code and Antigravity (agy) subsections', async () => {
+    const guide = await readFile(join(repoRoot, 'docs', 'guides', 'install.md'), 'utf8');
+    expect(guide).toContain('### Claude Code');
+    expect(guide).toContain('### Antigravity (agy)');
+    // grounded in the real emit command from cross-gai.md — no invented steps
+    expect(guide).toContain('node plugin/scripts/init.mjs --host agy');
+    expect(guide).toMatch(/\[Cross-GAI guide\]\(cross-gai\.md\)/);
+    // does not duplicate the Claude-Code slash/terminal command pair for agy
+    const agySection = guide.slice(guide.indexOf('### Antigravity (agy)'));
+    expect(agySection).not.toContain('/plugin marketplace add');
+    expect(agySection).not.toContain('claude plugin marketplace add');
+  });
+
+  it('AC-423.3: the prerequisites table cross-references agy users to the Antigravity subsection', async () => {
+    const guide = await readFile(join(repoRoot, 'docs', 'guides', 'install.md'), 'utf8');
+    const beforeStep1 = guide.slice(0, guide.indexOf('## 1. Install the plugin'));
+    expect(beforeStep1).toMatch(/Running Antigravity instead of Claude Code/);
+    expect(beforeStep1).toContain('agy --version');
+    expect(beforeStep1).toMatch(/\[Antigravity \(agy\)\]\(#antigravity-agy\)/);
+  });
+});


### PR DESCRIPTION
Closes #423

Feedback said installing with Antigravity (`agy`) wasn't visible on the landing page and that `docs/guides/install.md` was ambiguous about it. forge's engine is already host-agnostic (ADR-0007) and the agy adapter is proven end-to-end in `docs/guides/cross-gai.md` — the gap was presentation, not capability.

Per the owner-approved approach on the ticket (decision `esc-423-msnjwjfk`): explicitly surface AGY as a primary environment alongside Claude Code, **without** duplicating the `/plugin` slash-command pair (agy has no slash-command install form — its real entry point is the one-command emit), and defer the full walkthrough to the existing Cross-GAI guide rather than re-deriving agy install steps in a second place.

## What changed

- **`site/index.html`** — the `#install` section gains a second `.installbox` ("or, running Antigravity (agy)") showing the real emit command, the heading becomes "Three commands, inside Claude Code — or Antigravity.", and the prerequisites paragraph cross-links the Cross-GAI guide. Reuses the existing `.installbox`/`.top`/`.p` markup idiom — **no new CSS**.
- **`docs/guides/install.md`** — `## 1. Install the plugin` is split into `### Claude Code` (existing content, byte-identical) and a new `### Antigravity (agy)` subsection; a one-line note under the prerequisites table routes agy users there and names the extra `agy --version` prerequisite.
- **`tests/docs/agy-install-docs.test.mjs`** — new, 3 grounding tests (mirrors the existing AC-307.2 doc-content-assertion pattern in `tests/agy/emit.test.mjs`).
- **`docs/plans/2026-08-12-423-agy-install-docs.md`** + **`docs/README.md`** — the plan and its route-index row.

## Acceptance criteria

- [x] **AC-423.1** — `site/index.html`'s `#install` section explicitly names Antigravity as an install path alongside Claude Code, with a concrete agy command (not just a passing mention), and links to the Cross-GAI guide.
- [x] **AC-423.2** — `docs/guides/install.md`'s "Install the plugin" step is split into Claude Code / Antigravity (agy) subsections: the grounded emit command, the in-place-discovery rationale, and a link to `cross-gai.md` — without duplicating the Claude-Code slash/terminal command pair for agy.
- [x] **AC-423.3** — the prerequisites table is cross-referenced for agy users (same Node/git/gh prerequisites plus the `agy` CLI), so it isn't read as Claude-Code-exclusive.

## Grounding

Every AGY claim traces to a pre-existing source in this repo — nothing was invented:

| claim | source |
| --- | --- |
| `node plugin/scripts/init.mjs --host agy` | `docs/guides/cross-gai.md` Step 1; `plugin/scripts/init.mjs` (`--host` parsing, `agy` the only accepted value) |
| no `--out` is the recommended path; emits to `.agents/plugins/forge/`, discovered in place | `docs/guides/cross-gai.md` Step 1 |
| agy ingests the Claude plugin format natively; slash commands auto-convert to skills | `docs/guides/cross-gai.md` "What gets emitted" + Step 4 validate output |
| Antigravity is the one adapter proven end-to-end; Codex deferred to #292 | `docs/guides/cross-gai.md` intro; ADR-0007 |
| the `agy` CLI prerequisite (`agy --version`) | `docs/guides/cross-gai.md` prerequisites table |

## Verification (what was actually run)

- `pnpm verify` — **911 tests / 62 files, all passing**, including the 3 new ones.
- Gates: `plandrift` **pass**, `testintent` **pass**, `depguard` **pass** (no new deps), `acgate` **pass** (all 3 ACs mapped to passing tests via the vitest JSON reporter).
- HTML sanity check on `site/index.html`: `<div>` 124/124 balanced, `<pre>` 2/2 balanced, DOCTYPE intact. The new box reuses existing classes, so no stylesheet change was needed.
- `forge:reviewer` and `forge:security` full-branch subagents: both `verdict: pass`, zero critical/high. The reviewer raised one *minor* copy inconsistency — the h2 claimed "three commands" for both hosts while the agy box shows one — fixed in the second commit; gates + verify re-run green after it.
- Ship gates: `situation` **pass**, `conventions` **pass**, `docsync` **pass**. Rebased on `origin/main` (already current).

No runtime surface is touched — this is docs + static site markup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
