### PR TITLE
fix(monitors): ci-watch stops emitting CI lines for a merged/closed PR

### DIFF
--- a/plugin/scripts/monitors/ci-watch.mjs
+++ b/plugin/scripts/monitors/ci-watch.mjs
@@ -100,6 +100,16 @@ export function isNoPr(res) {
   return s === '' || s.includes('no pull request') || s.includes('no open pull request') || s.includes('no commits');
 }
 
+/** #507 — a PR that has already left "open" (merged or closed). `merge.mjs`
+ * deletes the branch on merge, which normally moves the checkout off the PR
+ * within one poll interval — but there is a race window between the merge
+ * landing and the branch actually disappearing where `gh pr view` still
+ * resolves the same, now-terminal, PR. Once here, its check rollup is no
+ * longer meaningful: quiet it like `isNoPr()`. */
+export function isTerminalPr(state) {
+  return state === 'MERGED' || state === 'CLOSED';
+}
+
 /**
  * `queuedSince` (#408) tracks — using the watcher's OWN clock, not any GitHub
  * per-job timestamp — how long the rollup has been continuously "every check
@@ -112,11 +122,17 @@ export function isNoPr(res) {
  * specific commit instead of trusting the timestamp alone.
  */
 export async function poll(gh, prev, { queuedSince = null, outageReported = false, now = Date.now, stuckQueuedMs } = {}) {
-  const res = await gh(['pr', 'view', '--json', 'number,headRefName,headRefOid,statusCheckRollup'], { parseJson: true });
+  const res = await gh(['pr', 'view', '--json', 'number,headRefName,headRefOid,statusCheckRollup,state,mergedAt'], { parseJson: true });
   if (!res.ok) {
     // Distinguish "no PR yet" (benign, quiet) from a standing gh failure (#318).
     if (isNoPr(res)) return { prev, pr: null, sha: null, line: null, ok: true, queuedSince: null, outageReported: false };
     return { prev, pr: null, sha: null, line: null, ok: false, reason: String(res?.stderr || 'gh pr view failed'), queuedSince, outageReported };
+  }
+  // #507 AC.2-4: a merged/closed PR's rollup is stale by definition — go quiet
+  // exactly like isNoPr() (ok:true, no line, no state carried) rather than
+  // emitting a transition line or persisting a reading for ciGreen() to reuse.
+  if (isTerminalPr(res.json?.state)) {
+    return { prev, pr: null, sha: null, line: null, ok: true, queuedSince: null, outageReported: false };
   }
   const checks = res.json?.statusCheckRollup;
   const state = rollupState(checks);

--- a/tests/monitors/monitors.test.mjs
+++ b/tests/monitors/monitors.test.mjs
@@ -3,7 +3,7 @@ import { readFile, mkdtemp, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { rollupState, transition, poll as ciPoll, isNoPr, writeCiWatchState, loadCiWatchState, CI_WATCH_RELPATH, allQueued } from '../../plugin/scripts/monitors/ci-watch.mjs';
+import { rollupState, transition, poll as ciPoll, isNoPr, isTerminalPr, writeCiWatchState, loadCiWatchState, CI_WATCH_RELPATH, allQueued } from '../../plugin/scripts/monitors/ci-watch.mjs';
 import { newlyResolved, poll as decisionsPoll } from '../../plugin/scripts/monitors/decisions-watch.mjs';
 import { probeReachable, poll as outboxPoll } from '../../plugin/scripts/monitors/outbox-watch.mjs';
 import {
@@ -49,6 +49,48 @@ describe('CI monitor (#151)', () => {
     expect(second.line).toBe(null);
     expect(second.pr).toBe(42);
     expect(second.sha).toBe('aaa111');
+  });
+
+  // #507 — a merged/closed PR must go quiet exactly like isNoPr(), not keep
+  // emitting rollup transitions for a PR that has already left "open".
+  describe('poll() on a merged/closed PR (#507, epic #503)', () => {
+    it('isTerminalPr: true only for MERGED/CLOSED, false for OPEN or unknown', () => {
+      expect(isTerminalPr('MERGED')).toBe(true);
+      expect(isTerminalPr('CLOSED')).toBe(true);
+      expect(isTerminalPr('OPEN')).toBe(false);
+      expect(isTerminalPr(undefined)).toBe(false);
+    });
+
+    it('AC-507.1: poll() requests state and mergedAt in the --json field list', async () => {
+      let requestedFields = null;
+      const gh = async (args) => {
+        requestedFields = args[args.indexOf('--json') + 1];
+        return { ok: true, json: { number: 1, headRefName: 'x', headRefOid: 'sha1', statusCheckRollup: [], state: 'OPEN' } };
+      };
+      await ciPoll(gh, null);
+      expect(requestedFields).toContain('state');
+      expect(requestedFields).toContain('mergedAt');
+    });
+
+    it('AC-507.2/AC-507.3/AC-507.4: a MERGED PR emits no line, leaves prev unchanged, stays ok, and reports pr:null so no state is persisted', async () => {
+      const gh = async () => ({ ok: true, json: { number: 9, headRefName: 'feat/z', headRefOid: 'bbb222', statusCheckRollup: [{ conclusion: 'SUCCESS' }], state: 'MERGED', mergedAt: '2026-08-20T00:00:00.000Z' } });
+      const first = await ciPoll(gh, 'pass'); // prior observed state was 'pass' from before the merge landed
+      expect(first.line).toBe(null); // AC-507.2: no transition line
+      expect(first.prev).toBe('pass'); // AC-507.2: prev passed through unchanged, not overwritten with the rollup state
+      expect(first.ok).toBe(true); // AC-507.3: not a poll failure — quiet like isNoPr(), must not trip poll-guard.mjs
+      expect(first.pr).toBe(null); // AC-507.4: mirrors the isMain gate `if (r.ok && r.pr != null)` — no stale reading persisted for ciGreen()
+      const second = await ciPoll(gh, first.prev);
+      expect(second.line).toBe(null); // still quiet on a repeat observation
+    });
+
+    it('AC-507.2/AC-507.3/AC-507.4/AC-507.5: a CLOSED PR (no merge) is equally quiet — stubbed gh, no network', async () => {
+      const gh = async () => ({ ok: true, json: { number: 10, headRefName: 'feat/dead', headRefOid: 'ccc333', statusCheckRollup: [{ conclusion: 'FAILURE' }], state: 'CLOSED', mergedAt: null } });
+      const r = await ciPoll(gh, 'fail');
+      expect(r.line).toBe(null); // AC-507.2
+      expect(r.prev).toBe('fail'); // AC-507.2
+      expect(r.ok).toBe(true); // AC-507.3
+      expect(r.pr).toBe(null); // AC-507.4
+    });
   });
 
   // #407 AC.2 — the monitor persists its last observed state so merge.mjs's


### PR DESCRIPTION
Closes #507

## Summary
`poll()` in `plugin/scripts/monitors/ci-watch.mjs` never read PR `state`/`mergedAt`, so it could not
tell a merged/closed PR apart from an open one — after a merge, in the window before
`merge.mjs --delete-branch` switches the checkout off the branch, the watcher kept evaluating the
(now stale) check rollup and could emit CI transition lines / persist a reading for it.

`poll()` now requests `state`/`mergedAt` and treats `MERGED`/`CLOSED` exactly like the existing
`isNoPr()` quiet path: no transition line, `prev` left unchanged, `ok:true` (never trips
`poll-guard.mjs`), and `pr:null` (so the existing `if (r.ok && r.pr != null)` write-gate in the
`isMain` tick loop never calls `writeCiWatchState` for it — no stale reading reaches `merge.mjs`'s
`ciGreen()` fresh-state shortcut).

Scope confirmed narrow at triage: this closes the race window between merge landing and branch
deletion, not indefinite per-PR polling (a broader "large ongoing idle drain" hypothesis was
investigated separately and refuted).

## AC checklist
- [x] AC-507.1 — `poll()` requests `state` (and `mergedAt`) in its `--json` field list.
- [x] AC-507.2 — A PR whose `state` is `MERGED`/`CLOSED` produces no CI transition line and does not update `prev`.
- [x] AC-507.3 — The merged/closed case is quiet like `isNoPr()` — not a poll failure, does not trip `poll-guard.mjs`.
- [x] AC-507.4 — `writeCiWatchState()` is not called for a merged/closed PR (returns `pr: null`, mirroring the existing write-gate).
- [x] AC-507.5 — Tests cover merged, closed, and open PRs against a stubbed `gh` — no network.

## Verification
- `pnpm verify` — 85 files / 1684 tests, all green (full suite, not just the touched file).
- Mechanical gates all green: `plandrift` (2 files touched, both declared), `testintent` (no existing
  assertions weakened), `depguard` (no new deps), `acgate` (all 5 AC-507 ids covered by passing,
  labelled tests).
- Full-branch `forge:reviewer`: verdict pass, 2 minor findings (an unused-but-AC-required `mergedAt`
  field, and a small return-literal duplication opportunity) — no critical/high, not blocking.
- Full-branch `forge:security`: verdict pass, zero findings — no injection surface from the new
  fields, no widening of the pre-existing `gh` trust boundary, symlink/TOCTOU guards on
  `writeCiWatchState`/`loadCiWatchState` untouched and unaffected.
