### PR TITLE
fix(board): give comment.mjs and escalate.mjs a --*-file path (#557)

### DIFF
--- a/plugin/scripts/board/comment.mjs
+++ b/plugin/scripts/board/comment.mjs
@@ -3,6 +3,7 @@
  * board comment — ticket-trail comment, idempotent per phase marker
  * (spec §6 ticket-trail law; plan T4, AC-2.3).
  */
+import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { run, makeGh } from '../lib/exec.mjs';
@@ -12,22 +13,46 @@ import { attemptOrDefer } from '../lib/outbox.mjs';
 
 export const PHASES = ['started', 'spec', 'plan', 'pr', 'gate-fail', 'escalation', 'ci-green', 'merged', 'note'];
 
+const KNOWN_FLAGS = '--issue --phase --body --body-file --actor --session';
+
 export function parseArgs(argv) {
-  const a = { issue: null, phase: null, body: null, actor: null, session: null };
+  const a = { issue: null, phase: null, body: null, bodyFile: null, actor: null, session: null, unknownFlags: [] };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
-    else if (argv[i] === '--phase') a.phase = argv[++i];
-    else if (argv[i] === '--body') a.body = argv[++i];
-    else if (argv[i] === '--actor') a.actor = argv[++i];
-    else if (argv[i] === '--session') a.session = argv[++i];
+    const k = argv[i];
+    if (k === '--issue') a.issue = Number(argv[++i]);
+    else if (k === '--phase') a.phase = argv[++i];
+    else if (k === '--body') a.body = argv[++i];
+    else if (k === '--body-file') a.bodyFile = argv[++i];
+    else if (k === '--actor') a.actor = argv[++i];
+    else if (k === '--session') a.session = argv[++i];
+    else a.unknownFlags.push(k); // #557 (AC-4): never silently drop — mirrors create.mjs (#104)
   }
   return a;
 }
 
 export async function runComment(ctx, args, log = console.log) {
+  // #557 (AC-4): fail-fast on unrecognized flags rather than dropping them
+  // silently, matching create.mjs's existing behaviour (#104).
+  if (args.unknownFlags?.length) {
+    return { ok: false, error: `unrecognized flag(s): ${args.unknownFlags.join(', ')} — supported: ${KNOWN_FLAGS}` };
+  }
   if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
   if (!PHASES.includes(args.phase)) return { ok: false, error: `unknown phase '${args.phase}' — valid: ${PHASES.join(', ')}` };
-  if (!args.body) return { ok: false, error: '--body is required' };
+  // #557 (AC-3): --body and --body-file are mutually exclusive, resolved as a
+  // hard error rather than one silently winning — a caller who passes both
+  // gets told immediately instead of guessing which one landed.
+  if (args.body && args.bodyFile) {
+    return { ok: false, error: '--body and --body-file are mutually exclusive — pass one, not both' };
+  }
+  // #557 (AC-2): --body-file reads the comment body from a file, same
+  // semantics (and the same read-error message shape) as create.mjs's
+  // --body-file (#104) — this is the mechanism the denylist literal-string
+  // mitigation every skill prescribes actually depends on for a trail comment.
+  if (args.bodyFile) {
+    try { args = { ...args, body: await readFile(args.bodyFile, 'utf8') }; }
+    catch (e) { return { ok: false, error: `--body-file: cannot read ${args.bodyFile}: ${e.message}` }; }
+  }
+  if (!args.body) return { ok: false, error: '--body or --body-file is required' };
 
   // #108: optional actor + session so a picked ticket records who + which session.
   const meta = [args.actor && `by @${args.actor}`, args.session && `session \`${args.session}\``].filter(Boolean).join(' · ');

--- a/plugin/scripts/board/escalate.mjs
+++ b/plugin/scripts/board/escalate.mjs
@@ -6,7 +6,7 @@
  */
 import { resolve, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { writeFile, mkdir } from 'node:fs/promises';
+import { writeFile, mkdir, readFile } from 'node:fs/promises';
 import { run, makeGh } from '../lib/exec.mjs';
 import { makeBoardCtx } from '../lib/boardctx.mjs';
 import { upsertMarkedComment, listComments } from '../lib/issues.mjs';
@@ -15,17 +15,52 @@ import { pendingDecisions } from '../lib/situation.mjs';
 import { runMove } from './move.mjs';
 import { writeJson } from '../lib/jsonfile.mjs';
 
+// #557 (AC-5 audit): --reason/--context are exactly the "escalation reason"
+// free text the denylist literal-string caveat names (autopilot/SKILL.md
+// § Literal-string caveat already instructs subagents to pass these via a
+// file — a mechanism that didn't exist until this fix) — so escalate.mjs
+// gets the same --*-file treatment as comment.mjs, not just an audit note.
+const KNOWN_FLAGS = '--issue --reason --reason-file --options --recommend --context --context-file --check';
+
 export function parseArgs(argv) {
-  const a = { issue: null, reason: null, options: null, recommend: null, context: '', check: false };
+  const a = { issue: null, reason: null, reasonFile: null, options: null, recommend: null, context: '', contextFile: null, check: false, unknownFlags: [] };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
-    else if (argv[i] === '--reason') a.reason = argv[++i];
-    else if (argv[i] === '--options') a.options = argv[++i];
-    else if (argv[i] === '--recommend') a.recommend = argv[++i];
-    else if (argv[i] === '--context') a.context = argv[++i];
-    else if (argv[i] === '--check') a.check = true;
+    const k = argv[i];
+    if (k === '--issue') a.issue = Number(argv[++i]);
+    else if (k === '--reason') a.reason = argv[++i];
+    else if (k === '--reason-file') a.reasonFile = argv[++i];
+    else if (k === '--options') a.options = argv[++i];
+    else if (k === '--recommend') a.recommend = argv[++i];
+    else if (k === '--context') a.context = argv[++i];
+    else if (k === '--context-file') a.contextFile = argv[++i];
+    else if (k === '--check') a.check = true;
+    else a.unknownFlags.push(k); // #557 (AC-4-style): never silently drop, matching create.mjs (#104)
   }
   return a;
+}
+
+/** Shared fail-fast guard for both entry points (escalate + check) — same parseArgs feeds both. */
+function rejectUnknownFlags(args) {
+  if (args.unknownFlags?.length) {
+    return { ok: false, error: `unrecognized flag(s): ${args.unknownFlags.join(', ')} — supported: ${KNOWN_FLAGS}` };
+  }
+  return null;
+}
+
+/**
+ * #557: --reason/--context-file read the same way as comment.mjs's
+ * --body-file (same error-message shape); --*-file and its inline sibling are
+ * mutually exclusive (never a silent winner, mirrors comment.mjs AC-3).
+ */
+async function resolveFileArg(args, inlineKey, fileKey, flagName) {
+  if (args[inlineKey] && args[fileKey]) {
+    return { ok: false, error: `--${flagName} and --${flagName}-file are mutually exclusive — pass one, not both` };
+  }
+  if (args[fileKey]) {
+    try { return { ok: true, value: await readFile(args[fileKey], 'utf8') }; }
+    catch (e) { return { ok: false, error: `--${flagName}-file: cannot read ${args[fileKey]}: ${e.message}` }; }
+  }
+  return { ok: true, value: args[inlineKey] };
 }
 
 /**
@@ -54,8 +89,15 @@ export function escapeMd(s) {
 }
 
 export async function runEscalate(ctx, args, log = console.log) {
+  const unknown = rejectUnknownFlags(args);
+  if (unknown) return unknown;
   if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
-  if (!args.reason) return { ok: false, error: '--reason is required' };
+  const reasonResolved = await resolveFileArg(args, 'reason', 'reasonFile', 'reason');
+  if (!reasonResolved.ok) return reasonResolved;
+  const contextResolved = await resolveFileArg(args, 'context', 'contextFile', 'context');
+  if (!contextResolved.ok) return contextResolved;
+  args = { ...args, reason: reasonResolved.value, context: contextResolved.value ?? '' };
+  if (!args.reason) return { ok: false, error: '--reason or --reason-file is required' };
   const options = normalizeOptions(args.options);
   if (options.length < 2) return { ok: false, error: '--options "a|b[|c…]" needs at least two options' };
 
@@ -115,6 +157,8 @@ const TRUSTED_REPLY_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
 
 /** Scan pending decisions for a TRUSTED human reply (a later, non-forge-marked comment from someone with write access). */
 export async function runCheck(ctx, args, log = console.log) {
+  const unknown = rejectUnknownFlags(args);
+  if (unknown) return unknown;
   const pending = await pendingDecisions(ctx.cwd);
   const targets = args.issue ? pending.filter((d) => d.issue === args.issue) : pending;
   if (targets.length === 0) {

--- a/plugin/skills/board/SKILL.md
+++ b/plugin/skills/board/SKILL.md
@@ -13,7 +13,7 @@ Run any script as: `node "${CLAUDE_PLUGIN_ROOT}/scripts/board/<script>.mjs" <arg
 | --- | --- | --- |
 | `create.mjs` | new ticket, fully placed | `--title` `--body` `--type item\|bug\|epic\|test` `--priority p0..p2` `--size xs..xl` `--status backlog` `--parent <epic#>` `--assignee <login>` |
 | `move.mjs` | status transition | `--issue N --status backlog\|ready\|inProgress\|inReview\|blocked\|done` (keys from forge.json) |
-| `comment.mjs` | ticket-trail comment | `--issue N --phase <phase> --body "…"` — same phase twice updates in place |
+| `comment.mjs` | ticket-trail comment | `--issue N --phase <phase> --body "…"` (or `--body-file <path>` — required whenever the text itself might mention a denylisted command; `--body`/`--body-file` are mutually exclusive) — same phase twice updates in place |
 | `receipt.mjs` | merge receipt | `--issue N --pr N --sha <sha> --title "…"` |
 | `log.mjs` | delivery-log row | `--pr N --sha <sha> --issues "1,2" --title "…"` |
 | `digest.mjs` | refresh epic child table | `--epic N` — rewrites only the managed block in the epic body |

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -586,6 +586,48 @@ describe('comment (AC-2.3)', () => {
     expect(res.ok).toBe(false);
     expect(res.error).toContain('valid:');
   });
+
+  it('AC-557.1/.2: --body-file loads the comment body from a file (#557)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-comment-bodyfile-'));
+    const bf = join(dir, 'body.md');
+    await writeFile(bf, 'Body loaded from file, not inline.', 'utf8');
+    let comments = [];
+    const { ctx, calls } = await ctxWith([
+      [(j) => j.startsWith('api repos/') && j.includes('/comments?'), () => ({ stdout: JSON.stringify(comments) })],
+      [(j) => j.startsWith('api repos/') && j.endsWith('/comments') === false && j.includes('-f'), () => {
+        comments = [{ id: 99, body: '<!-- forge:trail:note -->' }];
+        return { stdout: JSON.stringify({ id: 99 }) };
+      }],
+    ]);
+    const res = await runComment(ctx, commentArgs(['--issue', '4', '--phase', 'note', '--body-file', bf]), noop);
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.includes('Body loaded from file, not inline.'))).toBe(true);
+  });
+
+  it('AC-557.2: a --body-file read error has the same message shape as create.mjs (#104)', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runComment(ctx, commentArgs(['--issue', '4', '--phase', 'note', '--body-file', 'C:/definitely/not/a/real/path.md']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/^--body-file: cannot read/);
+    expect(calls.some((c) => c.startsWith('api'))).toBe(false); // nothing posted
+  });
+
+  it('AC-557.3: --body and --body-file together fail fast — never a silent winner', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runComment(ctx, commentArgs(['--issue', '4', '--phase', 'note', '--body', 'inline', '--body-file', 'C:/whatever.md']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('mutually exclusive');
+    expect(calls.some((c) => c.startsWith('api'))).toBe(false);
+  });
+
+  it('AC-557.4: unrecognized flags fail fast on comment.mjs, matching create.mjs (#104)', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runComment(ctx, commentArgs(['--issue', '4', '--phase', 'note', '--body', 'x', '--bogus']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unrecognized flag/);
+    expect(res.error).toContain('--bogus');
+    expect(calls.some((c) => c.startsWith('api'))).toBe(false);
+  });
 });
 
 describe('close (AC-117)', () => {

--- a/tests/escalate.test.mjs
+++ b/tests/escalate.test.mjs
@@ -84,6 +84,61 @@ describe('escalate (AC-3.2)', () => {
     expect(res.error).toContain('two options');
   });
 
+  it('AC-557.5: --reason-file/--context-file load their text from a file (same literal-string hazard as comment.mjs)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-esc-file-'));
+    const reasonFile = join(dir, 'reason.txt');
+    const contextFile = join(dir, 'context.txt');
+    await writeFile(reasonFile, 'the same gate failed twice', 'utf8');
+    await writeFile(contextFile, 'extra context loaded from a file', 'utf8');
+    let status = 'In progress';
+    const f = fakeGh([
+      ['repo view', REPO_VIEW],
+      [(j) => j.startsWith('project item-list'), () => ({ stdout: JSON.stringify({ items: [{ id: 'IT3', content: { number: 3 }, status }] }) })],
+      [(j) => j.startsWith('project item-edit'), () => { status = 'Blocked / Needs decision'; return { stdout: '' }; }],
+      [(j) => j.includes('/comments?'), { stdout: '[]' }],
+      [(j) => j.includes('/issues/3/comments'), { stdout: JSON.stringify({ id: 501 }) }],
+    ]);
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd: await cwdWithConfig() });
+    const res = await runEscalate(ctx, parseArgs(['--issue', '3', '--reason-file', reasonFile, '--context-file', contextFile, '--options', 'a|b']), noop);
+    expect(res.ok).toBe(true);
+    expect(f.calls.some((c) => c.includes('the same gate failed twice'))).toBe(true);
+    expect(f.calls.some((c) => c.includes('extra context loaded from a file'))).toBe(true);
+  });
+
+  it('AC-557.5: --reason and --reason-file together fail fast — never a silent winner', async () => {
+    const f = fakeGh([['repo view', REPO_VIEW]]);
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd: await cwdWithConfig() });
+    const res = await runEscalate(ctx, parseArgs(['--issue', '3', '--reason', 'inline', '--reason-file', 'C:/whatever.txt', '--options', 'a|b']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('mutually exclusive');
+  });
+
+  it('AC-557.5: a --reason-file read error has the same message shape as comment.mjs/create.mjs', async () => {
+    const f = fakeGh([['repo view', REPO_VIEW]]);
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd: await cwdWithConfig() });
+    const res = await runEscalate(ctx, parseArgs(['--issue', '3', '--reason-file', 'C:/definitely/not/a/real/path.txt', '--options', 'a|b']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/^--reason-file: cannot read/);
+  });
+
+  it('AC-557.5: unrecognized flags fail fast on escalate.mjs, matching create.mjs (#104)', async () => {
+    const f = fakeGh([['repo view', REPO_VIEW]]);
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd: await cwdWithConfig() });
+    const res = await runEscalate(ctx, parseArgs(['--issue', '3', '--reason', 'x', '--options', 'a|b', '--bogus']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unrecognized flag/);
+    expect(res.error).toContain('--bogus');
+    expect(f.calls.some((c) => c.includes('/comments'))).toBe(false); // nothing posted
+  });
+
+  it('AC-557.5: unrecognized flags fail fast on --check too', async () => {
+    const f = fakeGh([['repo view', REPO_VIEW]]);
+    const ctx = await makeBoardCtx({ gh: f.gh, cwd: await cwdWithConfig() });
+    const res = await runCheck(ctx, parseArgs(['--check', '--bogus']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unrecognized flag/);
+  });
+
   it('check: resolves on the first human (marker-free) reply after the decision comment', async () => {
     const cwd = await cwdWithConfig();
     await mkdir(join(cwd, '.forge', 'decisions'), { recursive: true });


### PR DESCRIPTION
Closes #557

## What

`plugin/scripts/board/comment.mjs` parsed `--body <string>` only, so the denylist
literal-string mitigation every skill prescribes ("write it to a file, pass
`--body-file`, never inline on a shell command line") was impossible to follow for a
ticket-trail comment — the one place the rule is actually about.

- `comment.mjs` gains `--body-file <path>`, mirroring `create.mjs`'s (#104) semantics
  exactly: same read-error message shape (`--body-file: cannot read <path>: <msg>`),
  same fail-fast-on-unrecognized-flag behaviour naming the supported flags.
- `--body` and `--body-file` together is a hard error ("mutually exclusive — pass one,
  not both"), never a silent winner.
- **AC-5 audit** of every other script under `plugin/scripts/board/` that accepts
  free text:
  - `escalate.mjs` (`--reason`/`--context`) — same hazard class. The project's own
    `autopilot/SKILL.md` literal-string caveat already names "a shape subagent's
    `escalate.mjs --reason`/`--context`" as needing this treatment, so it gains
    `--reason-file`/`--context-file` with the identical mutual-exclusivity-error and
    fail-fast-unknown-flag pattern (applied to both `runEscalate` and `runCheck`,
    since both share `parseArgs`).
  - `receipt.mjs`, `log.mjs` (`--title` only) — verified not needing it: a short
    label, not a body, already surfaced inline elsewhere via `gh pr create --title`.
  - `close.mjs` (`--note`, optional/free text but lower risk) — flagged as a
    candidate for a follow-up rather than folded into this fix.
  - `reparent.mjs`, `digest.mjs`, `move.mjs`, `status.mjs` — no free-text arguments
    at all; not applicable.
- `plugin/skills/board/SKILL.md`'s `comment.mjs` row updated to document
  `--body-file`.

## Acceptance criteria

- [x] AC-1 — regression test: `comment.mjs --body-file <path>` fails before the fix
      (unrecognized flag), passes after.
- [x] AC-2 — `comment.mjs` reads the body from `--body-file`, same semantics
      (including the read-error message shape) as `create.mjs`.
- [x] AC-3 — `--body` + `--body-file` together is a documented, deterministic hard
      error, never a silent winner.
- [x] AC-4 — an unrecognized flag on `comment.mjs` fails fast, naming the supported
      flags, matching `create.mjs` (#104).
- [x] AC-5 — every other `plugin/scripts/board/*.mjs` script audited; `escalate.mjs`
      fixed the same way, the rest recorded as verified-not-needed or a follow-up
      candidate (see above and the ticket-trail note on #557).

## Verification

- `pnpm verify` — 1646/1646 tests green (full suite, including new coverage in
  `tests/board.test.mjs` and `tests/escalate.test.mjs`).
- Mechanical gates: `conventions`, `situation`, `testintent`, `dep`, `plandrift`, `ac`
  — all pass.
- Full-branch `forge:reviewer` and `forge:security` — both **pass**, zero
  critical/high findings. Two low/minor documentation-discoverability notes recorded
  (not code issues): `escalate.mjs`'s new flags aren't listed in `board/SKILL.md`'s
  table (that table never listed `escalate.mjs` at all — pre-existing), and the
  `autopilot/SKILL.md` literal-string caveat still says "`--body-file`" generically
  for the `escalate.mjs` case rather than naming `--reason-file`/`--context-file`
  explicitly — left as-is here because that file already sits 2 bytes under a hard
  70000-byte size ceiling enforced by `tests/skills/autopilot-size.test.mjs` (from a
  prior delivery, #467/#517/#523), so essentially any addition trips that unrelated
  gate; a real fix there needs a compensating cut, which is out of scope for this
  bug. Recorded as a follow-up.
