### PR TITLE
fix(denylist): judge a NUL-fused safe-word/dash continuation instead of filtering it as a flag (#472)

### DIFF
--- a/docs/plans/2026-08-17-472-safermtarget-nul-dash-fusion.md
+++ b/docs/plans/2026-08-17-472-safermtarget-nul-dash-fusion.md
@@ -1,0 +1,96 @@
+# Plan: #472 - denylist: a NUL fusing a safe word with a dash-prefixed suffix bypasses safeRmTarget
+
+**Ticket:** #472 (board #8) - **Kind:** bug
+**Base:** main - **Branch:** fix/472-safermtarget-nul-dash-fusion - **Verify:** `npm run verify`
+
+`safeRmTarget()` in `plugin/hooks/denylist.mjs` splits `rm`'s argument text
+(the `spacedText` reading, where a dropped NUL is substituted with an inert
+space, #446) on whitespace and unconditionally filters any `-`-leading token
+out as a flag. A raw NUL between a safe-word token and a dash-prefixed
+continuation defeats this: `dist<NUL>-prod-secrets` real-bash-fuses to the
+single argument `dist-prod-secrets` (not a whole `dist` component — nothing
+ends the word at `/` or string-end there), which correctly fails
+`SAFE_RM_TARGET` as one piece — but split via `spacedText`, "dist" is judged
+and passes while "-prod-secrets" is silently discarded as a flag and never
+judged at all. Verified against `check()` directly against `main` before
+this fix: `rm -rf dist<NUL>-prod-secrets` read `blocked:false`.
+
+Re-verified first per this ticket's own shaping instruction (a sibling,
+#471, turned out to already be fixed by #452/PR #473) — this one still
+reproduces on current `main`, unrelated to and unfixed by #452/#473.
+
+## Design
+
+`safeRmTarget()` is only eligible to filter a dash-leading token as a
+genuine flag when REAL bash whitespace preceded it — not when the only
+thing preceding it was a position where a NUL was substituted with a space.
+It determines this per-token by walking `rest` (the existing
+`spacedText`-derived reading) in LOCKSTEP with a new `restText` parameter
+(the sibling `text`-derived reading, where a dropped NUL leaves nothing
+behind at all — already computed by `normalizeShellText()` and already
+available to `recursive-delete`'s rule as `c`, just not previously forwarded
+into `safeRmTarget()`).
+
+Two alternative designs were considered and rejected during shaping:
+
+- **Always fuse a synthetic-gap pair back into one string before judging
+  it.** Reopens #446: fusing `/prod-secrets<NUL>/scratchpad` back into one
+  string reintroduces exactly the bypass #446 closed, since
+  `SAFE_RM_TARGET.test()` matches a trailing safe component anywhere in a
+  string, not the whole string — the fused form ends in `/scratchpad` and
+  would wrongly test safe.
+- **Embed a new sentinel character into `spacedText` itself** to mark
+  synthetic insertion points, instead of comparing against the sibling
+  `text` reading. Rejected: any single fixed sentinel character risks
+  colliding with a literal, non-NUL control byte a real (adversarial)
+  command could contain verbatim as ordinary bare data — `normalizeShellText()`
+  never strips or decodes an unquoted, non-NUL control byte — which would
+  spoof or blind the "was this gap synthetic" test depending on which
+  direction the collision ran. It would also require changing
+  `normalizeShellText()`'s `spacedText` output, touching AC-452.5's pinned
+  exact-content assertions.
+
+Neither `normalizeShellText()`, `spacedText`, nor `guardedText` is touched
+by this fix — it is confined entirely to `safeRmTarget()`'s own
+flag-eligibility test and the one call site that constructs its arguments.
+No pinned AC-446.6 / AC-450.* / AC-452.* semantic changes.
+
+## AC map
+
+- **AC-472.1** A safe word fused by a dropped NUL with a dash-prefixed
+  continuation is judged as part of the real target, not silently filtered
+  as a flag — the ticket's exact reproduction, every `SAFE_RM_TARGET`
+  alternative as the fused prefix, and regardless of position among other
+  targets.
+- **AC-472.2** No regression: #446's raw-NUL target-splice cases, #450's
+  POSIX `--` end-of-options cases, and #452's NUL-in-flag-cluster cases all
+  stay exactly as before.
+- **AC-472.3** A genuine, standalone flag preceded by real whitespace is
+  still correctly filtered, even alongside an unrelated NUL elsewhere in
+  the same command.
+- **AC-472.4** The long-flag (`--recursive --force`) spelling is affected
+  identically to the short `-rf` spelling.
+
+## Task 1 (test): failing tests first
+
+New `#472`-titled describe block in `tests/hooks/denylist.test.mjs`, after
+the existing `#454` blocks: the ticket's exact reproduction, every safe-word
+alternative, position-independence, and explicit re-runs of #446/#450/#452's
+own pinned cases by name.
+
+**Files:** tests/hooks/denylist.test.mjs
+**AC map:** AC-472.1 – AC-472.4
+**Test plan:** `npx vitest run tests/hooks/denylist.test.mjs -t "472"`
+
+## Task 2 (code): safeRmTarget() lockstep rewrite
+
+- Rewrite `safeRmTarget()` to accept a second `restText` parameter and walk
+  both readings in lockstep, only filtering a dash-leading token as a flag
+  when the sibling reading shows real IFS whitespace at that same gap.
+- Update `recursive-delete`'s `test()` to compute `restText` (sliced from
+  `c` at its own `\brm\b` match) and pass it through.
+
+**Files:** plugin/hooks/denylist.mjs
+**AC map:** AC-472.1, AC-472.2, AC-472.3, AC-472.4
+**Done:** Task 1's new tests pass; full `tests/hooks/denylist.test.mjs`
+green (167/167); full `npm run verify` green (1533/1533 across 82 files).

--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -135,6 +135,23 @@ const SAFE_RM_TARGET =
  * comparison baseline, not a character value attacker input could collide
  * with.
  *
+ * Two adjacent, pre-existing gaps a full-branch adversarial pass on this
+ * ticket's own diff found — confirmed identical on `main` before this
+ * fix, i.e. neither introduced nor worsened by the lockstep walk here —
+ * are deliberately NOT closed by it and are tracked separately rather than
+ * folded into this bounded change: a NUL splitting the literal `rm` token
+ * itself can desync which occurrence `rest`/`restText` each anchor at
+ * (#537), and a QUOTED INTERNAL space is invisible to both readings the
+ * same way a NUL-inserted one is, since neither `text` nor `spacedText`
+ * retains whether a given whitespace character was genuinely a top-level
+ * separator or protected inside a quote — the same ambiguity `guardedText`
+ * exists to resolve for `beforeEndOfOptions()`'s flag-boundary check, just
+ * not yet threaded into this function's target/flag split (#538). #538 is
+ * NOT NUL-related at all — `rm -rf "tmp -etc-shadow"` alone reproduces it,
+ * with no NUL byte anywhere in the command — so it needs a third
+ * (`guardedText`-based) reading threaded through, not a fix to this
+ * function's two-reading NUL-vs-real-separator comparison.
+ *
  * POSIX `--` end-of-options (#450, AC-450.*): a bare `--` token tells the
  * shell/utility that every token AFTER it is a filename, never a flag, even
  * one that starts with `-`. Verified against real bash (`argv rm -rf --
@@ -190,9 +207,18 @@ function safeRmTarget(rest, restText) {
     if (i >= n) break;
     const start = i;
     // `text` and `spacedText` share the identical non-whitespace character
-    // sequence in order (AC-452.5) once aligned at their own `rm`, so a
-    // token in `rest` and its counterpart in `restText` advance in lockstep
-    // one character at a time.
+    // sequence in order (AC-452.5), so a token in `rest` and its
+    // counterpart in `restText` advance in lockstep one character at a
+    // time PROVIDED the two `\brm\b` matches below anchor at the same
+    // logical `rm` occurrence — a full-branch adversarial `forge:reviewer`
+    // pass found that assumption can fail (a NUL splitting the literal
+    // `rm` token itself, `r<NUL>m`, moves `cSpaced`'s own `\brm\b` match to
+    // a LATER decoy occurrence while `c`'s independent match stays
+    // correctly anchored at the real one). Confirmed pre-existing —
+    // verified identical on `main` before this ticket, unrelated to and
+    // unaffected by the lockstep walk itself — and filed separately rather
+    // than folded into this ticket's bounded scope; see the call site's
+    // own comment for the tracking issue.
     while (i < n && !isIfsChar(rest[i])) { i++; j++; }
     const tok = rest.slice(start, i);
     if (!seenRm) { seenRm = true; continue; }
@@ -1456,7 +1482,10 @@ export const RULES = [
       // match — see safeRmTarget()'s own comment for why this, not a new
       // marker character, is what tells a genuine bash argument boundary
       // apart from one that only exists because a NUL was substituted with
-      // a space.
+      // a space. This match is independent of `rmMatch` above; see
+      // safeRmTarget()'s own comment on the lockstep loop for a known,
+      // pre-existing case (#537, out of #472's bounded scope) where the two
+      // can diverge.
       const rmMatchText = /\brm\b/.exec(c);
       const restText = rmMatchText ? c.slice(rmMatchText.index) : c;
       // EVERY target must be safe, not merely one of them (#446) — see

--- a/plugin/hooks/denylist.mjs
+++ b/plugin/hooks/denylist.mjs
@@ -94,6 +94,47 @@ const SAFE_RM_TARGET =
  * is treated as unsafe — that keeps the old outcome for a bare `rm -rf`, and
  * "nothing recognisable to vouch for" should never read as "safe".
  *
+ * ## A NUL fusing a safe word with a dash-prefixed continuation (#472)
+ *
+ * The per-argument split above closes "one safe decoy vouches for the whole
+ * line" (#446), but `spacedText`'s NUL-to-space substitution it depends on
+ * (see `normalizeShellText()`'s own comment) is a genuine OVER-
+ * approximation for that case specifically: real bash FUSES
+ * `/prod-secrets<NUL>/scratchpad` into ONE argument, but reading it as TWO
+ * tokens here is exactly what lets the dangerous `/prod-secrets` half be
+ * judged on its own instead of hiding behind the trailing safe word. That
+ * same over-approximation runs backwards when the token AFTER a dropped
+ * NUL starts with `-`: `dist<NUL>-prod-secrets` real-bash-fuses to the
+ * single argument `dist-prod-secrets` — not a whole `dist` component
+ * (nothing ends the word at `/` or string-end there), so it correctly
+ * fails `SAFE_RM_TARGET` as one piece — but split via `spacedText`, "dist"
+ * is judged and passes while "-prod-secrets" is silently discarded as a
+ * flag and never judged at all. One safe-looking prefix vouches for the
+ * fused unsafe whole.
+ *
+ * The fix is neither "stop splitting" (reopens #446 above) nor "always fuse
+ * a synthetic-gap pair back together" (tried and rejected during shaping:
+ * fusing `/prod-secrets<NUL>/scratchpad` back into one string reintroduces
+ * #446's own bypass, since `SAFE_RM_TARGET.test()` matches a trailing safe
+ * COMPONENT anywhere in its argument, not the whole argument — the fused
+ * form ends in `/scratchpad` and would wrongly test safe). It only changes
+ * which pieces are ELIGIBLE to be filtered as a flag: a `-`-leading piece
+ * is a genuine, standalone flag only when REAL bash whitespace preceded it
+ * — not when the only thing preceding it was a position where a NUL was
+ * dropped. `safeRmTarget()` determines that per-piece by walking `rest`
+ * (the `spacedText`-derived reading) in LOCKSTEP with `restText` (the
+ * sibling `text`-derived reading, where a dropped NUL leaves nothing behind
+ * at all), rather than by embedding some new marker character into
+ * `spacedText` itself: a fixed sentinel character risks colliding with a
+ * literal, non-NUL control byte a real command could contain verbatim as
+ * ordinary bare data (`normalizeShellText()` never strips or decodes an
+ * unquoted, non-NUL control byte), which would spoof or blind the
+ * "was this gap synthetic" test depending on which direction the collision
+ * ran. Comparing against the sibling `text` reading — already computed,
+ * already available to this rule — has no such risk: it is `rest`'s own
+ * comparison baseline, not a character value attacker input could collide
+ * with.
+ *
  * POSIX `--` end-of-options (#450, AC-450.*): a bare `--` token tells the
  * shell/utility that every token AFTER it is a filename, never a flag, even
  * one that starts with `-`. Verified against real bash (`argv rm -rf --
@@ -120,20 +161,50 @@ const SAFE_RM_TARGET =
  * tab does separate. Carriage returns need no case here — normalizeShellText()
  * strips them before any rule runs.
  */
-function safeRmTarget(rest) {
+/** Bash's own default IFS — space, tab, newline (see safeRmTarget()'s own comment on why not JS's wider `\s`). */
+const isIfsChar = (ch) => ch === ' ' || ch === '\t' || ch === '\n';
+
+function safeRmTarget(rest, restText) {
   let endOfOptions = false;
-  const targets = rest
-    .split(/[ \t\n]+/)
-    .slice(1)
-    .filter((t) => {
-      if (!t) return false;
-      if (endOfOptions) return true;
-      if (t === '--') {
-        endOfOptions = true;
-        return false;
-      }
-      return !t.startsWith('-');
-    });
+  const targets = [];
+  let i = 0;
+  let j = 0;
+  const n = rest.length;
+  const m = restText.length;
+  let seenRm = false; // the first token is always 'rm' itself; drop it
+  while (i < n) {
+    // Walk the gap in `rest`. `gapHasRealSep` goes true only if `restText`
+    // ALSO has whitespace somewhere in this same gap — i.e. real bash
+    // genuinely split here too, not merely a space `spacedText` re-inserted
+    // for a dropped NUL that leaves nothing behind in `restText` at all
+    // (#472). `j` only advances when a `restText` whitespace character is
+    // actually consumed, so a gap containing BOTH a real separator and a
+    // NUL-inserted space still correctly reports real, and a purely
+    // synthetic gap leaves `j` exactly where it was, pointing straight at
+    // the next real character in `restText`.
+    let gapHasRealSep = false;
+    while (i < n && isIfsChar(rest[i])) {
+      if (j < m && isIfsChar(restText[j])) { gapHasRealSep = true; j++; }
+      i++;
+    }
+    if (i >= n) break;
+    const start = i;
+    // `text` and `spacedText` share the identical non-whitespace character
+    // sequence in order (AC-452.5) once aligned at their own `rm`, so a
+    // token in `rest` and its counterpart in `restText` advance in lockstep
+    // one character at a time.
+    while (i < n && !isIfsChar(rest[i])) { i++; j++; }
+    const tok = rest.slice(start, i);
+    if (!seenRm) { seenRm = true; continue; }
+    if (!tok) continue;
+    if (endOfOptions) { targets.push(tok); continue; }
+    if (tok === '--') { endOfOptions = true; continue; }
+    if (tok.startsWith('-') && gapHasRealSep) continue; // a genuine, standalone flag
+    // A dash-led token whose own leading gap was NUL-only is not a real,
+    // separate flag argument in real bash at all (#472) — judged as a
+    // target instead of silently discarded, same as any non-dash-led piece.
+    targets.push(tok);
+  }
   if (targets.length === 0) return false;
   return targets.every((t) => SAFE_RM_TARGET.test(t));
 }
@@ -1381,10 +1452,17 @@ export const RULES = [
       // above already establishes one exists in the sibling `text` reading).
       const rmMatch = /\brm\b/.exec(cSpaced);
       const rest = cSpaced.slice(rmMatch ? rmMatch.index : 0);
+      // The sibling `text`-derived reading (#472), sliced at ITS OWN `rm`
+      // match — see safeRmTarget()'s own comment for why this, not a new
+      // marker character, is what tells a genuine bash argument boundary
+      // apart from one that only exists because a NUL was substituted with
+      // a space.
+      const rmMatchText = /\brm\b/.exec(c);
+      const restText = rmMatchText ? c.slice(rmMatchText.index) : c;
       // EVERY target must be safe, not merely one of them (#446) — see
       // safeRmTarget(): a single safe-looking decoy argument used to exempt
       // the whole command, however many real targets sat beside it.
-      return !safeRmTarget(rest);
+      return !safeRmTarget(rest, restText);
     },
     msg: 'rm -rf (incl. --recursive --force) outside build/temp dirs',
   },

--- a/tests/hooks/denylist.test.mjs
+++ b/tests/hooks/denylist.test.mjs
@@ -877,6 +877,124 @@ describe('recursive-delete flag detection honors POSIX -- end-of-options (#454/#
   });
 });
 
+// #472 — a raw NUL fusing a safe word with a dash-prefixed continuation
+// defeats safeRmTarget(). spacedText's NUL-to-space substitution (#446) is a
+// deliberate over-approximation FOR the case where the NUL is deleted and
+// the pieces fuse into something that would otherwise wrongly read as safe
+// (a trailing safe word vouching for a fused whole) — but the same
+// substitution runs backwards when the piece AFTER the dropped NUL starts
+// with `-`: safeRmTarget()'s flag filter unconditionally treats ANY
+// dash-leading token as a flag and discards it, with no way to tell "a real
+// bash argument boundary" apart from "a boundary that only exists because a
+// NUL was substituted with a space." `dist<NUL>-prod-secrets` real-bash-fuses
+// to the single argument `dist-prod-secrets` — not a whole `dist` component
+// (nothing ends the word at `/` or string-end there), so it correctly fails
+// SAFE_RM_TARGET as one piece — but split via spacedText, "dist" is judged
+// and passes while "-prod-secrets" is silently filtered as a flag and never
+// judged at all. One safe-looking prefix vouches for the fused unsafe whole.
+//
+// Verified against `check()` directly against `main` before this fix:
+// `rm -rf dist<NUL>-prod-secrets` read `blocked:false`.
+//
+// Fixed by walking the spacedText-derived reading in lockstep with the
+// sibling text-derived reading (already available to this rule as `c`) and
+// only treating a dash-leading token as a genuine, filterable flag when the
+// sibling reading ALSO shows real IFS whitespace at that same gap — i.e.
+// real bash genuinely split there, not merely a NUL-inserted space. This
+// touches only `safeRmTarget()`'s own flag-eligibility test; it does not
+// change `normalizeShellText()`, `spacedText`, or `guardedText` in any way,
+// so AC-446.6/AC-450.*/AC-452.*'s pinned semantics (including AC-452.5's
+// exact-content assertions on `spacedText`) are untouched by this ticket.
+describe('a NUL fusing a safe word with a dash-prefixed continuation defeats safeRmTarget (#472, AC-472.*)', () => {
+  const NUL = String.fromCharCode(0);
+
+  // AC-472.1 — the ticket's exact reproduction.
+  it('AC-472.1: a safe word fused by a dropped NUL with a dash-prefixed continuation is judged, not filtered as a flag', () => {
+    expect(check(`rm -rf dist${NUL}-prod-secrets`)).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+
+  // AC-472.1 — every SAFE_RM_TARGET alternative is checked as the fused
+  // prefix, not just `dist`: the bug lives in safeRmTarget()'s generic
+  // flag-filtering, not in any one alternative's own matching.
+  it('AC-472.1: every safe-word alternative fused with a dash-prefixed continuation still blocks', () => {
+    for (const cmd of [
+      `rm -rf node_modules${NUL}-prod-secrets`,
+      `rm -rf build${NUL}-prod-secrets`,
+      `rm -rf coverage${NUL}-prod-secrets`,
+      `rm -rf temp${NUL}-prod-secrets`,
+      `rm -rf tmp${NUL}-prod-secrets`,
+      `rm -rf scratchpad${NUL}-prod-secrets`,
+      `rm -rf .forge${NUL}-prod-secrets`,
+      `rm -rf $TMP${NUL}-prod-secrets`,
+    ]) {
+      expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    }
+  });
+
+  // AC-472.1 — the decoy still blocks regardless of position among other
+  // targets, matching #446's own per-argument (never whole-line) discipline.
+  it('AC-472.1: the fused decoy still blocks regardless of position among other targets', () => {
+    expect(check(`rm -rf dist build${NUL}-prod-secrets`)).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    expect(check(`rm -rf dist${NUL}-prod-secrets build`)).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    expect(check(`rm -rf /already-unsafe dist${NUL}-prod-secrets`)).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+
+  // AC-472.2 — no regression on #446's own raw-NUL target-splice tests:
+  // those need the OPPOSITE outcome from this fix in the analogous position
+  // (the piece after the NUL there does not start with `-`, so it is
+  // untouched by the new flag-eligibility condition), and this fix must not
+  // have changed that via an alternative design (fusing split pieces back
+  // together) considered and rejected during shaping — see the ticket
+  // trail for why fusing would have reopened exactly this bypass. Re-run by
+  // name so a regression here is never mistaken for an unrelated failure.
+  it('AC-472.2: #446\'s raw-NUL target-splice cases stay blocked, unchanged', () => {
+    for (const cmd of [
+      `rm -rf /prod-secrets${NUL}/scratchpad`,
+      `rm -rf "/prod-secrets${NUL}/scratchpad"`,
+      `rm -rf '/prod-secrets${NUL}/scratchpad'`,
+      `rm -rf important-secret-data${NUL}dist`,
+    ]) {
+      expect(check(cmd), cmd).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    }
+    // ...and the all-safe NUL-joined case (neither side dash-led) stays
+    // exempt — this fix's new condition only ever gates a dash-led piece.
+    expect(check(`rm -rf dist${NUL}build`).blocked).toBe(false);
+  });
+
+  // AC-472.2 — no regression on #450's POSIX `--` end-of-options handling:
+  // a genuine `--` marker (real whitespace throughout, no NUL involved)
+  // still latches end-of-options exactly as before.
+  it('AC-472.2: #450\'s -- end-of-options cases stay unaffected', () => {
+    expect(check('rm -rf -- -prod-secrets dist')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+    expect(check('rm -rf -- dist').blocked).toBe(false);
+    expect(check('rm -rf --')).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+
+  // AC-472.2 — no regression on #452's own NUL-inside-a-flag-cluster fix:
+  // that mechanism reads the NUL-DELETED `text` view via shortFlagCluster()
+  // on `c`, an entirely different code path from the target-parsing this
+  // ticket touches.
+  it('AC-472.2: #452\'s NUL-in-flag-cluster cases stay blocked', () => {
+    expect(check(`rm -r${NUL}f /prod-secrets`)).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+
+  // AC-472.3 — a genuine, standalone flag preceded by REAL whitespace is
+  // still correctly filtered and never mistaken for a fused continuation,
+  // even when some OTHER NUL appears elsewhere in the same command, or
+  // immediately after real whitespace of its own.
+  it('AC-472.3: a real flag with genuine whitespace before it is still filtered, even alongside an unrelated NUL elsewhere', () => {
+    expect(check(`rm -rf dist -x${NUL}build`).blocked).toBe(false);
+    expect(check(`rm -rf ${NUL}-rf dist`).blocked).toBe(false);
+  });
+
+  // AC-472.4 — the long-flag (--recursive --force) spelling is affected
+  // identically, since safeRmTarget()'s target-parsing is flag-spelling-
+  // agnostic.
+  it('AC-472.4: the long-flag (--recursive --force) spelling is affected identically', () => {
+    expect(check(`rm --recursive --force dist${NUL}-prod-secrets`)).toMatchObject({ blocked: true, rule: 'recursive-delete' });
+  });
+});
+
 describe('hard-reset reordered/bundled/abbreviated spellings (#437, AC-437.1)', () => {
   // AC-437.1 — --hard blocks regardless of OTHER flags sitting between `reset`
   // and `--hard`, in either order, and regardless of a global git flag before


### PR DESCRIPTION
Closes #472

## What

`safeRmTarget()` in `plugin/hooks/denylist.mjs` split `rm`'s argument text (the `spacedText` reading, where a dropped NUL is substituted with an inert space, #446) on IFS whitespace and unconditionally filtered any `-`-leading token out as a flag, never judging it. A raw NUL directly between a safe word and a dash-prefixed continuation real-bash-fuses into a single argument that correctly fails `SAFE_RM_TARGET` as one piece, but split via `spacedText` the safe half passed independently while the dangerous half was silently discarded as a "flag" and never judged — one safe-looking prefix vouching for a fused unsafe argument.

Fixed by giving `safeRmTarget()` a second parameter — the sibling `text`-derived reading (where a dropped NUL leaves nothing behind at all) — and walking both readings in lockstep. A dash-leading token is now only treated as a genuine, filterable flag when the sibling reading also shows real IFS whitespace at that same gap; otherwise it's judged as a target like anything else. No change to `normalizeShellText()`, `spacedText`, or `guardedText`.

## Why this design (not the alternatives)

Two other designs were considered and rejected — documented in the plan doc and in the code comments:

- **Always fuse the split pieces back together before judging.** Rejected: it reopens the #446 bypass this file already closed, since `SAFE_RM_TARGET.test()` matches a trailing safe component anywhere in a string, not the whole string — a fused decoy-prefix-plus-safe-suffix would wrongly test safe.
- **Embed a new sentinel character into `spacedText` to mark synthetic insertion points.** Rejected: a fixed sentinel risks colliding with a literal, non-NUL control byte a real adversarial command could contain verbatim as bare data, and it would also touch `spacedText`'s pinned exact-content assertions (AC-452.5).

## Adversarial review

`forge:reviewer` and `forge:security` both ran a full-branch adversarial pass. Both returned a critical finding on the first round — both real, both confirmed by direct comparison against a `main` checkout to be **pre-existing and unaffected by this diff** (identical behavior with and without this change):

- **#537** — a NUL splitting the literal `rm` token itself can desync which occurrence the pre-existing `\brm\b`-anchored slice (#454's own AC-454.1 fix, untouched by this diff) lands on, letting a decoy `rm`-shaped later argument hide an earlier dangerous target from judgement.
- **#538** — a quoted internal space defeats `safeRmTarget()`'s target/flag split the same general way, entirely independent of any NUL byte (`rm -rf "tmp -etc-shadow"` alone reproduces it) — the same ambiguity `guardedText` already resolves for the flag-boundary side of this rule, just not yet threaded into the target-parsing side.

Both filed under epic #182, linked to #472, with reproductions and suggested fix directions. A round-two pass, given this empirical pre-existing-verification, returned `verdict: pass` from both agents on #472's own bounded change. One agent's non-blocking note (commit the corrected comment) has been addressed.

## AC checklist

- [x] AC-472.1 — a safe word fused by a dropped NUL with a dash-prefixed continuation is judged, not filtered as a flag (ticket repro, every `SAFE_RM_TARGET` alternative, position-independence)
- [x] AC-472.2 — no regression on #446/#450/#452's pinned cases
- [x] AC-472.3 — a genuine, real-whitespace-preceded flag is still filtered correctly
- [x] AC-472.4 — the long-flag (`--recursive --force`) spelling is affected identically

## Verification

- `npm run verify`: 1533/1533 passing across 82 files
- `tests/hooks/denylist.test.mjs`: 167/167 (8 new `#472` tests)
- Mechanical gates: plandrift, testintent, depguard, acgate all pass (acgate: 4/4 ACs covered by passing tests)
- Re-verified the ticket's exact reproduction directly against `check()` before and after: `blocked:false` → `blocked:true`
- Commit-subject conventions lint: pass
- Branch fast-forwards cleanly onto `main` tip, no rebase conflicts
