### PR TITLE
docs(triage): add Report contract section for {issue,verdict,outcome}

### DIFF
--- a/plugin/skills/triage/SKILL.md
+++ b/plugin/skills/triage/SKILL.md
@@ -24,3 +24,14 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/board/create.mjs" --title "…" --body "…"
 6. Report the ticket link + one-line summary of type/priority/size reasoning.
 
 Vague reports: ask at most one clarifying round; otherwise ticket what is known, mark the gaps in the body, and let investigate fill them.
+
+## Report contract
+
+When run as a spawned subagent (`autopilot/SKILL.md` § Orchestration, `action: triage`), end with the terminal JSON the orchestrator consumes: `{"issue":<n>,"verdict":"pass|fail","outcome":"ready|escalated"}`.
+
+`verdict` and `outcome` are not independent axes for triage — only two pairings occur:
+
+- **`verdict:"pass"` → `outcome:"ready"`** — the ticket is now correctly typed with acceptance criteria and board placement, confirmed deliverable. The orchestrator records it via `ledger.mjs` `applyOutcome` with `stage:"triage"` and the ticket re-enters the autopilot queue as `deliver` on the next iteration — the same re-entry mechanics `autopilot/SKILL.md` documents for `shape`'s `outcome:"ready"`.
+- **`verdict:"fail"` → `outcome:"escalated"`** — the ask or acceptance criteria can't be pinned down without a product decision. Escalate-and-skip via the auto-triage front door (`autopilot/SKILL.md` § Auto-triage front door): the ticket is parked, the loop moves to the next one.
+
+There is no `verdict:"pass"` paired with `outcome:"escalated"`, nor `verdict:"fail"` paired with `outcome:"ready"` — a passing triage is always ready, and an escalation is always a fail.

