### PR TITLE
fix(denylist): honor POSIX -- end-of-options in recursive-delete targets

### DIFF
--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -94,6 +94,19 @@ const SAFE_RM_TARGET =
  * is treated as unsafe — that keeps the old outcome for a bare `rm -rf`, and
  * "nothing recognisable to vouch for" should never read as "safe".
  *
+ * POSIX `--` end-of-options (#450, AC-450.*): a bare `--` token tells the
+ * shell/utility that every token AFTER it is a filename, never a flag, even
+ * one that starts with `-`. Verified against real bash (`argv rm -rf --
+ * -prod-secrets dist`, printed with one arg per line): `--` and
+ * `-prod-secrets` both arrive as their own literal argv entries, unmangled.
+ * The pre-fix filter here did not know that — it dropped every `-`-leading
+ * token regardless of position, so `-prod-secrets` vanished from judgement
+ * and the decoy `dist` sitting after it vouched for the whole line. The `--`
+ * token itself is dropped (it is punctuation, not a path); once seen, every
+ * later token is a target unconditionally, while tokens BEFORE it are still
+ * flag-filtered exactly as before (AC-450.3) — this only changes what counts
+ * as a target after the marker, nothing about flag parsing ahead of it.
+ *
  * The split is on bash's OWN default IFS — space, tab, newline — and
  * deliberately not on JavaScript's `\s`, which is a strictly wider class. That
  * gap is not cosmetic: `\s` also matches NBSP, vertical tab, form feed and the
@@ -108,7 +121,19 @@ const SAFE_RM_TARGET =
  * strips them before any rule runs.
  */
 function safeRmTarget(rest) {
-  const targets = rest.split(/[ \t\n]+/).slice(1).filter((t) => t && !t.startsWith('-'));
+  let endOfOptions = false;
+  const targets = rest
+    .split(/[ \t\n]+/)
+    .slice(1)
+    .filter((t) => {
+      if (!t) return false;
+      if (endOfOptions) return true;
+      if (t === '--') {
+        endOfOptions = true;
+        return false;
+      }
+      return !t.startsWith('-');
+    });
   if (targets.length === 0) return false;
   return targets.every((t) => SAFE_RM_TARGET.test(t));
 }

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -483,6 +483,54 @@ describe('SAFE_RM_TARGETS is component-anchored, not substring (#446, AC-446.*)'
   });
 });
 
