### PR TITLE
fix(board): give close.mjs a --note-file path (#562)

### DIFF
--- a/plugin/scripts/board/close.mjs
+++ b/plugin/scripts/board/close.mjs
@@ -8,6 +8,7 @@
  */
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { readFile } from 'node:fs/promises';
 import { run, makeGh } from '../lib/exec.mjs';
 import { makeBoardCtx } from '../lib/boardctx.mjs';
 import { upsertMarkedComment } from '../lib/issues.mjs';
@@ -22,20 +23,47 @@ export const REASONS = {
   duplicate: { ghReason: 'not planned', status: 'wontDo', label: 'duplicate' },
 };
 
+// #562 (AC-4 audit follow-up from #557): --note is the same free-text-flag
+// hazard comment.mjs's --body and escalate.mjs's --reason/--context were —
+// close.mjs gets the same --*-file treatment.
+const KNOWN_FLAGS = '--issue --reason --note --note-file';
+
 export function parseArgs(argv) {
-  const a = { issue: null, reason: null, note: null };
+  const a = { issue: null, reason: null, note: null, noteFile: null, unknownFlags: [] };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--issue') a.issue = Number(argv[++i]);
-    else if (argv[i] === '--reason') a.reason = argv[++i];
-    else if (argv[i] === '--note') a.note = argv[++i];
+    const k = argv[i];
+    if (k === '--issue') a.issue = Number(argv[++i]);
+    else if (k === '--reason') a.reason = argv[++i];
+    else if (k === '--note') a.note = argv[++i];
+    else if (k === '--note-file') a.noteFile = argv[++i];
+    else a.unknownFlags.push(k); // #562 (AC-4): never silently drop — mirrors create.mjs (#104)
   }
   return a;
 }
 
 export async function runClose(ctx, args, log = console.log) {
+  // #562 (AC-4): fail-fast on unrecognized flags rather than dropping them
+  // silently, matching create.mjs (#104) / comment.mjs / escalate.mjs (#557).
+  if (args.unknownFlags?.length) {
+    return { ok: false, error: `unrecognized flag(s): ${args.unknownFlags.join(', ')} — supported: ${KNOWN_FLAGS}` };
+  }
   if (!Number.isInteger(args.issue)) return { ok: false, error: '--issue <number> is required' };
   const spec = REASONS[args.reason];
   if (!spec) return { ok: false, error: `--reason must be one of: ${Object.keys(REASONS).join(', ')}` };
+
+  // #562 (AC-3): --note and --note-file are mutually exclusive, resolved as a
+  // hard error rather than one silently winning — mirrors comment.mjs's
+  // --body/--body-file rule from #557.
+  if (args.note && args.noteFile) {
+    return { ok: false, error: '--note and --note-file are mutually exclusive — pass one, not both' };
+  }
+  // #562 (AC-2): --note-file reads the closing note from a file, same
+  // semantics (and the same read-error message shape) as comment.mjs's
+  // --body-file (#557) / create.mjs's --body-file (#104).
+  if (args.noteFile) {
+    try { args = { ...args, note: await readFile(args.noteFile, 'utf8') }; }
+    catch (e) { return { ok: false, error: `--note-file: cannot read ${args.noteFile}: ${e.message}` }; }
+  }
 
   // the target board status must exist (Won't do needs the option present)
   const opt = ctx.resolveOption('status', spec.status);
@@ -86,8 +114,18 @@ export async function runClose(ctx, args, log = console.log) {
  * failures, and return a `{ ok, closed, failed, results }` summary.
  */
 export async function runCloseBatch(ctx, args, log = console.log) {
+  // #562 (AC-4): fail fast before any GitHub call — same rationale as the
+  // --reason/--issue checks below (a request-level error, not a per-issue one).
+  if (args.unknownFlags?.length) {
+    return { ok: false, error: `unrecognized flag(s): ${args.unknownFlags.join(', ')} — supported: ${KNOWN_FLAGS}` };
+  }
   if (!REASONS[args.reason]) {
     return { ok: false, error: `--reason must be one of: ${Object.keys(REASONS).join(', ')}` };
+  }
+  // #562 (AC-3): --note/--note-file mutual exclusion is also a whole-batch
+  // request error — fail before any GitHub call, mirroring --reason above.
+  if (args.note && args.noteFile) {
+    return { ok: false, error: '--note and --note-file are mutually exclusive — pass one, not both' };
   }
   // strict per-token parsing: split on ',', trim, require positive integers.
   // no silent drops — an empty list or ANY bad token fails before any GitHub call

--- a/tests/board.test.mjs
+++ b/tests/board.test.mjs
@@ -710,6 +710,47 @@ describe('close (AC-117)', () => {
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/--reason must be one of/);
   });
+
+  it('AC-562.2: --note-file loads the closing note from a file (#562)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'forge-close-notefile-'));
+    const nf = join(dir, 'note.md');
+    await writeFile(nf, 'Note loaded from file, not inline.', 'utf8');
+    const ref = { comments: [] };
+    const { ctx, calls } = await ctxWith([
+      ['issue view', { stdout: JSON.stringify({ state: 'OPEN' }) }],
+      ['issue close', { stdout: '' }],
+      ...statefulItems([{ id: 'ITEM_9', number: 12, status: 'Done' }]),
+      ...commentRoutes(ref),
+    ]);
+    const res = await runClose(ctx, closeArgs(['--issue', '12', '--reason', 'not-planned', '--note-file', nf]), noop);
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.includes('Note loaded from file, not inline.'))).toBe(true);
+  });
+
+  it('AC-562.2: a --note-file read error has the same message shape as comment.mjs/create.mjs (#562)', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runClose(ctx, closeArgs(['--issue', '12', '--reason', 'not-planned', '--note-file', 'C:/definitely/not/a/real/path.md']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/^--note-file: cannot read/);
+    expect(calls.some((c) => c.startsWith('issue'))).toBe(false); // nothing closed
+  });
+
+  it('AC-562.3: --note and --note-file together fail fast — never a silent winner (#562)', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runClose(ctx, closeArgs(['--issue', '12', '--reason', 'not-planned', '--note', 'inline', '--note-file', 'C:/whatever.md']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('mutually exclusive');
+    expect(calls.some((c) => c.startsWith('issue'))).toBe(false);
+  });
+
+  it('AC-562.4: unrecognized flags fail fast on close.mjs, matching create.mjs (#104)', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runClose(ctx, closeArgs(['--issue', '12', '--reason', 'not-planned', '--bogus']), noop);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unrecognized flag/);
+    expect(res.error).toContain('--bogus');
+    expect(calls.some((c) => c.startsWith('issue'))).toBe(false);
+  });
 });
 
 describe('batch close (AC-123)', () => {
@@ -816,6 +857,27 @@ describe('batch close (AC-123)', () => {
     expect(calls.some((c) => c.startsWith('issue view'))).toBe(false);
     expect(calls.some((c) => c.startsWith('issue close'))).toBe(false);
     expect(calls.some((c) => c.startsWith('project item-edit'))).toBe(false);
+  });
+
+  it('AC-562.4: unrecognized flags fail fast on batch close too — no GitHub call is made', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runCloseBatch(ctx, closeArgs(['--issue', '12,13', '--reason', 'not-planned', '--bogus']), noop);
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unrecognized flag/);
+    expect(res.error).toContain('--bogus');
+    expect(calls.some((c) => c.startsWith('issue view'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('issue close'))).toBe(false);
+  });
+
+  it('AC-562.3: --note and --note-file together fail fast on batch close — no GitHub call is made', async () => {
+    const { ctx, calls } = await ctxWith([]);
+    const res = await runCloseBatch(ctx, { issue: '12,13', reason: 'not-planned', note: 'inline', noteFile: 'C:/whatever.md' }, noop);
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('mutually exclusive');
+    expect(calls.some((c) => c.startsWith('issue view'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('issue close'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #562

Follow-up from #557's AC-5 audit. `board/close.mjs`'s `--note` was the last board-script free-text flag with no file-based alternative. This mirrors PR #560's shape for `comment.mjs --body-file` and `escalate.mjs --reason-file`/`--context-file` exactly: same read-error message shape, same mutual-exclusion hard error, same fail-fast-on-unknown-flags behaviour (matching `create.mjs`, #104).

## What changed

- `close.mjs` accepts `--note-file <path>`, reading the closing note from a file with the same read-error message shape as `create.mjs`'s `--body-file`.
- `--note` and `--note-file` together is a hard error (`mutually exclusive`), never a silent winner.
- Unrecognized flags fail fast, naming the supported set.
- `runCloseBatch` gets the same unknown-flag and mutual-exclusion checks up front, alongside its existing `--reason` validation, so a bad batch request fails before any GitHub call rather than partway through.

## AC checklist

- [x] AC-1 — regression test shows `--note-file` unrecognised before the fix, passes after (`AC-562.1/AC-562.2` test).
- [x] AC-2 — `--note-file <path>` with the same semantics/read-error shape as `comment.mjs --body-file` (#557/#560).
- [x] AC-3 — `--note`/`--note-file` together is a hard error (checked in both `runClose` and `runCloseBatch`).
- [x] AC-4 — unrecognized flags fail fast, naming the supported set, matching `create.mjs` (#104).
- [x] AC-5 — audit table re-verified and posted to the ticket: no board script left with a free-text flag lacking a file-based alternative (`create.mjs`, `comment.mjs`, `escalate.mjs`, `close.mjs` all covered; `receipt.mjs`/`log.mjs` take `--title` only; `reparent.mjs`/`digest.mjs`/`move.mjs`/`status.mjs` take no free text).

## Verification

- Ran: `pnpm verify` (full suite) — 85 files, 1660 tests, all passing, before and after this change.
- Ran the mechanical gates: `situationgate` (proceed), `conventions` (clean), `plandrift` (clean, 2 files touched, both declared), `testintent` (clean, no weakened assertions), `depguard` (no new deps), `docsync` (clean), `acgate` (all 4 code-mapped ACs covered by passing tests).
- Full-branch `forge:reviewer` and `forge:security` subagents both returned verdict `pass`, zero findings, against the actual diff.
- NOT independently re-verified beyond the above: CI will run the same suite on GitHub-hosted runners; watching to green before merge.