--- a/tests/skills/triage.test.mjs
+++ b/tests/skills/triage.test.mjs
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => readFile(join(root, rel), 'utf8');
+
+describe('forge:triage skill (#469, AC-1/AC-2/AC-3/AC-4/AC-5)', () => {
+  it('AC-1: gains a Report contract section with the exact terminal JSON shape', async () => {
+    const s = await read('plugin/skills/triage/SKILL.md');
+    expect(s).toMatch(/^## Report contract$/m);
+    expect(s).toContain('{"issue":<n>,"verdict":"pass|fail","outcome":"ready|escalated"}');
+  });
+
+  it('AC-2: documents verdict:pass -> outcome:ready re-entering the autopilot queue via ledger.mjs applyOutcome stage:triage', async () => {
+    const s = await read('plugin/skills/triage/SKILL.md');
+    expect(s).toMatch(/`verdict:"pass"`\s*→\s*`outcome:"ready"`/);
+    expect(s).toMatch(/applyOutcome/);
+    expect(s).toMatch(/stage:"triage"/);
+    expect(s).toMatch(/re-enters the autopilot queue/i);
+  });
+
+  it('AC-3: documents verdict:fail -> outcome:escalated and states the axes are not independent', async () => {
+    const s = await read('plugin/skills/triage/SKILL.md');
+    expect(s).toMatch(/`verdict:"fail"`\s*→\s*`outcome:"escalated"`/);
+    expect(s).toMatch(/Auto-triage front door/);
+    expect(s).toMatch(/not independent axes/i);
+  });
+
+  it('AC-4: pinning test — fails if the Report contract heading or literal JSON shape is edited out', async () => {
+    const s = await read('plugin/skills/triage/SKILL.md');
+    // Re-assert both load-bearing strings directly (independent of the AC-1 test)
+    // so this test alone pins the contract per the ticket's own wording.
+    expect(s).toMatch(/## Report contract/);
+    expect(s).toContain('{"issue":<n>,"verdict":"pass|fail","outcome":"ready|escalated"}');
+    // placed at the end of the file, same placement as shape/SKILL.md's own section:
+    // no other '## ' heading follows it.
+    const headings = [...s.matchAll(/^## .+$/gm)].map((m) => m[0]);
+    expect(headings[headings.length - 1]).toBe('## Report contract');
+  });
+
+  it('AC-5: documentation-only — the runtime contract those files already imply is unchanged (OUTCOMES/RESOLVED_OUTCOMES still admit ready + escalated)', async () => {
+    const { OUTCOMES } = await import('../../plugin/scripts/autopilot/ledger.mjs');
+    const { RESOLVED_OUTCOMES } = await import('../../plugin/scripts/autopilot/watchdog.mjs');
+    for (const outcome of ['ready', 'escalated']) {
+      expect(OUTCOMES, 'ledger.mjs OUTCOMES').toContain(outcome);
+      expect(RESOLVED_OUTCOMES, 'watchdog.mjs RESOLVED_OUTCOMES').toContain(outcome);
+    }
+  });
+});


### PR DESCRIPTION
Closes #469

## What
Adds a `## Report contract` section to `plugin/skills/triage/SKILL.md`, mirroring the existing section in `plugin/skills/shape/SKILL.md` (same placement — end of file), stating the exact terminal JSON `{"issue":<n>,"verdict":"pass|fail","outcome":"ready|escalated"}` a spawned triage subagent returns, and documenting that `verdict`/`outcome` are not independent axes for triage (only pass/ready and fail/escalated occur). Adds a pinning test, `tests/skills/triage.test.mjs`, following the `tests/skills/shape.test.mjs` idiom.

Documentation-only — no runtime behaviour change. `plugin/scripts/autopilot/select.mjs`, `watchdog.mjs`, and `ledger.mjs` are untouched; this documents a contract those files already imply (confirmed against `ledger.mjs`'s `OUTCOMES` and `watchdog.mjs`'s `RESOLVED_OUTCOMES`, both of which admit `ready`/`escalated`).

## AC checklist
- [x] AC-1: `plugin/skills/triage/SKILL.md` gains a `## Report contract` section at the end of the file stating the exact terminal JSON shape.
- [x] AC-2: documents `verdict:"pass"` → `outcome:"ready"` re-entering the autopilot queue via `ledger.mjs` `applyOutcome` with `stage:"triage"`.
- [x] AC-3: documents `verdict:"fail"` → `outcome:"escalated"` via the auto-triage front door, and states plainly the axes are not independent.
- [x] AC-4: pinning test at `tests/skills/triage.test.mjs` fails if the heading or literal JSON shape is edited out.
- [x] AC-5: documentation-only — no change to `select.mjs`/`watchdog.mjs`/`ledger.mjs`. Covered by an AC-5-titled test that imports `ledger.mjs`'s `OUTCOMES` and `watchdog.mjs`'s `RESOLVED_OUTCOMES` and asserts both still admit `ready`/`escalated` (a live `git diff`-based check was deliberately avoided — `verify.yml` sets no `fetch-depth`, so a shallow PR checkout can't reliably resolve `origin/main`/`HEAD~1`, which would make that assertion flaky rather than honest). The diff itself (2 files: the SKILL.md and the new test) is the mechanical proof of AC-5's scope boundary.

## Verification
- `npx vitest run tests/skills/triage.test.mjs` — 5/5 pass.
- Full suite: `npx vitest run` — 82 files, 1525/1525 pass.
- Mechanical gates: `plandrift` clean (2 touched, all declared), `testintent` clean, `depguard` clean (no new deps), `acgate` 5/5 ACs covered by passing tests.
- `situationgate --action ship`: proceed (current board situation `awaiting-decision` does not restrict ship).
- Adversarial `forge:reviewer` pass: verdict pass, zero findings — cross-checked the new prose against `ledger.mjs`/`watchdog.mjs`/`autopilot/SKILL.md` for factual accuracy, confirmed AC-5 by inspection (only 2 files touched, no runtime file changed).
- Adversarial `forge:security` pass (performed synchronously against the branch diff): verdict pass, zero findings — no new dependencies, no CI/hook files touched, no shell execution or dynamic/user-derived paths introduced, no secrets, the new test's imports are literal relative paths to existing internal modules only.

## Scope note
Filed #535 (child of epic #182) as a follow-up for a pre-existing, unrelated `docsync` gap discovered on `main` while running the ship gates (`docs/plans/2026-08-17-448-brace-expansion-denylist.md` not linked in `docs/README.md`, predates this PR, from #448/PR #534). Not fixed here — out of #469's documentation-only scope.
