### PR TITLE
fix(denylist): anchor SAFE_RM_TARGETS to path components and judge each rm target on its own (#446)

### DIFF
--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -15,7 +15,33 @@
  * for a few known-catastrophic commands, not a security boundary.
  */
 
-const SAFE_RM_TARGETS = /(node_modules|\.forge|dist|build|coverage|te?mp|\$TMP|\$TEMP|scratchpad)/i;
+// Component-anchored (#446): each alternative must occupy a WHOLE path
+// component, not merely appear as a substring. `dist` and `dist/` are safe;
+// `distribution-of-secrets` is not, because "dist" there abuts "r", not a
+// component boundary. The boundary class is path separators (`/` — the only
+// one bash itself treats specially — and a bare `\`, which can only reach
+// this regex as a SURVIVING literal separator: normalizeShellText() consumes
+// a lone backslash as an escape, so a literal one only comes through when the
+// source doubled it, `dist\\build`, exactly how bash's own argv expansion
+// keeps a literal backslash, verified against this platform's bash), plus
+// whitespace/start/end for a bare argument. Deliberately NOT `\b`/word-
+// boundary: a hyphen is a non-word character, so a plain `\b` would still
+// treat "coverage" inside `coverage-notes-prod-db` as a whole word and let
+// the exact bypass this ticket closes back in.
+//
+// `$TMP`/`$TEMP` get no special-casing (AC.4): they are matched by the same
+// component-anchored rule as every literal directory name, which already
+// produces the right outcome for the one case that matters — bash itself
+// resolves `$TMPDIR` to a DIFFERENT (and here, unset) variable than `$TMP`
+// followed by literal `DIR`, because env-var-name expansion consumes maximal
+// `[A-Za-z0-9_]*` after the `$`. The component boundary here (`/`, whitespace,
+// `\`, start/end) is a STRICTER right-edge than bash's own variable-name
+// boundary would be (it also rejects a same-token `-` suffix bash would
+// resolve as literal data, e.g. `$TMP-backup`), which only ever narrows the
+// safe set — the one case AC.2 requires, `"$TMP/forge-test"`, has a `/`
+// immediately after `$TMP` and keeps matching.
+const SAFE_RM_TARGETS =
+  /(?:^|[\s/\\])(?:node_modules|\.forge|dist|build|coverage|te?mp|\$TMP|\$TEMP|scratchpad)(?=$|[\s/\\])/i;
 const PROTECTED_BRANCHES = /\b(main|master|staging|production)\b/;
 
 /**

--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -193,7 +193,7 @@ const SEPARATOR_CHARS = /[;|&\n]/;
  *  1. **Quote characters are removed** (`-"f"` -> `-f`).
  *  2. **Backslashes are removed** (`-\f` -> `-f`, `-\-hard` -> `--hard`), and
  *     the `$` introducing ANSI-C/locale quoting is dropped so `$'-f'` -> `-f`.
- *     A `$` anywhere else is untouched, so `$TMP` still matches SAFE_RM_TARGETS
+ *     A `$` anywhere else is untouched, so `$TMP` still matches SAFE_RM_TARGET
  *     and `$(` still trips `eval-exec`.
  *  3. **Shell separators found INSIDE a quoted region become spaces.**
  *     `splitSegments()` is not quote-aware, so a separator hidden in a quoted
@@ -274,7 +274,33 @@ function normalizeShellText(rawCommand) {
   // A Linux bash keeps a literal CR instead. Stripping it there can only JOIN
   // tokens the shell would have kept apart, i.e. match more, never less — the
   // safe direction — and a CR cannot spell part of a flag either way.
-  const command = rawCommand.replace(/\r/g, '');
+  //
+  // A RAW NUL goes next, and for a different reason than the CR above.
+  // emitCodePoint() already turns a DECODED control byte into an inert space,
+  // which is what closes the `$'…\x00scratchpad'` splice (#446) — but that
+  // guarantee only ever covered NUL spelled as an ESCAPE. A NUL byte sitting
+  // literally in the command text never reaches emitCodePoint(): it flows
+  // through the plain push()/emit() paths untouched (emit() neutralises only
+  // `;|&\n`), so the checker saw ONE opaque token spanning a byte that the
+  // exec layer treats as a hard C-string terminator. That divergence reopened
+  // the very class the escape form had closed —
+  // `rm -rf /prod-secrets<NUL>/scratchpad` read as a single path ending in the
+  // safe component `scratchpad`, while the kernel truncates at the NUL and
+  // deletes `/prod-secrets`. It is reachable input, not a curiosity: `\u0000`
+  // is a legal JSON string escape and main()'s JSON.parse hands it straight to
+  // check() with no sanitisation, as does agy-deny.mjs (#446, adversarial
+  // security review of the anchoring fix).
+  //
+  // Mapping it to the same inert SPACE the decoded form already gets makes the
+  // two spellings agree, and blocks under BOTH readings of a NUL: if the
+  // consumer truncates (real exec), the surviving head `/prod-secrets` is now
+  // judged on its own; if it instead ignores the byte, the head is still
+  // judged on its own. Either way the dangerous component stops being vouched
+  // for by a safe word on the far side of the byte. Deliberately NUL ONLY, not
+  // control bytes generally: VT/FF are real in-token data that bash does not
+  // word-split on, and splitting there is exactly the non-IFS bypass the IFS
+  // split above exists to prevent.
+  const command = rawCommand.replace(/\r/g, '').replace(/\0/g, ' ');
   // Output is accumulated as single-character CHUNKS and joined once at the
   // end, rather than appended onto a growing string.
   //

--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -91,9 +91,22 @@ const SAFE_RM_TARGET =
  * `--force` must not be mistaken for a path. A line with NO target token left
  * is treated as unsafe — that keeps the old outcome for a bare `rm -rf`, and
  * "nothing recognisable to vouch for" should never read as "safe".
+ *
+ * The split is on bash's OWN default IFS — space, tab, newline — and
+ * deliberately not on JavaScript's `\s`, which is a strictly wider class. That
+ * gap is not cosmetic: `\s` also matches NBSP, vertical tab, form feed and the
+ * Unicode spaces, none of which bash word-splits on. Splitting a token there
+ * cuts ONE bash argument into several, and if each fragment happens to look
+ * like a safe word the real target escapes judgement entirely — `rm -rf
+ * dist<NBSP>build` deletes a single file named `dist<NBSP>build`, which is
+ * neither `dist` nor `build`, yet `\s` splitting saw two safe components and
+ * exempted the line. Verified against this platform's bash by printing the
+ * expanded argv: NBSP, VT and FF all arrive INSIDE one argument, while a raw
+ * tab does separate. Carriage returns need no case here — normalizeShellText()
+ * strips them before any rule runs.
  */
 function safeRmTarget(rest) {
-  const targets = rest.split(/\s+/).slice(1).filter((t) => t && !t.startsWith('-'));
+  const targets = rest.split(/[ \t\n]+/).slice(1).filter((t) => t && !t.startsWith('-'));
   if (targets.length === 0) return false;
   return targets.every((t) => SAFE_RM_TARGET.test(t));
 }

--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -79,13 +79,15 @@ const SAFE_RM_TARGET =
  * Splitting on whitespace also closes the sharpest reported variant, which
  * needed no visible second argument at all: normalizeShellText() emits an
  * inert SPACE for any decoded control byte, so `$'/etc/shadow-backup\x00
- * scratchpad'` — one argument to a reader, and truncated at the NUL to just
- * `/etc/shadow-backup` by real bash — normalises to two tokens here. Under
- * the old whole-string test the hidden `scratchpad` exempted the line; split
- * per token, `/etc/shadow-backup` is judged on its own and blocks. Treating
- * that space as a separator over-approximates (bash would have dropped the
- * tail entirely) in the BLOCKING direction, which is the right way to be
- * wrong about a byte no legitimate path contains.
+ * scratchpad'` — one single-quoted argument, in which a real bash session
+ * drops the embedded NUL byte and fuses everything around it into that SAME
+ * one argument, rather than truncating anything away — normalises to two
+ * tokens here. Under the old whole-string test the hidden `scratchpad`
+ * exempted the line; split per token, `/etc/shadow-backup` is judged on its
+ * own and blocks. Treating the decoded NUL's stand-in space as a token
+ * separator over-approximates (real bash keeps the whole quoted string as
+ * ONE argument, byte dropped, rest fused) in the BLOCKING direction, which is
+ * the right way to be wrong about a byte no legitimate path contains.
  *
  * Flag tokens are skipped, not judged: they are not delete targets, and
  * `--force` must not be mistaken for a path. A line with NO target token left
@@ -281,25 +283,26 @@ function normalizeShellText(rawCommand) {
   // guarantee only ever covered NUL spelled as an ESCAPE. A NUL byte sitting
   // literally in the command text never reaches emitCodePoint(): it flows
   // through the plain push()/emit() paths untouched (emit() neutralises only
-  // `;|&\n`), so the checker saw ONE opaque token spanning a byte that the
-  // exec layer treats as a hard C-string terminator. That divergence reopened
-  // the very class the escape form had closed —
+  // `;|&\n`), so the checker saw ONE opaque token spanning the byte —
   // `rm -rf /prod-secrets<NUL>/scratchpad` read as a single path ending in the
-  // safe component `scratchpad`, while the kernel truncates at the NUL and
-  // deletes `/prod-secrets`. It is reachable input, not a curiosity: `\u0000`
+  // safe component `scratchpad`, exempting the whole line. It is reachable
+  // input, not a curiosity: `\u0000`
   // is a legal JSON string escape and main()'s JSON.parse hands it straight to
   // check() with no sanitisation, as does agy-deny.mjs (#446, adversarial
   // security review of the anchoring fix).
   //
   // Mapping it to the same inert SPACE the decoded form already gets makes the
-  // two spellings agree, and blocks under BOTH readings of a NUL: if the
-  // consumer truncates (real exec), the surviving head `/prod-secrets` is now
-  // judged on its own; if it instead ignores the byte, the head is still
-  // judged on its own. Either way the dangerous component stops being vouched
-  // for by a safe word on the far side of the byte. Deliberately NUL ONLY, not
-  // control bytes generally: VT/FF are real in-token data that bash does not
-  // word-split on, and splitting there is exactly the non-IFS bypass the IFS
-  // split above exists to prevent.
+  // two spellings agree, and blocks regardless of how a downstream consumer
+  // actually handles the byte — which is NOT truncation under either concrete
+  // path checked: Node's child_process throws on an embedded NUL before the
+  // command ever runs, and a persistent bash session silently drops the byte
+  // and fuses the surrounding text into ONE argument rather than cutting
+  // anything off. This fix does not need to match either of those; it
+  // deliberately over-blocks by splitting the token at the byte, so
+  // `/prod-secrets` is judged on its own merits either way. Deliberately NUL
+  // ONLY, not control bytes generally: VT/FF are real in-token data that bash
+  // does not word-split on, and splitting there is exactly the non-IFS bypass
+  // the IFS split above exists to prevent.
   const command = rawCommand.replace(/\r/g, '').replace(/\0/g, ' ');
   // Output is accumulated as single-character CHUNKS and joined once at the
   // end, rather than appended onto a growing string.

--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -15,33 +15,88 @@
  * for a few known-catastrophic commands, not a security boundary.
  */
 
-// Component-anchored (#446): each alternative must occupy a WHOLE path
-// component, not merely appear as a substring. `dist` and `dist/` are safe;
-// `distribution-of-secrets` is not, because "dist" there abuts "r", not a
-// component boundary. The boundary class is path separators (`/` — the only
-// one bash itself treats specially — and a bare `\`, which can only reach
-// this regex as a SURVIVING literal separator: normalizeShellText() consumes
-// a lone backslash as an escape, so a literal one only comes through when the
-// source doubled it, `dist\\build`, exactly how bash's own argv expansion
-// keeps a literal backslash, verified against this platform's bash), plus
-// whitespace/start/end for a bare argument. Deliberately NOT `\b`/word-
-// boundary: a hyphen is a non-word character, so a plain `\b` would still
-// treat "coverage" inside `coverage-notes-prod-db` as a whole word and let
-// the exact bypass this ticket closes back in.
+// Component-anchored, and matched against ONE argument at a time (#446).
+//
+// Two halves of the same fix, because either alone leaves the other's bypass
+// open — see safeRmTarget() below for the per-argument half.
+//
+// ANCHORING: each alternative must occupy a WHOLE path component of the
+// argument, not merely appear as a substring of it. `dist` and `dist/` are
+// safe; `distribution-of-secrets` is not, because "dist" there abuts "r"
+// rather than a component boundary. Deliberately NOT `\b`/word-boundary: a
+// hyphen is a non-word character, so a plain `\b` would still read "coverage"
+// inside `coverage-notes-prod-db` as a whole word and let the exact bypass
+// this ticket closes straight back in.
+//
+// The boundary is `/` ALONE, plus the argument's own start/end. Notably it is
+// NOT a backslash, which an earlier draft of this fix included and the
+// adversarial review rejected on two independent grounds, both correct:
+// (1) on bash — the shell every rule in this file is written against — `\` is
+// not a path separator at all, it is an ordinary filename byte, so treating
+// it as component punctuation carves a fake "component" out of a single
+// arbitrary filename (`customer-database\temp`, `.ssh\build`); and (2) the
+// premise that a literal `\` only survives normalizeShellText() when the
+// source doubled it is simply false — inside single quotes a backslash is
+// literal and passes through untouched (this file's own AC-437.5 cases
+// already depend on that), so `'temp\prod-secrets'` would have been waved
+// through as safe. Excluding `\` costs only over-blocking an unquoted
+// Windows-style path whose backslashes normalizeShellText() eats as escapes
+// anyway (`C:\repo\dist` normalises to `C:repodist`) — the safe direction,
+// and pinned by AC-446.5 so the choice is a decision rather than an accident.
 //
 // `$TMP`/`$TEMP` get no special-casing (AC.4): they are matched by the same
 // component-anchored rule as every literal directory name, which already
 // produces the right outcome for the one case that matters — bash itself
 // resolves `$TMPDIR` to a DIFFERENT (and here, unset) variable than `$TMP`
-// followed by literal `DIR`, because env-var-name expansion consumes maximal
-// `[A-Za-z0-9_]*` after the `$`. The component boundary here (`/`, whitespace,
-// `\`, start/end) is a STRICTER right-edge than bash's own variable-name
-// boundary would be (it also rejects a same-token `-` suffix bash would
-// resolve as literal data, e.g. `$TMP-backup`), which only ever narrows the
-// safe set — the one case AC.2 requires, `"$TMP/forge-test"`, has a `/`
-// immediately after `$TMP` and keeps matching.
-const SAFE_RM_TARGETS =
-  /(?:^|[\s/\\])(?:node_modules|\.forge|dist|build|coverage|te?mp|\$TMP|\$TEMP|scratchpad)(?=$|[\s/\\])/i;
+// followed by a literal `DIR`, because env-var-name expansion consumes the
+// maximal `[A-Za-z0-9_]*` run after the `$`. The component boundary here is a
+// STRICTER right edge than bash's own variable-name boundary (it also rejects
+// a same-token `-` suffix bash would resolve as literal data, e.g.
+// `$TMP-backup`), which only ever narrows the safe set — and the one case
+// AC.2 requires, `"$TMP/forge-test"`, has a `/` straight after `$TMP` and
+// keeps matching.
+const SAFE_RM_TARGET =
+  /(?:^|\/)(?:node_modules|\.forge|dist|build|coverage|te?mp|\$TMP|\$TEMP|scratchpad)(?=$|\/)/i;
+
+/**
+ * Is EVERY delete target on this `rm` line a safe build/temp path?
+ *
+ * Anchoring the words was only half of #446. The exemption used to be one
+ * boolean test of SAFE_RM_TARGETS against the whole command tail, so a single
+ * safe-looking token ANYWHERE in the argument list exempted the entire
+ * command — `rm -rf /secret/data dist` and `rm -rf /var/lib/db ~/.ssh
+ * node_modules` both passed, with the real targets sitting right there in
+ * plain sight. Anchoring alone does not touch that: `dist` is a perfectly
+ * legitimate whole component, it just is not the argument that matters. The
+ * decoy has to be defeated by asking the question PER ARGUMENT, so one safe
+ * target can never vouch for an unsafe sibling. (Both were found by the
+ * adversarial security review of the anchoring-only fix; both predate this
+ * ticket — verified against `main` — but they are the same "a safe word
+ * somewhere exempts the whole command" class #446 exists to close, so they
+ * are closed here rather than left behind a fix that appears to have handled
+ * them.)
+ *
+ * Splitting on whitespace also closes the sharpest reported variant, which
+ * needed no visible second argument at all: normalizeShellText() emits an
+ * inert SPACE for any decoded control byte, so `$'/etc/shadow-backup\x00
+ * scratchpad'` — one argument to a reader, and truncated at the NUL to just
+ * `/etc/shadow-backup` by real bash — normalises to two tokens here. Under
+ * the old whole-string test the hidden `scratchpad` exempted the line; split
+ * per token, `/etc/shadow-backup` is judged on its own and blocks. Treating
+ * that space as a separator over-approximates (bash would have dropped the
+ * tail entirely) in the BLOCKING direction, which is the right way to be
+ * wrong about a byte no legitimate path contains.
+ *
+ * Flag tokens are skipped, not judged: they are not delete targets, and
+ * `--force` must not be mistaken for a path. A line with NO target token left
+ * is treated as unsafe — that keeps the old outcome for a bare `rm -rf`, and
+ * "nothing recognisable to vouch for" should never read as "safe".
+ */
+function safeRmTarget(rest) {
+  const targets = rest.split(/\s+/).slice(1).filter((t) => t && !t.startsWith('-'));
+  if (targets.length === 0) return false;
+  return targets.every((t) => SAFE_RM_TARGET.test(t));
+}
 const PROTECTED_BRANCHES = /\b(main|master|staging|production)\b/;
 
 /**
@@ -515,7 +570,10 @@ export const RULES = [
       const force = /f/.test(shortFlags) || /\B--force\b/.test(c);
       if (!recursive || !force) return false;
       const rest = c.slice(c.indexOf('rm'));
-      return !SAFE_RM_TARGETS.test(rest);
+      // EVERY target must be safe, not merely one of them (#446) — see
+      // safeRmTarget(): a single safe-looking decoy argument used to exempt
+      // the whole command, however many real targets sat beside it.
+      return !safeRmTarget(rest);
     },
     msg: 'rm -rf (incl. --recursive --force) outside build/temp dirs',
   },

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -422,6 +422,33 @@ describe('SAFE_RM_TARGETS is component-anchored, not substring (#446, AC-446.*)'
     }
   });
 
+  // AC-446.6 — the same splice one layer lower, as a RAW byte rather than an
+  // escape. The case above only ever exercised the `$'…\x00…'` spelling, and
+  // the inert-space guarantee it relies on lives in emitCodePoint(), which
+  // DECODED escapes reach and a literal byte does not. So a NUL already present
+  // in the command text sailed straight through as ordinary data, and the
+  // checker judged one opaque token spanning a byte that exec treats as a hard
+  // string terminator: the real deletion is the truncated head, while the safe
+  // word hiding behind the NUL vouched for the whole line. Reachable without
+  // any shell quoting at all — `\u0000` is legal JSON, and check() is handed
+  // the parsed string unsanitised. (Found by the adversarial security review of
+  // the anchoring fix; the escape form alone was NOT enough.)
+  it('AC-446.6: a RAW NUL byte splice is neutralised exactly like the escape form', () => {
+    const NUL = String.fromCharCode(0);
+    for (const cmd of [
+      `rm -rf /prod-secrets${NUL}/scratchpad`,
+      `rm -rf "/prod-secrets${NUL}/scratchpad"`,
+      `rm -rf '/prod-secrets${NUL}/scratchpad'`,
+      `rm -rf important-secret-data${NUL}dist`,
+    ]) {
+      expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    }
+    // The head is what actually gets deleted, so when the head is genuinely
+    // safe the line stays exempt — the byte must not become a blunt "block
+    // anything containing a NUL" rule.
+    expect(check(`rm -rf dist${NUL}build`).blocked).toBe(false);
+  });
+
   // AC-446.6 — the per-argument split must use bash's OWN default IFS (space,
   // tab, newline), not JavaScript's `\s`, which is a strictly wider class.
   // Splitting on a character bash does NOT word-split on cuts one real argument

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -285,6 +285,71 @@ describe('recursive-delete long flags (#312, AC-312.*)', () => {
   });
 });
 
+describe('SAFE_RM_TARGETS is component-anchored, not substring (#446, AC-446.*)', () => {
+  // AC-446.1 — a safe word only exempts a delete when it occupies a WHOLE path
+  // component (bounded by `/`, whitespace, `\`, or start/end of the argument),
+  // not merely appears as a substring. `dist` and `dist/` are safe; a longer
+  // name that merely CONTAINS `dist` is not.
+  it('AC-446.1: dist and dist/ (trailing slash) are safe; distribution-of-secrets is not', () => {
+    expect(check('rm -rf dist').blocked).toBe(false);
+    expect(check('rm -rf dist/').blocked).toBe(false);
+    expect(check('rm -rf dist/sub').blocked).toBe(false);
+    expect(check('rm -rf distribution-of-secrets')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+
+  // AC-446.1 — a nested safe-named directory is still safe regardless of its
+  // parent's name: anchoring is per-COMPONENT, not top-level-only, matching
+  // how `packages/app/dist` was already treated as safe pre-fix.
+  it('AC-446.1: a safe word nested under an unrelated parent directory is still safe', () => {
+    expect(check('rm -rf packages/app/dist').blocked).toBe(false);
+    expect(check('rm -rf ~/project/node_modules').blocked).toBe(false);
+  });
+
+  // AC-446.2 — non-negotiable per the ticket: every existing safe-target case
+  // (AC-312.2, plus the ticket's own quoted-$TMP example) must keep passing
+  // completely unchanged after anchoring. Re-asserted here, by name, so a
+  // regression in this exact set is never mistaken for an unrelated failure.
+  it('AC-446.2: pre-existing safe-target cases are UNCHANGED by anchoring', () => {
+    expect(check('rm -rf node_modules').blocked).toBe(false);
+    expect(check('rm -rf dist build coverage').blocked).toBe(false);
+    expect(check('rm -rf "$TMP/forge-test"').blocked).toBe(false);
+    expect(check('rm --recursive --force node_modules').blocked).toBe(false);
+    expect(check('rm --force --recursive dist build coverage').blocked).toBe(false);
+  });
+
+  // AC-446.3 — the substring-lookalike paths from the ticket (and the widest
+  // alternative, `te?mp`, against every word it used to leak through) are
+  // pinned as BLOCKED, in the style of AC-429.3 / AC-437.3.
+  it('AC-446.3: substring-lookalike dangerous paths are blocked, not exempted', () => {
+    for (const cmd of [
+      'rm -rf /important-template-configs',            // "temp" inside "template"
+      'rm -rf ~/my-distribution-of-prod-secrets',       // "dist" inside "distribution"
+      'rm -rf ./coverage-notes-prod-db',                // "coverage" abutting "-notes"
+      'rm -rf /srv/scratchpad-lookalike-prod',          // "scratchpad" abutting "-lookalike"
+      'rm -rf /srv/temporary-prod-data',                // "temp" inside "temporary"
+      'rm -rf /srv/attempt-to-delete-prod',             // "temp" inside "attempt"
+      'rm -rf /srv/contemplate-prod-migration',         // "temp" inside "contemplate"
+      'rm -rf buildings-and-infra',                     // "build" inside "buildings"
+      'rm -rf node_modules_backup_of_prod',             // "node_modules" abutting "_backup"
+    ]) {
+      expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    }
+  });
+
+  // AC-446.4 — decision: `$TMP`/`$TEMP` get NO special-casing beyond the same
+  // component anchor every other alternative uses. That already produces the
+  // bash-correct outcome: `$TMPDIR` is a DIFFERENT (here, unset) variable to
+  // real bash, not `$TMP` + literal `DIR` — env-var-name expansion consumes
+  // maximal `[A-Za-z0-9_]*` after the `$` — so treating `$TMPDIR` as exempt
+  // would itself have been a bypass, not just an inconsistency.
+  it('AC-446.4: $TMP/$TEMP are exempt only as a whole component, not as a prefix of a longer name', () => {
+    expect(check('rm -rf $TMP/forge-test').blocked).toBe(false);
+    expect(check('rm -rf $TEMP/forge-test').blocked).toBe(false);
+    expect(check('rm -rf $TMPDIR/prod-secrets')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    expect(check('rm -rf $TEMPORARY_CREDENTIALS_DIR')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+});
+
 describe('hard-reset reordered/bundled/abbreviated spellings (#437, AC-437.1)', () => {
   // AC-437.1 — --hard blocks regardless of OTHER flags sitting between `reset`
   // and `--hard`, in either order, and regardless of a global git flag before

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -406,10 +406,13 @@ describe('SAFE_RM_TARGETS is component-anchored, not substring (#446, AC-446.*)'
   // AC-446.6 — the sharpest reported variant of the decoy, needing no visible
   // second argument at all. normalizeShellText() emits an inert SPACE for any
   // decoded control byte, so a NUL escape splices a hidden safe word onto the
-  // single real target. Real bash TRUNCATES `$'…'` at an embedded NUL, so the
-  // command genuinely deletes only the dangerous prefix — the trailing word
-  // exists purely to fool a whole-line match, and is invisible without hex
-  // inspection. Splitting per token judges the real target on its own merits.
+  // single real target. A persistent bash session drops the embedded NUL byte
+  // and fuses the surrounding text into ONE quoted argument rather than
+  // truncating anything away — the trailing word is not discarded, it stays
+  // part of the same real target, existing purely to fool a whole-line match
+  // and invisible without hex inspection. Splitting per token judges the real
+  // target on its own merits regardless of how a shell would actually resolve
+  // the byte.
   it('AC-446.6: a NUL-escape hidden decoy cannot exempt the real target', () => {
     const B = String.fromCharCode(92);
     const S = String.fromCharCode(39);
@@ -427,10 +430,13 @@ describe('SAFE_RM_TARGETS is component-anchored, not substring (#446, AC-446.*)'
   // the inert-space guarantee it relies on lives in emitCodePoint(), which
   // DECODED escapes reach and a literal byte does not. So a NUL already present
   // in the command text sailed straight through as ordinary data, and the
-  // checker judged one opaque token spanning a byte that exec treats as a hard
-  // string terminator: the real deletion is the truncated head, while the safe
-  // word hiding behind the NUL vouched for the whole line. Reachable without
-  // any shell quoting at all — `\u0000` is legal JSON, and check() is handed
+  // checker judged one opaque token spanning the byte, with the safe word on
+  // the far side vouching for the whole line. This is NOT a truncation bug:
+  // Node's child_process throws on an embedded NUL before the command ever
+  // runs, and a bash session drops the byte and fuses the text around it into
+  // one argument rather than cutting anything off — either way, nothing here
+  // relies on which of those happens. Reachable without any shell quoting at
+  // all — `\u0000` is legal JSON, and check() is handed
   // the parsed string unsanitised. (Found by the adversarial security review of
   // the anchoring fix; the escape form alone was NOT enough.)
   it('AC-446.6: a RAW NUL byte splice is neutralised exactly like the escape form', () => {
@@ -443,9 +449,9 @@ describe('SAFE_RM_TARGETS is component-anchored, not substring (#446, AC-446.*)'
     ]) {
       expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
     }
-    // The head is what actually gets deleted, so when the head is genuinely
-    // safe the line stays exempt — the byte must not become a blunt "block
-    // anything containing a NUL" rule.
+    // Neither runtime turns this into a "block anything containing a NUL"
+    // rule: the substitution judges each side of the byte on its own merits,
+    // so when both sides are genuinely safe words the line stays exempt.
     expect(check(`rm -rf dist${NUL}build`).blocked).toBe(false);
   });
 

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -348,6 +348,79 @@ describe('SAFE_RM_TARGETS is component-anchored, not substring (#446, AC-446.*)'
     expect(check('rm -rf $TMPDIR/prod-secrets')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
     expect(check('rm -rf $TEMPORARY_CREDENTIALS_DIR')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
   });
+
+  // AC-446.5 — the boundary is `/` ALONE, deliberately NOT a backslash. An
+  // earlier draft of this fix included `\` in the boundary class; the
+  // adversarial review killed it on two independent grounds. First, on bash —
+  // the shell every rule in this file is written against — a backslash is not
+  // a path separator at all but an ordinary filename byte, so honouring it
+  // carves a fake "component" out of one arbitrary filename. Second, the
+  // premise that a literal backslash only survives normalizeShellText() when
+  // the source doubled it is false: inside single quotes a backslash is
+  // literal and passes through untouched (the AC-437.5 cases below already
+  // depend on exactly that), so a quoted `temp\prod-secrets` — one filename,
+  // not a path under a `temp/` directory — was being waved through as safe.
+  it('AC-446.5: a backslash is NOT a component boundary and cannot carve a fake safe component', () => {
+    const B = String.fromCharCode(92); // backslash
+    const S = String.fromCharCode(39); // '
+    const Q = String.fromCharCode(34); // "
+    for (const cmd of [
+      `rm -rf ${S}temp${B}prod-secrets${S}`,     // single-quoted: backslash survives verbatim
+      `rm -rf ${Q}temp${B}prod-secrets${Q}`,     // double-quoted, backslash before a non-escape char
+      `rm -rf customer-database${B}${B}temp`,     // unquoted, doubled -> one literal backslash
+      `rm -rf .ssh${B}${B}build`,
+      `rm -rf dist${B}${B}production-secrets`,    // safe word on the LEFT of the fake boundary
+    ]) {
+      expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    }
+  });
+
+  // AC-446.6 — anchoring the words was only HALF the fix. The exemption used to
+  // be one boolean test against the whole command tail, so a single safe-looking
+  // token anywhere in the argument list vouched for every other argument on the
+  // line. Anchoring alone does not touch that: `dist` is a perfectly legitimate
+  // whole component, it just is not the argument that matters. Both classes here
+  // predate this ticket (verified against `main`), but they are the same "a safe
+  // word somewhere exempts the whole command" class #446 exists to close, so
+  // leaving them behind an apparently-complete fix would be worse than not
+  // having fixed anything.
+  it('AC-446.6: one safe decoy argument does NOT exempt unsafe siblings (per-argument, not whole-line)', () => {
+    for (const cmd of [
+      'rm -rf /secret/data dist',                        // decoy last
+      'rm -rf tmp /home/user/photos',                    // decoy first
+      'rm -rf /var/lib/db /home/user/.ssh node_modules', // decoy buried among several real targets
+      'rm --recursive --force /secret/data dist',        // long-flag spelling of the same
+      'rm -rf $TMP /etc/important-config',               // env-var form as the decoy
+    ]) {
+      expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    }
+    // ...while an all-safe argument list stays exempt, which is exactly what
+    // keeping AC.2 intact means: `dist build coverage` is three safe targets,
+    // not one safe target vouching for two unknowns.
+    expect(check('rm -rf dist build coverage').blocked).toBe(false);
+    // A line with NO target left to judge stays blocked — "nothing recognisable
+    // to vouch for" must never read as "safe".
+    expect(check('rm -rf')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+
+  // AC-446.6 — the sharpest reported variant of the decoy, needing no visible
+  // second argument at all. normalizeShellText() emits an inert SPACE for any
+  // decoded control byte, so a NUL escape splices a hidden safe word onto the
+  // single real target. Real bash TRUNCATES `$'…'` at an embedded NUL, so the
+  // command genuinely deletes only the dangerous prefix — the trailing word
+  // exists purely to fool a whole-line match, and is invisible without hex
+  // inspection. Splitting per token judges the real target on its own merits.
+  it('AC-446.6: a NUL-escape hidden decoy cannot exempt the real target', () => {
+    const B = String.fromCharCode(92);
+    const S = String.fromCharCode(39);
+    const D = String.fromCharCode(36);
+    for (const cmd of [
+      `rm -rf ${D}${S}/etc/shadow-backup${B}x00scratchpad${S}`,
+      `rm -rf ${D}${S}important-secret-data${B}x00dist${S}`,
+    ]) {
+      expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    }
+  });
 });
 
 describe('hard-reset reordered/bundled/abbreviated spellings (#437, AC-437.1)', () => {

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -421,6 +421,33 @@ describe('SAFE_RM_TARGETS is component-anchored, not substring (#446, AC-446.*)'
       expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
     }
   });
+
+  // AC-446.6 — the per-argument split must use bash's OWN default IFS (space,
+  // tab, newline), not JavaScript's `\s`, which is a strictly wider class.
+  // Splitting on a character bash does NOT word-split on cuts one real argument
+  // into several, and if each fragment looks like a safe word the actual target
+  // escapes judgement — the decoy problem again, arriving from the opposite
+  // direction. Verified against this platform's bash by printing the expanded
+  // argv: NBSP, vertical tab and form feed all arrive INSIDE a single argument,
+  // so `dist<NBSP>build` names one file that is neither `dist` nor `build`.
+  it('AC-446.6: token splitting follows bash IFS, so a non-IFS space cannot fake two safe components', () => {
+    for (const [sep, label] of [
+      [' ', 'NBSP'],
+      ['\v', 'vertical tab'],
+      ['\f', 'form feed'],
+      [' ', 'narrow NBSP'],
+      ['　', 'ideographic space'],
+    ]) {
+      const cmd = `rm -rf dist${sep}build`;
+      expect(check(cmd), label).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    }
+    // ...while a raw TAB, which bash DOES word-split on, still separates two
+    // safe targets, so a genuinely all-safe list stays exempt. (Newline is not
+    // exercised here: segments() splits the command on it upstream, so it never
+    // reaches the target split at all.)
+    expect(check('rm -rf dist\tbuild').blocked).toBe(false);
+    expect(check('rm -rf dist\t/etc/secrets')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
 });
 
 describe('hard-reset reordered/bundled/abbreviated spellings (#437, AC-437.1)', () => {


### PR DESCRIPTION
Closes #446

## Summary

`SAFE_RM_TARGETS` used to exempt `rm -rf` targets by an **unanchored substring** match, so any dangerous path that merely *contained* a safe-looking word (`dist`, `temp`, `scratchpad`, …) anywhere was waved through — `rm -rf /important-template-configs`, `rm -rf ~/my-distribution-of-prod-secrets`, etc. This branch closes that class and five related bypasses discovered by two adversarial review rounds along the way.

This went through **four adversarial review rounds and two owner escalations**. It ships intentionally incomplete: three further bypass classes are known, filed, and owner-accepted as out-of-scope follow-ups (#450, #451, #452), plus one un-ticketed false-positive nit noted below. **This PR does not claim the guard is complete.**

## Six classes closed (verified against `check()`; each has a regression test that fails against the preceding commit)

1. **Substring containment** (the filed bug) — safe words must now occupy a whole path component. `/important-template-configs`, `~/my-distribution-of-prod-secrets`, `./coverage-notes-prod-db`, `/srv/scratchpad-lookalike-prod` all block.
2. **Multi-argument decoy** — the exemption used to be one regex test over the whole command tail, so a single safe-looking argument vouched for every unsafe sibling (`rm -rf /secret/data dist` was not blocked). Now judged per argument.
3. **NUL-escape splice** — `$'...\x00scratchpad'` hid a safe word behind a decoded NUL on the single real target; the decoded byte is now mapped to an inert separator.
4. **Backslash pseudo-boundary** — a quoted `temp\prod-secrets` is one filename, not a path under `temp/`.
5. **Non-IFS whitespace** — the per-argument split now uses bash's actual IFS (space/tab/newline), not JavaScript's wider `\s` (which also matches NBSP/VT/FF, none of which bash word-splits on).
6. **Raw NUL byte target splice** — class 3 only ever covered the NUL spelled as an escape (`\x00`); a literal NUL byte already present in the command text flowed through untouched. It's now mapped to the same inert separator as the decoded form, closing the raw-byte spelling of the same splice.

## Three known-open classes — pre-existing on `main`, NOT introduced or worsened here, NOT merge blockers

- **#450** — POSIX `--` end-of-options is not honored: the flag-skip logic treats every `-`-prefixed token as a flag even after `--`, so the real target can vanish from judgement (`rm -rf -- -prod-secrets dist`).
- **#451** — `..` path traversal bypasses the anchor: a safe leading component satisfies the check and nothing validates what follows (`rm -rf dist/../../prod-secrets`). Not fixable without path resolution, which this hook deliberately does not do.
- **#452** — a raw NUL byte inside a short-flag cluster defeats `shortFlagCluster()`'s contiguous match, defeating flag detection (not target detection) in four rules at once: `recursive-delete`, `force-push`, `git-clean-force`, `env-branch-delete`. Two candidate fixes were verified mutually exclusive under the current design (mapping NUL→space closes this but reopens the raw-NUL target splice; deleting the NUL instead does the reverse) — closing it needs a model decision, not a patch, and is intentionally left for its own ticket.

All three are pre-existing on `main`, confirmed side-by-side, and unaffected by this branch either way. The guard is **not** complete after this PR; treat it as a tripwire, not a fence.

## A fourth known item — NOT yet ticketed, needs one

The `forge:security` re-review of this final tip surfaced one more real item, outside the three above. It is **not** a bypass and did not block the review, but it should not be lost:

- **`recursive-delete` re-slices on a plain `indexOf('rm')`** (`plugin/hooks/denylist.mjs`, the `const rest = c.slice(c.indexOf('rm'));` line). Because that is an unanchored substring search, any earlier word in the same segment containing the lowercase substring `rm` shifts the slice and produces a **false positive**: `TERM=xterm rm -rf dist` and `X=affirm rm -rf dist` are both wrongly blocked, verified live against `check()`.

Unlike #450/#451/#452 this one **was introduced on this branch** (by `f233cc1`, which added the per-argument split). It is kept rather than patched because the owner's decision on this ticket was explicitly to stop patching this guard here, and because it fails **closed**: the security pass tried ~15 adversarial constructions against it and every case containing a genuinely dangerous target still blocked, so the impact is an unnecessary prompt, not exposure. Suggested fix is to anchor the slice to the real `rm` match position (the rule's own regex `.index`) rather than `indexOf`.

**This needs a follow-up ticket filed under epic #182.** It could not be filed automatically — creating it needs the owner to name the ticket and its destination.

## Mitigation, unchanged throughout

No host currently auto-approves any of these commands, so a recursive delete still reaches a human prompt on both hosts. That is incidental to the rule, not guaranteed by it — #444 (widening the allowlist) is what would erode it.

## Wording correction

An earlier commit on this branch (`1e41745`) and two of its comments asserted that the exec layer "truncates at the NUL." That was inaccurate and has been corrected in a follow-up commit (comment-only, no behaviour change): Node's `child_process` throws on an embedded NUL before the command ever runs, and a persistent bash session silently drops the byte and fuses the surrounding text into one argument rather than truncating anything away. The fix stays safe under either model because the NUL→space substitution is a deliberate over-block (this file's stated safe direction), not because it matches literal truncation.

## Verification

- `pnpm verify`: 69 files / 1058 tests, green.
- Mechanical gates: ac, plandrift, testintent, depguard, docsync, conventions, situation — all pass.
- Two adversarial re-review passes on this exact tip (reviewer + security), each in an isolated worktree, each briefed that #450/#451/#452 are owner-accepted and out of scope — both returned pass with zero critical/high findings on in-scope code.