+describe('recursive-delete honors POSIX -- end-of-options (#450, AC-450.*)', () => {
+  // AC-450.1 — the ticket's exact reproduction: after a bare `--`, every
+  // following token is a filename by POSIX convention even though it starts
+  // with `-`. Pre-fix, the flag-skipping filter dropped `-prod-secrets`
+  // regardless of `--`, leaving only the decoy `dist` to judge, which read as
+  // safe and let the real target vanish from judgement entirely. Verified
+  // against real bash (`argv rm -rf -- -prod-secrets dist`) that `--` and
+  // `-prod-secrets` arrive as their own literal, unmangled argv tokens.
+  it('AC-450.1: a real target named with a leading dash after -- is judged, not filtered as a flag', () => {
+    expect(check('rm -rf -- -prod-secrets dist')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+
+  // AC-450.2 — ordinary `--`-free invocations and the existing safe-target
+  // cases are unaffected by the fix. Re-asserted here, by name, so a
+  // regression in this exact set is never mistaken for an unrelated failure.
+  it('AC-450.2: --free invocations and pre-existing safe-target cases are unaffected', () => {
+    expect(check('rm -rf dist').blocked).toBe(false);
+    expect(check('rm -rf node_modules').blocked).toBe(false);
+    expect(check('rm -rf dist build coverage').blocked).toBe(false);
+    expect(check('rm -rf "$TMP/forge-test"').blocked).toBe(false);
+  });
+
+  // AC-450.2 — a safe target named AFTER `--` is still recognised as safe: the
+  // fix only stops treating a leading `-` as a flag signal past the marker,
+  // it does not change the safe-word judgement itself.
+  it('AC-450.2: a safe-named target after -- stays allowed', () => {
+    expect(check('rm -rf -- dist').blocked).toBe(false);
+    expect(check('rm -rf dist -- build').blocked).toBe(false);
+  });
+
+  // AC-450.3 — a token that legitimately starts with `-` but comes BEFORE
+  // `--` is still treated as a flag, not a target: no regression on flag
+  // parsing generally. The unsafe case pairs a filtered pre-`--` flag with a
+  // real dash-named target after the marker, so the block can only be coming
+  // from the post-`--` token.
+  it('AC-450.3: a dash-leading token before -- is still filtered as a flag, not a target', () => {
+    expect(check('rm -rf -x -- dist').blocked).toBe(false);
+    expect(check('rm -rf -x -- -prod-secrets')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+
+  // AC-450.4 (regression per #446, AC-446.*): the bare-marker edge case —
+  // `--` with nothing following it — leaves no target token to vouch for the
+  // line, which must keep reading as unsafe, exactly like a bare `rm -rf`.
+  it('AC-450.4: a bare -- with no targets left stays blocked, same as a bare rm -rf', () => {
+    expect(check('rm -rf --')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+});
+
 describe('hard-reset reordered/bundled/abbreviated spellings (#437, AC-437.1)', () => {
   // AC-437.1 — --hard blocks regardless of OTHER flags sitting between `reset`
   // and `--hard`, in either order, and regardless of a global git flag before


### PR DESCRIPTION
## Summary

Closes #450.

`safeRmTarget()` in `plugin/hooks/denylist.mjs` filtered any token starting with a dash out of `rm` target judgement, without regard for a preceding bare `--`. POSIX end-of-options means every token after `--` is a filename by convention, even one that starts with `-`. The pre-fix filter did not know that, so a dash-named real delete target placed after `--` vanished from judgement entirely, and an unrelated safe-looking token (e.g. `dist`) elsewhere on the line vouched for the whole command — `rm -rf -- -prod-secrets dist` returned `blocked:false`.

Fix: once a bare `--` token is seen in the split argument stream, every subsequent token is treated as a target unconditionally (dash-leading or not). Tokens *before* the marker are still flag-filtered exactly as before — this only changes what counts as a target after the marker.

## Scope

This PR is the single bounded `--` fix per the ticket. It deliberately does **not** touch the sibling known-open bypass classes, which remain open on their own tickets:

- #451 — `..` traversal (needs a path-resolution/argv-model decision)
- #452 — raw NUL in a short-flag cluster (two candidate fixes are mutually exclusive; owner-accepted known-open)
- #454 — `recursive-delete` locating `rm` by unanchored `indexOf`
- #448 — brace expansion
- #449 — `shortFlagCluster` subshell awareness

## AC checklist

- [x] AC.1 `rm -rf -- -prod-secrets dist` is blocked (AC-450.1)
- [x] AC.2 `--`-free invocations and existing safe-target cases (`node_modules`, `dist build coverage`, `"$TMP/forge-test"`) are unaffected; a safe target named after `--` also stays allowed (AC-450.2)
- [x] AC.3 A dash-leading token *before* `--` is still treated as a flag, not a target (AC-450.3)
- [x] AC.4 Regression tests pin the reproduction, in the style of `AC-446.*` in `tests/hooks/denylist.test.mjs` (AC-450.1 through AC-450.4)

## Verification

- Validated against real bash argv splitting (not the code's own reasoning): a script-file probe (`argv rm -rf -- -prod-secrets dist`, one token per line via `printf`) confirmed `--` and `-prod-secrets` both arrive as their own literal, unmangled argv tokens — nothing about `--` or a leading dash is special-cased away by the shell.
- New tests proven to fail pre-fix: stashed `plugin/hooks/denylist.mjs`, re-ran the `AC-450.*` block — `AC-450.1` (the exact reproduction) failed red (`expected blocked:true, got blocked:false`); the other three passed even pre-fix since they don't depend on the fix (they pin flag-parsing-before-`--` and no-`--` behavior that was never broken). Restored the fix afterward.
- `#446`'s six closed bypass classes re-run and stay blocked; its safe cases (`rm -rf dist`, `node_modules`, `dist build coverage`, `"$TMP/forge-test"`) stay allowed — `AC-446.*` block is unchanged and green.
- Full `pnpm verify`: **1063 tests / 69 files passed** (baseline was 1058/69 after PR #453; this PR adds exactly 5 new `it()` cases under `AC-450.*`).
- Gates: `acgate` — all 4 ACs covered by passing tests; `conventions` — clean; `depguard` — no new dependencies; `docsync` — clean (78 docs indexed); `testintent` — clean, no existing assertions weakened; `situationgate --action ship` — proceed (situation idle).

## Review

Both `forge:reviewer` and `forge:security` were run in isolated worktrees, briefed up front that #448/#449/#451/#452/#454 are known-open and out of scope for this diff. Verdicts recorded in the PR thread.
