### PR TITLE
chore(config): reconcile the stale self-hosted runner block with hosted-CI reality (#426)

### DIFF
--- a/.claude/forge.json
+++ b/.claude/forge.json
@@ -52,7 +52,7 @@
     "plansDir": "docs/plans"
   },
   "runner": {
-    "enabled": true,
+    "enabled": false,
     "labels": ["self-hosted", "linux", "forge-local"],
     "sharing": "repo",
     "windows": "native"

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ One line per doc. Update this file whenever a doc lands, moves, or renames (`for
 - [#407 — GraphQL call reduction](plans/2026-08-08-407-graphql-call-reduction.md) — tasks for #407 (parent #183): wires the dead `rateBudget()` preflight into autopilot's run-start + periodic checks, threads the `forge-ci` monitor's fresh transition into `merge.mjs`'s `ciGreen()` to cut a redundant CI-status poll, and memoizes `lib/board.mjs`'s repo/field lookups per `gh` instance.
 - [#408 — outage detection + recovery](plans/2026-08-08-408-outage-detection.md) — tasks for #408 (parent #183): `isPlatformOutage()` in `exec.mjs`, stuck-queued wiring in the CI-watch monitor, and bounded rebase+repush recovery in the merge bar — distinguishes a GitHub Actions platform outage from a real gate failure.
 - [#423 — clarify AGY install docs](plans/2026-08-12-423-agy-install-docs.md) — tasks for #423: splits `docs/guides/install.md`'s "Install the plugin" step into Claude Code / Antigravity (agy) subsections and adds an agy install box to `site/index.html`'s Install section, grounded in the existing Cross-GAI guide.
+- [#426 — reconcile the stale self-hosted runner config](plans/2026-08-12-426-runner-config-reconcile.md) — tasks for #426 (parent #182): flips `.claude/forge.json`'s `runner.enabled` to `false` to match this public repo's hosted-only CI reality, with regression tests pinning `forge:doctor`/`forge:runner-check`'s coherent verdict against the repo's own committed config.
 
 ## Spikes
 

--- a/docs/plans/2026-08-12-426-runner-config-reconcile.md
+++ b/docs/plans/2026-08-12-426-runner-config-reconcile.md
@@ -1,0 +1,80 @@
+# Plan: #426 - reconcile the stale self-hosted `runner` block against hosted-runner CI reality
+
+**Ticket:** #426 (parent #182) - **Kind:** chore
+**Base:** main - **Branch:** chore/426-runner-config-reconcile
+
+Surfaced by #339 delivery / the full-branch review of PR #425: `.claude/forge.json`
+declared `runner.enabled: true`, but `.github/workflows/verify.yml` runs every leg
+on GitHub-hosted runners (this repo is public — hosted minutes are free/unlimited
+and a self-hosted runner must never process untrusted fork PRs; ADR-0005 decision
+3). The config block and the actual CI topology disagreed, which is a live
+footgun for anything that reads `runner` to reason about CI (`forge:runner-check`,
+`forge:doctor`'s runner-health line, a human reading the config).
+
+Confirmed before the fix: `node plugin/scripts/doctor.mjs` on this repo reported
+`✗ runner   runner.enabled on a PUBLIC repo — forks can run untrusted code on your
+machine (fork-PR RCE)` — a real FAIL line, even though the runner block was never
+wired into this repo's actual CI (`verify.yml` never references the `forge-local`
+label). That is the misleading picture AC.2 targets.
+
+Non-goal (explicit in the ticket): do not change where CI actually runs. The
+hosted-runner posture is correct for a public repo; this only fixes config/docs
+drift. `verify.yml`'s `runs-on` values are untouched.
+
+## AC map
+
+- **AC-426.1** `.claude/forge.json`'s `runner` block reflects reality for this
+  public repo: `enabled: false` (the documented, safe default — off until
+  explicitly enabled — per `RUNNER_DEFAULTS` in `plugin/scripts/lib/config.mjs`),
+  with the rest of the block (`labels`/`sharing`/`windows`) left in place as the
+  template a private fork would flip on (already documented as "Private
+  repositories only" in `runner/README.md` and ADR-0005). No schema change
+  needed: `enabled: false` is unambiguous and requires no new annotation field.
+- **AC-426.2** `forge:doctor` and `forge:runner-check` (both built on the shared
+  `plugin/scripts/lib/runner-checks.mjs`) report a coherent, non-misleading
+  verdict once AC-426.1 lands: doctor is silent on `runner`/`runner-secret` (its
+  existing "silent unless `runner.enabled`" behavior, `plugin/scripts/doctor.mjs`
+  line ~200) — no more false FAIL — while `forge:runner-check`, whose job is an
+  *adoption* preflight, still and correctly reports NOT READY (`runner-block`
+  disabled + `private-repo` public — both true, not contradictory). Neither
+  command's check logic needed to change; the fix is the config value itself.
+  Pinned by a regression test in each command's suite that loads the ACTUAL
+  committed `.claude/forge.json` (not a synthetic fixture) against a PUBLIC repo
+  view matching this repo's real visibility.
+
+## Task 1 (chore): flip the stale `runner.enabled` to match reality (AC-426.1)
+
+`.claude/forge.json`: `runner.enabled` `true` → `false`. Labels/sharing/windows
+left as-is (documents what a private-fork opt-in would use; matches
+`RUNNER_DEFAULTS`). No code change — `normalizeRunner`/`validateConfig`
+(`plugin/scripts/lib/config.mjs`) already treat `enabled:false` as the fully
+valid, documented-safe shape.
+
+**Files:** .claude/forge.json
+
+## Task 2 (test): pin the coherent doctor/runner-check verdict (AC-426.1, AC-426.2)
+
+`tests/doctor.test.mjs` — new case in the `runDoctor — runner health (AC-225.4)`
+describe block: reads the live `.claude/forge.json`, asserts
+`runner.enabled !== true` (regression pin against re-drifting), copies it
+byte-for-byte into a tmp cwd, runs `runDoctor` against a PUBLIC repo view
+(matching this repo's real visibility), and asserts zero `runner`/`runner-secret`
+results and no `runner`-named entry in the failed set.
+
+`tests/runner-check.test.mjs` — new case in the `runCheck — adoption readiness
+(#245)` describe block: same live-config load + pin, run through `runCheck`
+against a PUBLIC repo view + a scaffolded runner tree, asserting `ready:false`
+for the honest reasons only (`runner-block` fail mentioning "disabled",
+`private-repo` fail mentioning public/fork) — never a false READY for a config
+that is both inactive and unsafe to enable on this repo.
+
+**Files:** tests/doctor.test.mjs, tests/runner-check.test.mjs
+
+## Verification
+
+`pnpm verify` (full suite). Gates: plandrift clean (both **Files:** lists cover
+every touched path), testintent clean (only new assertions added), depguard
+clean (no new dependencies), ac-gate clean (AC-426.1 and AC-426.2 each covered
+by ≥1 passing test). Manual before/after: `node plugin/scripts/doctor.mjs` and
+`node plugin/scripts/runner/check.mjs` run directly against this repo, quoting
+real output in the PR.

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -161,6 +161,22 @@ describe('runDoctor — runner health (AC-225.4)', () => {
     expect(res.ok).toBe(false);
   });
 
+  it('AC-426.1, AC-426.2: this repo\'s own committed forge.json runner block matches hosted-CI reality — disabled on the PUBLIC repo it actually is, so doctor stays silent (no misleading FAIL)', async () => {
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    // Pin: this repo's CI runs entirely on GitHub-hosted runners (.github/workflows/verify.yml) —
+    // the `runner` block must never silently drift back to "enabled" here (that's what caused
+    // doctor to FAIL with a false fork-PR-RCE alarm before #426).
+    expect(committed.runner?.enabled).not.toBe(true);
+    const cwd = await tmpCwd();
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed), 'utf8');
+    const { gh } = fakeGh(runnerRoutes({ view: PUBLIC_VIEW }));
+    const res = await runDoctor({ gh, cwd, log: noop });
+    expect(byName(res, 'runner')).toEqual([]);
+    expect(byName(res, 'runner-secret')).toEqual([]);
+    expect(res.results.filter((r) => r.level === 'fail').map((r) => r.name)).not.toContain('runner');
+  });
+
   it('secret store TRACKED in git → FAIL', async () => {
     // runner.env committed (not ignored) → tracked → fail
     const cwd = await gitRepo({ gitignore: '.forge/\n', files: { 'runner.env': 'FORGE_RUNNER_PAT=redacted\n' } });

--- a/tests/runner-check.test.mjs
+++ b/tests/runner-check.test.mjs
@@ -120,6 +120,25 @@ describe('runCheck — adoption readiness (#245)', () => {
     expect(byName(res, 'private-repo')[0].msg).toMatch(/public|fork/i);
   });
 
+  it('AC-426.1, AC-426.2: this repo\'s own committed forge.json runner block, run against its real PUBLIC topology → honest NOT READY (never a false READY for an inactive, unsafe-to-adopt config)', async () => {
+    const cwd = await gitRepo();
+    const committed = JSON.parse(await readFile(join(process.cwd(), '.claude', 'forge.json'), 'utf8'));
+    // Pin: the committed block must not claim "enabled" on this public repo (#426) —
+    // CI here runs entirely on GitHub-hosted runners (.github/workflows/verify.yml).
+    expect(committed.runner?.enabled).not.toBe(true);
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(join(cwd, '.claude', 'forge.json'), JSON.stringify(committed), 'utf8');
+    await writeScaffold(cwd);
+    const { gh } = fakeGh(routes({ view: PUBLIC_VIEW, runners: runnersResponse([{ id: 1, status: 'online', labels: FORGE_LINUX }]) }));
+    const res = await runCheck({ gh, cwd, log: noop, exec: fakeExec() });
+    // Never a false READY for a config that is both disabled and unsafe to enable here.
+    expect(res.ready).toBe(false);
+    expect(byName(res, 'runner-block')[0].level).toBe('fail');
+    expect(byName(res, 'runner-block')[0].msg).toMatch(/disabled/i);
+    expect(byName(res, 'private-repo')[0].level).toBe('fail');
+    expect(byName(res, 'private-repo')[0].msg).toMatch(/public|fork/i);
+  });
+
   it('runner block missing/disabled → NOT READY (runner-block fail)', async () => {
     const cwd = await gitRepo();
     await writeCfg(cwd, { enabled: false });


### PR DESCRIPTION
Closes #426

`.claude/forge.json` declared `runner.enabled: true`, but `.github/workflows/verify.yml` runs **every** leg on GitHub-hosted runners (`ubuntu-latest` / `windows-latest`). This repo is public, so hosted minutes are free and unlimited, and a self-hosted runner must never process untrusted fork PRs (ADR-0005 decision 3). The config block and the actual CI topology disagreed.

**Non-goal honored:** where CI actually runs is unchanged. `verify.yml`'s `runs-on` values are untouched, and the check logic in `doctor.mjs` / `runner/check.mjs` / `lib/runner-checks.mjs` is untouched. The fix is the config value plus regression tests.

## The shape chosen for AC.1

AC.1 offered two acceptable shapes (disable/remove, or annotate as the private-fork opt-in). Chose **`enabled: false`**, leaving `labels`/`sharing`/`windows` in place:

- `enabled: false` is the documented safe default — it is byte-identical to `RUNNER_DEFAULTS` in `plugin/scripts/lib/config.mjs` (`{enabled: false, labels: ['self-hosted','linux','forge-local'], sharing: 'repo', windows: 'native'}`), so the block now reads as exactly the stock template a private fork would flip on.
- No schema change and no new annotation field, so nothing has to special-case a new key. `runner-check` / `doctor` stay honest with zero added logic.
- The "private repositories only" framing already lives in `runner/README.md` and ADR-0005; duplicating it as a config comment would be a third copy to drift.

## Acceptance criteria

- [x] **AC.1** — `.claude/forge.json`'s `runner` block reflects reality: `enabled` flipped `true` → `false` for this public, hosted-CI repo.
- [x] **AC.2** — `forge:doctor` and `forge:runner-check` report a coherent, non-misleading verdict, with a test pinning it in each command's suite.

## Verification (real output, run against this repo)

`node plugin/scripts/doctor.mjs` — **before**:

```
✗ runner             runner.enabled on a PUBLIC repo — forks can run untrusted code on your machine (fork-PR RCE)  → set runner.enabled=false, or keep the repo private (ADR-0005 decision 3)
✓ runner-secret      runner.env gitignored + untracked; no PAT in committed files
✓ runner-version     pinned actions-runner v2.336.0 is current
⚠ runner-service     a runner service is present (targeting dngioidev/forge, dngioidev/iomanage) but dngioidev/forge has 0 online matching runners - the service may be targeting a different repo (JIT-ephemeral hides this)
doctor: 1 problem(s)
```

**after** — the runner lines are gone entirely (doctor is silent unless `runner.enabled`), and the false fork-PR-RCE alarm with them:

```
✓ gh-auth            authenticated with project scope
✓ node               node 22.23.1
✓ git                inside a git work tree
✓ config             .claude\forge.json valid
✓ board              project + all field/option ids resolve
✓ delivery-log       issue #15 open
✓ gitignore          .forge/ ignored
✓ ci-verify          verify workflow present
✓ statusline         wired
✓ branch-protection  main protected
✓ secret-scanning    enabled
doctor: healthy
```

`node plugin/scripts/runner/check.mjs` — **before** (incoherent: claims the runner is enabled and healthy, while the guard says it must not be):

```
✓ runner-block           runner enabled — labels [self-hosted, linux, forge-local], sharing:repo, windows:native
✗ private-repo           this is a PUBLIC repo — a self-hosted runner would let forks run untrusted code on your machine (fork-PR RCE)
...
NOT READY — 1 blocker(s): private-repo.
```

**after** (coherent: the block is off, and adopting it here would be unsafe — both true, and they agree):

```
✗ runner-block           runner block is absent or disabled in forge.json (runner.enabled != true)  → add a runner block with "enabled": true (see docs/guides/runner-adoption.md)
✗ private-repo           this is a PUBLIC repo — a self-hosted runner would let forks run untrusted code on your machine (fork-PR RCE)
...
NOT READY — 2 blocker(s): runner-block, private-repo.
```

`runner-check` is an *adoption* preflight, so NOT READY remains the honest verdict — the repo genuinely is not a candidate for the local runner. What changed is that the two lines no longer contradict each other, and `doctor` (the always-on health check) no longer cries wolf.

## Tests

Both new tests load the **actual committed** `.claude/forge.json` rather than a synthetic fixture, and assert `runner.enabled !== true` as a drift pin:

- `tests/doctor.test.mjs` — the live config against a PUBLIC repo view yields zero `runner`/`runner-secret` results and no `runner` entry in the failed set.
- `tests/runner-check.test.mjs` — the live config through `runCheck` yields `ready: false` for exactly the two honest reasons, never a false READY.

The reviewer independently confirmed the pins are not vacuous by flipping `enabled` back to `true` and observing both tests fail, then reverting.

- `pnpm verify`: **917 passed / 917**, 63 test files, 0 failed.
- Gates: plandrift clean (5 touched, all declared) · testintent clean (no assertions weakened) · depguard clean (no new deps) · docsync clean (71 docs indexed) · conventions clean · situation-gate proceed.
- ac-gate: `AC-426.1 ✓`, `AC-426.2 ✓` — all 2 ACs covered by passing tests.
- Adversarial review: `forge:reviewer` **pass** (0 findings) · `forge:security` **pass** (0 findings, confirmed the pre-existing "enabled on a PUBLIC repo → FAIL" guard test is byte-unmodified, so the ADR-0005 guard is not weakened for anyone who re-enables the block later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2bz8xioxL4h5NMP85bRCf
