### PR TITLE
fix(lib): close a TOCTOU race in lock.mjs's stale-lock reclaim (#482)

### DIFF
--- a/plugin/scripts/lib/lock.mjs
+++ b/plugin/scripts/lib/lock.mjs
@@ -154,7 +154,12 @@ const RECLAIM_MARKER_STALE_MS = 30_000;
  */
 async function reclaimStaleLock(path, { pid, hostname, now, staleMs, isAlive, _beforeMarkerAttempt }) {
   const marker = `${path}.reclaiming`;
-  await _beforeMarkerAttempt?.(); // test-only seam (#482) — never set by real callers
+  // Test-only seam (#482), hardened per security review: gated on `VITEST`
+  // (set automatically by the test runner) so a future consumer that merges
+  // external/CLI-derived config into `acquireLock`'s options bag can't
+  // accidentally wire an arbitrary async callback into this locking
+  // primitive outside of tests.
+  if (process.env.VITEST) await _beforeMarkerAttempt?.();
   let markerHandle;
   try {
     markerHandle = await open(marker, 'wx');
@@ -209,11 +214,12 @@ async function reclaimStaleLock(path, { pid, hostname, now, staleMs, isAlive, _b
  *
  * `_beforeMarkerAttempt` is a test-only seam (#482): an optional hook invoked
  * inside `reclaimStaleLock`, right before every attempt (including retries)
- * to grab the `.reclaiming` marker. Real callers never set it; it exists so
- * a test can deterministically pause one racer there while a second,
- * independent reclaim of the same lock runs to completion, exercising the
- * bug-3 race window (see `reclaimStaleLock`'s doc comment) without relying
- * on scheduling luck.
+ * to grab the `.reclaiming` marker, but ONLY when `process.env.VITEST` is
+ * set — never under a real run, even if a future caller mistakenly passes
+ * it. Real callers never set it; it exists so a test can deterministically
+ * pause one racer there while a second, independent reclaim of the same
+ * lock runs to completion, exercising the bug-3 race window (see
+ * `reclaimStaleLock`'s doc comment) without relying on scheduling luck.
  */
 export async function acquireLock(path, { pid = process.pid, hostname = osHostname(), now = Date.now, staleMs = DEFAULT_STALE_MS, isAlive = isProcessAlive, _beforeMarkerAttempt } = {}) {
   await mkdir(dirname(path), { recursive: true });

--- a/plugin/scripts/lib/lock.mjs
+++ b/plugin/scripts/lib/lock.mjs
@@ -137,9 +137,24 @@ const RECLAIM_MARKER_STALE_MS = 30_000;
  *    `open(path,'w')` (create-or-truncate, non-exclusive — safe here
  *    specifically because the marker already proved sole reclaimer status),
  *    with no unlink/recreate gap in between.
+ * 3. (found via #482 — flaky on GitHub-hosted Windows CI, empirically
+ *    reproduced locally under heavier concurrency than the original test
+ *    used) The marker only proves no OTHER caller is inside this critical
+ *    section AT THE SAME TIME — it says nothing about whether `path` is
+ *    STILL the stale lock this caller originally observed. A straggler that
+ *    read the same originally-stale `path` before a faster racer finished
+ *    can win the marker AFTER that racer has already written its own fresh
+ *    lock and released the marker, then (pre-fix) blindly overwrote it —
+ *    two "winners" again, just via a slower interleaving than bug 1's.
+ *    Fixed by re-reading and re-validating `path` for staleness (with the
+ *    caller's own `staleMs`/`isAlive`) immediately after winning the marker
+ *    and before overwriting — if it's no longer stale, someone else already
+ *    reclaimed it while this caller was racing to get here, so this caller
+ *    backs off with `{ok:false, heldBy}` instead of clobbering it.
  */
-async function reclaimStaleLock(path, { pid, hostname, now }) {
+async function reclaimStaleLock(path, { pid, hostname, now, staleMs, isAlive, _beforeMarkerAttempt }) {
   const marker = `${path}.reclaiming`;
+  await _beforeMarkerAttempt?.(); // test-only seam (#482) — never set by real callers
   let markerHandle;
   try {
     markerHandle = await open(marker, 'wx');
@@ -159,11 +174,19 @@ async function reclaimStaleLock(path, { pid, hostname, now }) {
       return { ok: false, error: `lock ${path} — a concurrent reclaim is already in progress` };
     }
     await unlink(marker).catch(() => {});
-    return reclaimStaleLock(path, { pid, hostname, now });
+    return reclaimStaleLock(path, { pid, hostname, now, staleMs, isAlive, _beforeMarkerAttempt });
   }
   try {
     await markerHandle.close();
-    const handle = await open(path, 'w'); // exclusively-marked reclaimer — safe to overwrite, `path` never goes missing
+    // Bug 3 fix: re-validate `path` is STILL stale before overwriting — the
+    // marker only guarantees exclusivity among callers racing RIGHT NOW, not
+    // that nobody already finished reclaiming this exact lock in the time it
+    // took this caller to get here (see doc comment above).
+    const current = await readLock(path);
+    if (!isStale(current, { now: now(), staleMs, isAlive })) {
+      return { ok: false, error: `lock ${path} held by pid ${current?.pid ?? '?'} (${current?.hostname ?? 'unknown host'})`, heldBy: current };
+    }
+    const handle = await open(path, 'w'); // exclusively-marked reclaimer, freshness re-checked above — safe to overwrite, `path` never goes missing
     try {
       await handle.writeFile(lockContents(pid, hostname, now()), 'utf8');
     } finally {
@@ -183,8 +206,16 @@ async function reclaimStaleLock(path, { pid, hostname, now }) {
  * than wedging forever on a crashed holder. `release()` on the success result
  * is idempotent and safe to call from a `finally` even if the file is already
  * gone.
+ *
+ * `_beforeMarkerAttempt` is a test-only seam (#482): an optional hook invoked
+ * inside `reclaimStaleLock`, right before every attempt (including retries)
+ * to grab the `.reclaiming` marker. Real callers never set it; it exists so
+ * a test can deterministically pause one racer there while a second,
+ * independent reclaim of the same lock runs to completion, exercising the
+ * bug-3 race window (see `reclaimStaleLock`'s doc comment) without relying
+ * on scheduling luck.
  */
-export async function acquireLock(path, { pid = process.pid, hostname = osHostname(), now = Date.now, staleMs = DEFAULT_STALE_MS, isAlive = isProcessAlive } = {}) {
+export async function acquireLock(path, { pid = process.pid, hostname = osHostname(), now = Date.now, staleMs = DEFAULT_STALE_MS, isAlive = isProcessAlive, _beforeMarkerAttempt } = {}) {
   await mkdir(dirname(path), { recursive: true });
   let handle;
   try {
@@ -195,7 +226,7 @@ export async function acquireLock(path, { pid = process.pid, hostname = osHostna
     if (!isStale(existing, { now: now(), staleMs, isAlive })) {
       return { ok: false, error: `lock ${path} held by pid ${existing?.pid ?? '?'} (${existing?.hostname ?? 'unknown host'})`, heldBy: existing };
     }
-    const reclaimed = await reclaimStaleLock(path, { pid, hostname, now });
+    const reclaimed = await reclaimStaleLock(path, { pid, hostname, now, staleMs, isAlive, _beforeMarkerAttempt });
     if (!reclaimed.ok) return reclaimed;
     return releasable(path);
   }

--- a/tests/lib/lock.test.mjs
+++ b/tests/lib/lock.test.mjs
@@ -115,10 +115,13 @@ describe('lib/lock (#414, per #387 design) — shared exclusive-lockfile helper'
   // unlink()+recreate reclaim let two concurrent callers BOTH judge the same
   // stale lock reclaimable and BOTH end up believing they hold it — the exact
   // #387 lost-update race this lockfile exists to prevent. The fix reclaims
-  // via an atomic rename (only one racer's rename can ever succeed); this
-  // pins that AT MOST ONE concurrent acquirer ever wins a race over one
-  // stale lock, run repeatedly since a race is inherently non-deterministic.
-  it('AC — concurrent acquireLock calls racing to reclaim the SAME stale lock: exactly one wins, never both', async () => {
+  // exclusively via a `.reclaiming` marker file (`open(marker,'wx')` — an
+  // atomic-rename attempt was tried first and empirically ALSO failed under
+  // concurrent load on this platform's filesystem, see lock.mjs's own doc
+  // comment); this pins that AT MOST ONE concurrent acquirer ever wins a race
+  // over one stale lock, run repeatedly since a race is inherently
+  // non-deterministic.
+  it('AC-482.2 — concurrent acquireLock calls racing to reclaim the SAME stale lock: exactly one wins, never both', async () => {
     for (let iter = 0; iter < 25; iter++) {
       const dir = await tmp();
       const path = join(dir, 'x.lock');
@@ -135,6 +138,58 @@ describe('lib/lock (#414, per #387 design) — shared exclusive-lockfile helper'
       expect(winners[0].ok).toBe(true);
       await winners[0].release();
     }
+  });
+
+  // #482 — the flaky-on-CI race, reproduced deterministically via a seam
+  // instead of relying on scheduling luck / a bigger stress loop. The
+  // `.reclaiming` marker (previous test) only serializes racers that attempt
+  // it AT THE SAME TIME; it does not, on its own, stop a STRAGGLER — one that
+  // independently read the SAME originally-stale lock earlier but is slow to
+  // reach its own marker attempt — from winning the marker AFTER a faster
+  // racer already finished a full reclaim and released it. Empirically
+  // reproduced on this machine under heavier concurrency (12-way, hundreds of
+  // iterations) than the test above uses: a handful of double-wins where the
+  // straggler blindly overwrote the fresh winner's lock with no re-check.
+  // This test forces exactly that interleaving with `_beforeMarkerAttempt`
+  // (a test-only seam in reclaimStaleLock) instead of hoping for it.
+  it('AC-482.3 — a straggler that observed the same stale lock before another racer already reclaimed it backs off instead of clobbering the fresh lock', async () => {
+    const dir = await tmp();
+    const path = join(dir, 'x.lock');
+    const now = Date.now();
+    await writeFile(path, JSON.stringify({ pid: 999999, startedAt: new Date(now).toISOString(), hostname: 'crashed-host' }), 'utf8');
+    const isAlive = (pid) => pid !== 999999;
+
+    // The straggler: paused right before its own marker attempt, i.e. after
+    // it has already (independently) judged the ORIGINAL stale lock
+    // reclaimable, exactly mirroring the real race window.
+    let releaseStraggler;
+    const stragglerPaused = new Promise((resolve) => { releaseStraggler = resolve; });
+    const stragglerPromise = acquireLock(path, {
+      pid: 2000,
+      hostname: 'straggler-host',
+      now: () => now,
+      isAlive,
+      _beforeMarkerAttempt: () => stragglerPaused,
+    });
+
+    // A full, independent reclaim of the same lock completes while the
+    // straggler is paused — this is the racer the straggler must defer to.
+    const winner = await acquireLock(path, { pid: 1000, hostname: 'winner-host', now: () => now, isAlive });
+    expect(winner.ok).toBe(true);
+
+    // Now let the straggler proceed: the marker is free again, but the lock
+    // it would overwrite is no longer stale.
+    releaseStraggler();
+    const straggler = await stragglerPromise;
+
+    expect(straggler.ok).toBe(false); // must back off, never a second winner
+    expect(straggler.heldBy).toMatchObject({ pid: 1000, hostname: 'winner-host' });
+
+    // the on-disk lock is untouched by the straggler — still the winner's
+    const raw = JSON.parse(await readFile(path, 'utf8'));
+    expect(raw).toMatchObject({ pid: 1000, hostname: 'winner-host' });
+
+    await winner.release();
   });
 
   // #414 review — symlink-safety on the READ side, mirroring


### PR DESCRIPTION
Closes #482

## Root cause (diagnosed, not guessed)

**This was a real TOCTOU race in `plugin/scripts/lib/lock.mjs`, not a test-side timing assumption.** The existing test has no `setTimeout`/fixed delay at all, so the "test timing too tight" candidate the ticket raised doesn't even apply to this test's actual code.

`reclaimStaleLock()` serializes concurrent reclaimers with an exclusive `.reclaiming` marker file (`open(marker,'wx')`) — that part is genuinely atomic. But the winner of that marker went straight to `open(path,'w')` and overwrote the lock file **without re-reading/re-validating that `path` was still the stale lock it originally observed**. The marker only proves "no one else is inside the critical section right now" — it says nothing about whether the content about to be overwritten is still stale.

Concretely: racer A reads a seeded stale lock, wins the marker, writes its own fresh lock, releases the marker — quickly. Racer B independently read the SAME original stale lock earlier (before A finished) and also decided to reclaim; if B is slow enough reaching `open(marker,'wx')` (e.g. queued behind other racers on Node's libuv threadpool — default size 4 — under a loaded/throttled CI runner), B's marker-open only executes *after* A already released it. B wins it too, and with no re-check, blindly clobbers A's fresh lock. Both report `ok:true`.

I reproduced this empirically and deterministically on this machine (same Windows OS family as the CI runner) under heavier concurrency than the existing 5-way test (12–14-way, run in batches of hundreds to thousands of iterations): several real double-wins pre-fix. Instrumented tracing confirmed the exact sequence above. After the fix: 0 double-wins (and 0 zero-winner outcomes) across 1500+2100+ further stress iterations at 12–14-way concurrency.

## Fix

`reclaimStaleLock` now re-reads and re-validates `path` (`readLock` + `isStale`, using the caller's own `staleMs`/`isAlive`) immediately after winning the marker, right before the overwrite. If the lock is no longer stale, this caller backs off with `{ok:false, error, heldBy}` instead of clobbering it. `staleMs`/`isAlive` are threaded through `reclaimStaleLock`'s signature (including its recursive "steal an abandoned marker" retry branch) so the re-check honors the caller's policy consistently — previously the reclaim path silently fell back to defaults there, a latent minor gap fixed as a side effect.

**The existing "exactly one wins, never both" assertion is untouched — not loosened, not retried, not skipped.** It's now retitled `AC-482.2` (title-only, for the AC gate) and still passes as-is.

## Regression test (deterministic, not a bigger stress loop)

Added `AC-482.3` in `tests/lib/lock.test.mjs`, which forces the exact race window instead of relying on scheduling luck: a new test-only seam, `_beforeMarkerAttempt` (optional hook on `acquireLock`'s options, gated on `process.env.VITEST` per security review so it can never fire outside tests), pauses a "straggler" racer right before its own marker attempt — exactly the point where it has already judged the *original* stale lock reclaimable but hasn't touched the marker yet. While paused, a second, independent `acquireLock` call fully reclaims the same lock. The straggler is then resumed and must back off (`ok:false`, `heldBy` pointing at the winner) rather than clobbering the fresh lock.

Verified this test is non-vacuous: with only the new re-validation removed (hook wiring intact) it fails as expected (`straggler.ok` was `true` instead of `false`); with the full fix it passes.

## Verification

- `pnpm verify`: 83 test files / 1573 tests, all green.
- `tests/lib/lock.test.mjs`: 14/14 green, including both `AC-482.2` and `AC-482.3`.
- Direct stress-testing of the shipped `lock.mjs` (outside the test file, ad hoc): 1500 iterations × 14-way concurrency → 0 double-wins, 0 zero-winners.
- Mechanical gates: `testintent` clean (no weakened assertions), `depguard` clean (no new deps), `acgate` — `AC-482.2` and `AC-482.3` both covered by passing tests.
- Full-branch adversarial passes: `forge:reviewer` → **pass**, zero findings. `forge:security` → **pass**, one **low**-severity hardening suggestion (gate the test-only hook so it's inert outside tests) — applied in a follow-up commit on this branch.
- Sole real consumer, `plugin/scripts/lib/outbox.mjs`, calls `acquireLock` with no overriding options — purely additive/optional signature change, confirmed unaffected by both review passes.

## Scope

Does not touch #486 (separate denylist perf-test flake, out of scope for this ticket).
